### PR TITLE
ops(ci): add GitHub Actions CI/CD pipeline and release workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,52 @@
+name: Checks
+
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: lint-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            lint-${{ runner.os }}-cargo-
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+        with:
+          toolchain: stable
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            test-${{ runner.os }}-cargo-
+      - name: Run tests
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,61 +5,21 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: lint-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            lint-${{ runner.os }}-cargo-
-
-      - name: Check formatting
-        run: cargo fmt --check
-
-      - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            test-${{ runner.os }}-cargo-
-
-      - name: Run tests
-        run: cargo test
+  checks:
+    name: Checks
+    uses: ./.github/workflows/checks.yml
 
   build:
     name: Build (${{ matrix.artifact }})
-    needs: [lint, test]
+    needs: [checks]
     strategy:
       fail-fast: false
       matrix:
@@ -94,13 +54,14 @@ jobs:
             artifact: samo-windows-aarch64.exe
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: |
             ~/.cargo/registry
@@ -113,7 +74,11 @@ jobs:
       - name: Install cross
         if: matrix.use_cross
         shell: bash
-        run: cargo install cross --locked
+        run: |
+          set -Eeuo pipefail
+          IFS=$'\n\t'
+          curl -fsSL "https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-musl.tar.gz" \
+            | tar xz -C "${HOME}/.cargo/bin"
 
       - name: Build (cross)
         if: matrix.use_cross
@@ -129,6 +94,8 @@ jobs:
         if: "!contains(matrix.os, 'windows')"
         shell: bash
         run: |
+          set -Eeuo pipefail
+          IFS=$'\n\t'
           cp "target/${{ matrix.target }}/release/samo" "${{ matrix.artifact }}"
           chmod +x "${{ matrix.artifact }}"
 
@@ -136,10 +103,12 @@ jobs:
         if: contains(matrix.os, 'windows')
         shell: bash
         run: |
+          set -Eeuo pipefail
+          IFS=$'\n\t'
           cp "target/${{ matrix.target }}/release/samo.exe" "${{ matrix.artifact }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,64 +5,21 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
-permissions:
-  contents: write
-
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: lint-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            lint-${{ runner.os }}-cargo-
-
-      - name: Check formatting
-        run: cargo fmt --check
-
-      - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            test-${{ runner.os }}-cargo-
-
-      - name: Run tests
-        run: cargo test
+  checks:
+    name: Checks
+    uses: ./.github/workflows/checks.yml
 
   build:
     name: Build (${{ matrix.artifact }})
-    needs: [lint, test]
+    needs: [checks]
     strategy:
       fail-fast: false
       matrix:
@@ -97,13 +54,14 @@ jobs:
             artifact: samo-windows-aarch64.exe
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: |
             ~/.cargo/registry
@@ -116,7 +74,11 @@ jobs:
       - name: Install cross
         if: matrix.use_cross
         shell: bash
-        run: cargo install cross --locked
+        run: |
+          set -Eeuo pipefail
+          IFS=$'\n\t'
+          curl -fsSL "https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-musl.tar.gz" \
+            | tar xz -C "${HOME}/.cargo/bin"
 
       - name: Build release (cross)
         if: matrix.use_cross
@@ -132,6 +94,8 @@ jobs:
         if: "!contains(matrix.os, 'windows')"
         shell: bash
         run: |
+          set -Eeuo pipefail
+          IFS=$'\n\t'
           cp "target/${{ matrix.target }}/release/samo" "${{ matrix.artifact }}"
           chmod +x "${{ matrix.artifact }}"
 
@@ -139,23 +103,55 @@ jobs:
         if: contains(matrix.os, 'windows')
         shell: bash
         run: |
+          set -Eeuo pipefail
+          IFS=$'\n\t'
           cp "target/${{ matrix.target }}/release/samo.exe" "${{ matrix.artifact }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
+  universal-binary:
+    name: macOS Universal Binary
+    needs: [build]
+    runs-on: macos-14
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: samo-darwin-x86_64
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: samo-darwin-aarch64
+
+      - name: Create universal binary
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          IFS=$'\n\t'
+          chmod +x samo-darwin-x86_64 samo-darwin-aarch64
+          lipo -create samo-darwin-x86_64 samo-darwin-aarch64 \
+            -output samo-darwin-universal
+          chmod +x samo-darwin-universal
+          file samo-darwin-universal
+          lipo -info samo-darwin-universal
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: samo-darwin-universal
+          path: samo-darwin-universal
+
   release:
     name: Create GitHub Release
-    needs: [build]
+    needs: [build, universal-binary]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: artifacts
 
@@ -174,9 +170,16 @@ jobs:
             done
           done
 
-          # Generate SHA256SUMS
+          # Generate SHA256SUMS (portable across Linux and macOS)
           cd release
-          sha256sum -- * > SHA256SUMS
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -- * > SHA256SUMS
+          elif command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 -- * > SHA256SUMS
+          else
+            echo "ERROR: no SHA256 tool found" >&2
+            exit 1
+          fi
 
           echo "=== Release artifacts ==="
           ls -la
@@ -189,12 +192,13 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
+          IFS=$'\n\t'
           tag="${GITHUB_REF_NAME}"
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
           echo "Releasing ${tag}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2
         with:
           tag_name: ${{ steps.notes.outputs.tag }}
           name: Samo ${{ steps.notes.outputs.tag }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ repository = "https://github.com/NikolayS/project-alpha"
 [features]
 integration = []
 
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+
 [[bin]]
 name = "samo"
 path = "src/main.rs"


### PR DESCRIPTION
## Summary

- Add **CI workflow** (`.github/workflows/ci.yml`) triggered on push to `main` and all PRs: lint (clippy + rustfmt), test, and build matrix for all 6 cross-compilation targets
- Add **release workflow** (`.github/workflows/release.yml`) triggered on tag push `v*.*.*`: lint/test gate, 6-target release build (stripped via Cargo profile), SHA256SUMS generation, and GitHub Release creation
- Add minimal `Cargo.toml` and `src/main.rs` stub so CI can build (the scaffold PR #12 will replace these with the full project)

### Build matrix (6 targets)

| Target | Runner | Method | Artifact |
|--------|--------|--------|----------|
| `x86_64-unknown-linux-musl` | ubuntu-latest | `cross` | `samo-linux-x86_64` |
| `aarch64-unknown-linux-musl` | ubuntu-latest | `cross` | `samo-linux-aarch64` |
| `x86_64-apple-darwin` | macos-13 | native | `samo-darwin-x86_64` |
| `aarch64-apple-darwin` | macos-14 | native | `samo-darwin-aarch64` |
| `x86_64-pc-windows-msvc` | windows-latest | native | `samo-windows-x86_64.exe` |
| `aarch64-pc-windows-msvc` | windows-latest | cross (MSVC) | `samo-windows-aarch64.exe` |

### Key decisions

- Linux musl targets use `cross` (Docker-based) for reliable static builds
- macOS uses version-specific runners: macos-13 for x86_64, macos-14 for aarch64
- Windows aarch64 cross-compiles from x64 via MSVC (no ARM runner needed)
- Release binaries stripped via `[profile.release] strip = true` (works with cross too)
- Cargo registry + target/ cached per target for faster builds

Closes #13

## Test plan

- [ ] CI passes lint (clippy, rustfmt) on the stub project
- [ ] CI passes test job (cargo test)
- [ ] All 6 build matrix entries complete successfully
- [ ] Artifacts are uploaded for each target
- [ ] Release workflow YAML is valid (validated locally with Python yaml parser)
- [ ] Tag push `v0.1.0` produces GitHub Release with 6 binaries + SHA256SUMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)