### PR TITLE
feat(cli): wire CLI flags and .psqlrc execution

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -375,6 +375,8 @@ fn build_settings(cli: &Cli) -> repl::ReplSettings {
     for assignment in &cli.variable {
         if let Some((name, val)) = assignment.split_once('=') {
             vars.set(name, val);
+        } else {
+            eprintln!("samo: -v requires name=value");
         }
     }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -612,8 +612,14 @@ pub async fn exec_file(client: &Client, path: &str, settings: &mut ReplSettings)
     let mut exit_code = 0i32;
 
     // -1 / --single-transaction: open a transaction before the first statement.
-    if settings.single_transaction && !execute_query(client, "begin", settings, &mut tx).await {
-        return 1;
+    // Use simple_query directly so that begin/commit/rollback are not echoed,
+    // logged, or prompted (they are internal bookkeeping, not user SQL).
+    if settings.single_transaction {
+        if let Err(e) = client.simple_query("begin").await {
+            eprintln!("samo: could not begin transaction: {e}");
+            return 1;
+        }
+        tx.update_from_sql("begin");
     }
 
     'outer: for line in content.lines() {
@@ -628,7 +634,8 @@ pub async fn exec_file(client: &Client, path: &str, settings: &mut ReplSettings)
                 exit_code = 1;
                 if settings.single_transaction {
                     // Roll back and abort the rest of the file.
-                    execute_query(client, "rollback", settings, &mut tx).await;
+                    let _ = client.simple_query("rollback").await;
+                    tx.update_from_sql("rollback");
                     break 'outer;
                 }
             }
@@ -643,16 +650,19 @@ pub async fn exec_file(client: &Client, path: &str, settings: &mut ReplSettings)
     {
         exit_code = 1;
         if settings.single_transaction {
-            execute_query(client, "rollback", settings, &mut tx).await;
+            let _ = client.simple_query("rollback").await;
+            tx.update_from_sql("rollback");
         }
     }
 
     // -1 / --single-transaction: commit on success.
-    if settings.single_transaction
-        && exit_code == 0
-        && !execute_query(client, "commit", settings, &mut tx).await
-    {
-        exit_code = 1;
+    if settings.single_transaction && exit_code == 0 {
+        if let Err(e) = client.simple_query("commit").await {
+            eprintln!("samo: could not commit transaction: {e}");
+            exit_code = 1;
+        } else {
+            tx.update_from_sql("commit");
+        }
     }
 
     exit_code


### PR DESCRIPTION
## Summary

- Wire remaining parsed-but-unused CLI flags to actual behavior: `-v` (variable assignment), `-o` (output redirection), `-L` (log file mirroring input+output), `-e`/`--echo-queries`, `-b`/`--echo-errors`, `-s`/`--single-step`, `-S`/`--single-line`, `-1`/`--single-transaction`, `-q`/`--quiet`, `-D`/`--debug`
- Add `startup_file()` resolving priority: `$PSQLRC` env → `~/.samorc` → `~/.psqlrc`
- Execute startup file in interactive REPL at startup unless `-X` (`--no-psqlrc`) is given
- Extract `build_settings()` helper to keep `main()` readable
- Add 5 unit tests covering new `ReplSettings` fields and `startup_file()` resolution

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (315 tests, 5 new)
- [ ] Manual: `samo -v FOO=bar -c 'select :'\'FOO\'''` echoes `bar`
- [ ] Manual: `samo -o /tmp/out.txt -c 'select 1'` writes to file
- [ ] Manual: `samo -L /tmp/log.txt -c 'select 1'` appends query+output to log
- [ ] Manual: `samo -e -c 'select 1'` prints query to stderr before execution
- [ ] Manual: `samo -b -c 'select bad'` echoes failing query to stderr
- [ ] Manual: `echo ~/.samorc` present → sourced on startup; `-X` suppresses it

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)