### PR TITLE
feat(exec): \g and \gx execution variants

### DIFF
--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -1872,7 +1872,10 @@ mod tests {
     #[test]
     fn parse_gx_to_file() {
         let m = parse("\\gx /tmp/out");
-        assert_eq!(m.cmd, MetaCmd::GoExecuteExpanded(Some("/tmp/out".to_owned())));
+        assert_eq!(
+            m.cmd,
+            MetaCmd::GoExecuteExpanded(Some("/tmp/out".to_owned()))
+        );
     }
 
     #[test]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1294,9 +1294,7 @@ async fn dispatch_io(
         MetaCmd::GoExecute(ref target) => {
             let result = match target.as_deref() {
                 None => MetaResult::ExecuteBuffer,
-                Some(t) if t.starts_with('|') => {
-                    MetaResult::ExecuteBufferPiped(t.to_owned())
-                }
+                Some(t) if t.starts_with('|') => MetaResult::ExecuteBufferPiped(t.to_owned()),
                 Some(f) => MetaResult::ExecuteBufferToFile(f.to_owned()),
             };
             Some(result)


### PR DESCRIPTION
## Summary

Closes #46.

- Add `\g [file|\|cmd]` — buffer-terminator that executes the current query buffer, with optional one-shot output redirection to a file or pipe
- Add `\gx [file]` — same as `\g` but forces expanded (`\x`) display mode for this single execution only
- Parser uses longest-match-first disambiguation to avoid conflicts with `\gset`, `\gexec`, and `\gdesc`

## Details

### New `MetaCmd` variants (`src/metacmd.rs`)

- `MetaCmd::GoExecute(Option<String>)` — `\g`, `\g file`, `\g |cmd`
- `MetaCmd::GoExecuteExpanded(Option<String>)` — `\gx`, `\gx file`

### New `MetaResult` variants (`src/repl.rs`)

- `ExecuteBuffer` — execute buffer to stdout
- `ExecuteBufferToFile(String)` — execute buffer, output to file
- `ExecuteBufferPiped(String)` — execute buffer, pipe through shell command
- `ExecuteBufferExpanded` — execute with expanded output (one-shot)
- `ExecuteBufferExpandedToFile(String)` — expanded output to file

### Pipe implementation

Uses a `CapturingWriter` (backed by `Arc<Mutex<Vec<u8>>>`) to collect query output into a buffer, then feeds it to the child process via its stdin. This avoids lifetime issues with `Box<dyn Write>`.

## Test plan

- [x] `cargo build` — passes
- [x] `cargo clippy -- -D warnings` — passes
- [x] `cargo test --bin samo` — all 356 tests pass, including 7 new parser tests:
  - `parse_g_bare`
  - `parse_g_to_file`
  - `parse_g_piped`
  - `parse_gx_bare`
  - `parse_gx_to_file`
  - `parse_g_not_confused_with_gset_gexec_gdesc`
  - `parse_gx_not_confused_with_g`

🤖 Generated with [Claude Code](https://claude.com/claude-code)