### PR TITLE
feat(repl): implement \gdesc meta-command

### DIFF
--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -179,6 +179,14 @@ pub enum MetaCmd {
     /// used.
     Watch,
 
+    // -- Buffer introspection (#52) ----------------------------------------
+    /// `\gdesc` — describe the result columns of the current query buffer
+    /// without executing it.
+    ///
+    /// Uses the extended-protocol `Describe` message so no rows are produced
+    /// and no side-effects occur on the server.
+    GDesc,
+
     // -- Fallback ----------------------------------------------------------
     /// Unrecognised command; carries the original command token.
     Unknown(String),
@@ -898,21 +906,28 @@ fn parse_shell(input: &str) -> ParsedMeta {
 // \g / \gx parser (#46)
 // ---------------------------------------------------------------------------
 
-/// Parse `\g [file||cmd]` and `\gx [file]`.
+/// Parse `\g [file||cmd]`, `\gx [file]`, and `\gdesc`.
 ///
 /// Disambiguation order (longest match first):
-///   `gset` → not handled here (unknown)
+///   `gset`  → not handled here (unknown)
 ///   `gexec` → not handled here (unknown)
-///   `gdesc` → not handled here (unknown)
-///   `gx`   → [`MetaCmd::GoExecuteExpanded`]
-///   `g`    → [`MetaCmd::GoExecute`]
+///   `gdesc` → [`MetaCmd::GDesc`]
+///   `gx`    → [`MetaCmd::GoExecuteExpanded`]
+///   `g`     → [`MetaCmd::GoExecute`]
 ///
 /// Any unknown `g`-prefixed command (e.g. `\gset`, `\gexec`) falls through
 /// to [`MetaCmd::Unknown`].
 fn parse_g_family(input: &str) -> ParsedMeta {
+    // `\gdesc` — describe buffer columns without executing.
+    if let Some(rest) = input.strip_prefix("gdesc") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            return ParsedMeta::simple(MetaCmd::GDesc);
+        }
+    }
+
     // Longer g-prefixed commands that must not be misread as \g.
     // Check them first so `\gset foo` → Unknown, not GoExecute("set foo").
-    for long_prefix in &["gset", "gexec", "gdesc"] {
+    for long_prefix in &["gset", "gexec"] {
         if let Some(rest) = input.strip_prefix(long_prefix) {
             if rest.is_empty() || rest.starts_with(char::is_whitespace) {
                 return ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()));
@@ -1904,11 +1919,25 @@ mod tests {
     }
 
     #[test]
-    fn parse_g_not_confused_with_gset_gexec_gdesc() {
+    fn parse_g_not_confused_with_gset_gexec() {
         // These longer g-prefixed commands must NOT parse as GoExecute.
         assert!(matches!(parse("\\gset foo").cmd, MetaCmd::Unknown(_)));
         assert!(matches!(parse("\\gexec").cmd, MetaCmd::Unknown(_)));
-        assert!(matches!(parse("\\gdesc").cmd, MetaCmd::Unknown(_)));
+    }
+
+    // -- \gdesc (#52) --------------------------------------------------------
+
+    #[test]
+    fn parse_gdesc() {
+        assert_eq!(parse("\\gdesc").cmd, MetaCmd::GDesc);
+        // Trailing whitespace is fine.
+        assert_eq!(parse("\\gdesc ").cmd, MetaCmd::GDesc);
+        // Must NOT be confused with \g or \gx.
+        assert!(!matches!(parse("\\gdesc").cmd, MetaCmd::GoExecute(_)));
+        assert!(!matches!(
+            parse("\\gdesc").cmd,
+            MetaCmd::GoExecuteExpanded(_)
+        ));
     }
 
     #[test]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -680,6 +680,108 @@ async fn execute_piped(
 }
 
 // ---------------------------------------------------------------------------
+// \gdesc — describe buffer columns without executing (#52)
+// ---------------------------------------------------------------------------
+
+/// Describe the result columns of `buf` using the extended-protocol `Prepare`
+/// message (no rows are produced; no side-effects occur on the server).
+///
+/// Output format (matching psql):
+/// ```text
+///  Column | Type
+/// --------+---------
+///  id     | integer
+///  name   | text
+/// (2 rows)
+/// ```
+///
+/// Type names are resolved via `pg_catalog.format_type(oid, NULL)` so they
+/// match psql's display names (`integer` not `int4`, etc.).
+///
+/// When `buf` is empty, prints an informational message.
+/// On prepare error, prints the Postgres error message.
+async fn describe_buffer(client: &Client, buf: &str) {
+    if buf.is_empty() {
+        println!("Query buffer is empty.");
+        return;
+    }
+
+    let stmt = match client.prepare(buf).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("ERROR:  {e}");
+            return;
+        }
+    };
+
+    let cols = stmt.columns();
+    if cols.is_empty() {
+        println!("This command doesn't return data.");
+        return;
+    }
+
+    // Collect (name, oid) pairs.
+    let col_info: Vec<(String, u32)> = cols
+        .iter()
+        .map(|c| (c.name().to_owned(), c.type_().oid()))
+        .collect();
+
+    // Resolve OIDs to display type names in a single query.
+    // Build: SELECT format_type($1, NULL), format_type($2, NULL), …
+    let select_exprs: Vec<String> = (1..=col_info.len())
+        .map(|i| format!("pg_catalog.format_type(${i}, NULL)"))
+        .collect();
+    let type_query = format!("select {}", select_exprs.join(", "));
+
+    let oid_params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = col_info
+        .iter()
+        .map(|(_, oid)| oid as &(dyn tokio_postgres::types::ToSql + Sync))
+        .collect();
+
+    let type_names: Vec<String> = match client.query_one(&type_query, &oid_params).await {
+        Ok(row) => (0..col_info.len())
+            .map(|i| row.get::<_, String>(i))
+            .collect(),
+        Err(e) => {
+            eprintln!("ERROR:  {e}");
+            return;
+        }
+    };
+
+    // Compute column widths for aligned output.
+    let header_col = "Column";
+    let header_type = "Type";
+    let col_w = col_info
+        .iter()
+        .map(|(n, _)| n.len())
+        .max()
+        .unwrap_or(0)
+        .max(header_col.len());
+    let type_w = type_names
+        .iter()
+        .map(String::len)
+        .max()
+        .unwrap_or(0)
+        .max(header_type.len());
+
+    // Header.
+    println!(" {header_col:<col_w$} | {header_type:<type_w$}");
+    // Separator.
+    println!("-{}-+-{}-", "-".repeat(col_w), "-".repeat(type_w));
+    // Rows.
+    for ((name, _), type_name) in col_info.iter().zip(type_names.iter()) {
+        println!(" {name:<col_w$} | {type_name:<type_w$}");
+    }
+    // Footer.
+    let n = col_info.len();
+    if n == 1 {
+        println!("(1 row)");
+    } else {
+        println!("({n} rows)");
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Non-interactive (piped / -c / -f) execution
 // ---------------------------------------------------------------------------
 
@@ -825,7 +927,25 @@ pub(crate) async fn exec_lines(
             // Dispatch meta-command (handles conditional tracking internally).
             let mut parsed = crate::metacmd::parse(line.trim());
             parsed.echo_hidden = settings.echo_hidden;
-            dispatch_meta(parsed, client, params, settings, tx).await;
+            let result = dispatch_meta(parsed, client, params, settings, tx).await;
+            // Handle buffer-aware results that exec_lines must act on directly.
+            match result {
+                MetaResult::ExecuteBuffer => {
+                    let sql = buf.trim().to_owned();
+                    buf.clear();
+                    if !sql.is_empty() && !execute_query(client, &sql, settings, tx).await {
+                        exit_code = 1;
+                        if settings.single_transaction {
+                            break 'lines;
+                        }
+                    }
+                }
+                MetaResult::DescribeBuffer => {
+                    // Buffer is NOT cleared after \gdesc.
+                    describe_buffer(client, buf.trim()).await;
+                }
+                _ => {}
+            }
         } else if settings.cond.is_active() {
             if !buf.is_empty() {
                 buf.push('\n');
@@ -1214,6 +1334,8 @@ pub enum MetaResult {
     ExecuteBufferExpanded,
     /// Execute the current buffer with expanded output written to a file (`\gx file`).
     ExecuteBufferExpandedToFile(String),
+    /// Describe the result columns of the buffer without executing it (`\gdesc`).
+    DescribeBuffer,
 }
 
 /// Default `\watch` interval in seconds.
@@ -1434,6 +1556,7 @@ async fn dispatch_io(
             };
             Some(result)
         }
+        MetaCmd::GDesc => Some(MetaResult::DescribeBuffer),
         _ => None,
     }
 }
@@ -1959,6 +2082,12 @@ async fn handle_backslash_dumb(
             }
             HandleLineResult::BufferUpdated
         }
+        MetaResult::DescribeBuffer => {
+            // Buffer is NOT cleared after \gdesc (same as psql).
+            let sql = buf.trim();
+            describe_buffer(client, sql).await;
+            HandleLineResult::Continue
+        }
         MetaResult::Continue => HandleLineResult::Continue,
     }
 }
@@ -2077,6 +2206,12 @@ async fn handle_line(
                     settings.pset.expanded = prev;
                 }
                 HandleLineResult::BufferUpdated
+            }
+            MetaResult::DescribeBuffer => {
+                // Buffer is NOT cleared after \gdesc (same as psql).
+                let sql = buf.trim().to_owned();
+                describe_buffer(client, &sql).await;
+                HandleLineResult::Continue
             }
             MetaResult::Continue => HandleLineResult::Continue,
         };

--- a/tests/integration_repl.rs
+++ b/tests/integration_repl.rs
@@ -248,3 +248,58 @@ async fn repl_timing_measures_query() {
         "elapsed time must be non-negative, got {elapsed_ms:.3} ms"
     );
 }
+
+// ---------------------------------------------------------------------------
+// \gdesc — describe buffer columns without executing (#52)
+// ---------------------------------------------------------------------------
+
+/// `\gdesc` describes the result columns of a query without executing it.
+///
+/// Uses `client.prepare()` (extended-protocol Describe) so no rows are
+/// produced and no side-effects occur on the server.
+#[tokio::test]
+async fn gdesc_reports_column_names_and_types() {
+    let _ = connect_or_skip!();
+
+    let client = raw_client().await.expect("raw client connect failed");
+
+    // prepare() parses and type-checks the query without executing it.
+    let stmt = client
+        .prepare("select 1 as id, 'hello'::text as name")
+        .await
+        .expect("prepare failed");
+
+    let cols = stmt.columns();
+    assert_eq!(cols.len(), 2, "expected 2 columns from prepare");
+    assert_eq!(cols[0].name(), "id", "first column name must be 'id'");
+    assert_eq!(cols[1].name(), "name", "second column name must be 'name'");
+
+    // Resolve OIDs to display names the same way describe_buffer() does.
+    let oids: Vec<u32> = cols.iter().map(|c| c.type_().oid()).collect();
+    let select_exprs: Vec<String> = (1..=oids.len())
+        .map(|i| format!("pg_catalog.format_type(${i}, NULL)"))
+        .collect();
+    let type_query = format!("select {}", select_exprs.join(", "));
+
+    let oid_params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = oids
+        .iter()
+        .map(|o| o as &(dyn tokio_postgres::types::ToSql + Sync))
+        .collect();
+
+    let row = client
+        .query_one(&type_query, &oid_params)
+        .await
+        .expect("format_type query failed");
+
+    let type_id: String = row.get(0);
+    let type_name: String = row.get(1);
+
+    assert_eq!(
+        type_id, "integer",
+        "expected 'integer' for the int4 literal, got '{type_id}'"
+    );
+    assert_eq!(
+        type_name, "text",
+        "expected 'text' for the text column, got '{type_name}'"
+    );
+}


### PR DESCRIPTION
## Summary

Implements `\gdesc` — the psql meta-command that describes the result columns of the current query buffer **without executing it**.

- **`src/metacmd.rs`**: Add `MetaCmd::GDesc` variant; update `parse_g_family` to return it instead of `Unknown`; add `parse_gdesc` unit test; update the renamed `parse_g_not_confused_with_gset_gexec` test (gdesc is no longer unknown)
- **`src/repl.rs`**: Add `MetaResult::DescribeBuffer` variant; handle `MetaCmd::GDesc` in `dispatch_io`; add `describe_buffer()` that uses `client.prepare()` (extended protocol Describe — no execution) and resolves OIDs to display names via `pg_catalog.format_type()`; handle `MetaResult::DescribeBuffer` in both the readline and dumb-loop backslash handlers

Example output:
```
samo=# select 1 as id, 'hello' as name \gdesc
 Column | Type
--------+---------
 id     | integer
 name   | text
(2 rows)
```

Closes #52

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 359/359 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Manual: `select 1 as id, 'hello' as name \gdesc` shows expected table
- [ ] Manual: `\gdesc` on empty buffer prints error message
- [ ] Manual: `\gdesc` on invalid SQL shows server error

🤖 Generated with [Claude Code](https://claude.com/claude-code)