### PR TITLE
feat(ux): named queries (\ns, \n, \n+, \nd)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod highlight;
 mod io;
 mod logging;
 mod metacmd;
+mod named;
 #[allow(dead_code)]
 mod output;
 mod pager;

--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -251,6 +251,16 @@ pub enum MetaCmd {
     /// `pattern` field.  The `plus` flag activates verbose output.
     Dba,
 
+    // -- Named queries (#69) -----------------------------------------------
+    /// `\ns name query` — save a named query.
+    NamedSave(String, String),
+    /// `\n name [args...]` — execute a named query.
+    NamedExec(String, Vec<String>),
+    /// `\n+` — list all named queries.
+    NamedList,
+    /// `\nd name` — delete a named query.
+    NamedDelete(String),
+
     // -- Fallback ----------------------------------------------------------
     /// Unrecognised command; carries the original command token.
     Unknown(String),
@@ -409,6 +419,7 @@ pub fn parse(input: &str) -> ParsedMeta {
         Some('g') => parse_g_family(input),
         Some('l') => parse_l(input),
         Some('d') => parse_d_family(input),
+        Some('n') => parse_n_family(input),
         Some('!') => parse_shell(input),
         _ => ParsedMeta::simple(MetaCmd::Unknown(input.to_owned())),
     }
@@ -1092,6 +1103,68 @@ fn parse_b_family(input: &str) -> ParsedMeta {
         if rest.is_empty() || rest.starts_with(char::is_whitespace) {
             let params = split_params(rest.trim());
             return ParsedMeta::simple(MetaCmd::Bind(params));
+        }
+    }
+
+    ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()))
+}
+
+// ---------------------------------------------------------------------------
+// \n family parser — named queries (#69)
+// ---------------------------------------------------------------------------
+
+/// Parse `\ns name query`, `\nd name`, `\n+`, and `\n name [args...]`.
+///
+/// Disambiguation order (longest match first):
+///   `ns` → [`MetaCmd::NamedSave`]
+///   `nd` → [`MetaCmd::NamedDelete`]
+///   `n+` → [`MetaCmd::NamedList`]
+///   `n`  → [`MetaCmd::NamedExec`]
+fn parse_n_family(input: &str) -> ParsedMeta {
+    // `\ns name query` — save a named query.  Must come before bare `\n`.
+    if let Some(rest) = input.strip_prefix("ns") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            let rest = rest.trim();
+            let mut parts = rest.splitn(2, char::is_whitespace);
+            let name = parts.next().unwrap_or("").to_owned();
+            let query = parts.next().map_or("", str::trim).to_owned();
+            if name.is_empty() || query.is_empty() {
+                return ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()));
+            }
+            return ParsedMeta::simple(MetaCmd::NamedSave(name, query));
+        }
+    }
+
+    // `\nd name` — delete a named query.  Must come before bare `\n`.
+    if let Some(rest) = input.strip_prefix("nd") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            let name = rest.trim().to_owned();
+            if name.is_empty() {
+                return ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()));
+            }
+            return ParsedMeta::simple(MetaCmd::NamedDelete(name));
+        }
+    }
+
+    // `\n+` — list all named queries.
+    if let Some(rest) = input.strip_prefix("n+") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            return ParsedMeta::simple(MetaCmd::NamedList);
+        }
+    }
+
+    // `\n name [args...]` — execute a named query.
+    if let Some(rest) = input.strip_prefix('n') {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            let rest = rest.trim();
+            if rest.is_empty() {
+                return ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()));
+            }
+            let mut parts = rest.splitn(2, char::is_whitespace);
+            let name = parts.next().unwrap_or("").to_owned();
+            let args_str = parts.next().unwrap_or("").trim();
+            let args = split_params(args_str);
+            return ParsedMeta::simple(MetaCmd::NamedExec(name, args));
         }
     }
 
@@ -2569,5 +2642,77 @@ mod tests {
         let m = parse("\\dba nonexistent");
         assert_eq!(m.cmd, MetaCmd::Dba);
         assert_eq!(m.pattern, Some("nonexistent".to_owned()));
+    }
+
+    // -- Named queries (#69) ------------------------------------------------
+
+    #[test]
+    fn parse_named_save() {
+        let m =
+            parse("\\ns top_tables SELECT * FROM pg_stat_user_tables ORDER BY $1 DESC LIMIT $2");
+        assert_eq!(
+            m.cmd,
+            MetaCmd::NamedSave(
+                "top_tables".to_owned(),
+                "SELECT * FROM pg_stat_user_tables ORDER BY $1 DESC LIMIT $2".to_owned(),
+            )
+        );
+    }
+
+    #[test]
+    fn parse_named_exec_with_args() {
+        let m = parse("\\n top_tables seq_scan 10");
+        assert_eq!(
+            m.cmd,
+            MetaCmd::NamedExec(
+                "top_tables".to_owned(),
+                vec!["seq_scan".to_owned(), "10".to_owned()],
+            )
+        );
+    }
+
+    #[test]
+    fn parse_named_exec_no_args() {
+        let m = parse("\\n my_query");
+        assert_eq!(m.cmd, MetaCmd::NamedExec("my_query".to_owned(), vec![]));
+    }
+
+    #[test]
+    fn parse_named_list() {
+        let m = parse("\\n+");
+        assert_eq!(m.cmd, MetaCmd::NamedList);
+    }
+
+    #[test]
+    fn parse_named_delete() {
+        let m = parse("\\nd top_tables");
+        assert_eq!(m.cmd, MetaCmd::NamedDelete("top_tables".to_owned()));
+    }
+
+    #[test]
+    fn parse_named_save_ns_not_confused_with_n() {
+        // `\ns` must not be mistaken for `\n` with arg `s`.
+        let m = parse("\\ns my_q select 1");
+        assert!(matches!(m.cmd, MetaCmd::NamedSave(_, _)));
+    }
+
+    #[test]
+    fn parse_named_delete_nd_not_confused_with_n() {
+        // `\nd` must not be mistaken for `\n` with arg `d`.
+        let m = parse("\\nd my_q");
+        assert!(matches!(m.cmd, MetaCmd::NamedDelete(_)));
+    }
+
+    #[test]
+    fn parse_named_save_missing_query_is_unknown() {
+        // `\ns name` with no query body should be Unknown.
+        let m = parse("\\ns only_name");
+        assert!(matches!(m.cmd, MetaCmd::Unknown(_)));
+    }
+
+    #[test]
+    fn parse_named_delete_missing_name_is_unknown() {
+        let m = parse("\\nd");
+        assert!(matches!(m.cmd, MetaCmd::Unknown(_)));
     }
 }

--- a/src/named.rs
+++ b/src/named.rs
@@ -1,0 +1,158 @@
+//! Named query storage and retrieval.
+//!
+//! Named queries are stored in a TOML file at
+//! `~/.config/samo/named_queries.toml`.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Named query store.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct NamedQueries {
+    #[serde(default)]
+    queries: BTreeMap<String, String>,
+}
+
+impl NamedQueries {
+    /// Load from the default file path, or return an empty store.
+    pub fn load() -> Self {
+        let Some(path) = Self::file_path() else {
+            return Self::default();
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(content) => toml::from_str(&content).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Save to the default file path.
+    pub fn save(&self) -> Result<(), String> {
+        let Some(path) = Self::file_path() else {
+            return Err("could not determine config directory".to_owned());
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let content = toml::to_string_pretty(self).map_err(|e| e.to_string())?;
+        std::fs::write(&path, content).map_err(|e| e.to_string())
+    }
+
+    fn file_path() -> Option<PathBuf> {
+        dirs::config_dir().map(|d| d.join("samo").join("named_queries.toml"))
+    }
+
+    /// Save a named query. Overwrites if name already exists.
+    pub fn set(&mut self, name: &str, query: &str) {
+        self.queries.insert(name.to_owned(), query.to_owned());
+    }
+
+    /// Get a named query by name.
+    pub fn get(&self, name: &str) -> Option<&str> {
+        self.queries.get(name).map(String::as_str)
+    }
+
+    /// Delete a named query. Returns true if it existed.
+    pub fn delete(&mut self, name: &str) -> bool {
+        self.queries.remove(name).is_some()
+    }
+
+    /// List all named queries.
+    pub fn list(&self) -> &BTreeMap<String, String> {
+        &self.queries
+    }
+
+    /// Substitute positional parameters (`$1`, `$2`, …) in a query.
+    ///
+    /// Parameters are replaced in order: `$1` → `args[0]`, `$2` → `args[1]`,
+    /// and so on. Placeholders for which no argument was supplied are left
+    /// unchanged.
+    pub fn substitute(query: &str, args: &[&str]) -> String {
+        let mut result = query.to_owned();
+        for (i, arg) in args.iter().enumerate() {
+            let placeholder = format!("${}", i + 1);
+            result = result.replace(&placeholder, arg);
+        }
+        result
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_and_get() {
+        let mut nq = NamedQueries::default();
+        nq.set("foo", "select 1");
+        assert_eq!(nq.get("foo"), Some("select 1"));
+    }
+
+    #[test]
+    fn test_get_missing() {
+        let nq = NamedQueries::default();
+        assert_eq!(nq.get("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_delete_existing() {
+        let mut nq = NamedQueries::default();
+        nq.set("foo", "select 1");
+        assert!(nq.delete("foo"));
+        assert_eq!(nq.get("foo"), None);
+    }
+
+    #[test]
+    fn test_delete_missing() {
+        let mut nq = NamedQueries::default();
+        assert!(!nq.delete("nonexistent"));
+    }
+
+    #[test]
+    fn test_list_empty() {
+        let nq = NamedQueries::default();
+        assert!(nq.list().is_empty());
+    }
+
+    #[test]
+    fn test_list_populated() {
+        let mut nq = NamedQueries::default();
+        nq.set("alpha", "select 1");
+        nq.set("beta", "select 2");
+        let list = nq.list();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list.get("alpha").map(String::as_str), Some("select 1"));
+        assert_eq!(list.get("beta").map(String::as_str), Some("select 2"));
+    }
+
+    #[test]
+    fn test_substitute_no_args() {
+        let result = NamedQueries::substitute("select * from t", &[]);
+        assert_eq!(result, "select * from t");
+    }
+
+    #[test]
+    fn test_substitute_single() {
+        let result = NamedQueries::substitute("select * from t order by $1", &["id"]);
+        assert_eq!(result, "select * from t order by id");
+    }
+
+    #[test]
+    fn test_substitute_multiple() {
+        let result =
+            NamedQueries::substitute("select * from t order by $1 limit $2", &["name", "10"]);
+        assert_eq!(result, "select * from t order by name limit 10");
+    }
+
+    #[test]
+    fn test_substitute_missing_arg() {
+        // $3 left as-is when only 2 args provided
+        let result = NamedQueries::substitute("$1 $2 $3", &["a", "b"]);
+        assert_eq!(result, "a b $3");
+    }
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -2735,6 +2735,56 @@ async fn dispatch_meta(
             let subcommand = parsed.pattern.as_deref().unwrap_or("");
             crate::dba::execute(client, subcommand, parsed.plus).await;
         }
+        // Named queries (#69).
+        MetaCmd::NamedSave(ref name, ref query) => {
+            let mut nq = crate::named::NamedQueries::load();
+            nq.set(name, query);
+            match nq.save() {
+                Ok(()) => {
+                    if !settings.quiet {
+                        eprintln!("Saved query \"{name}\".");
+                    }
+                }
+                Err(e) => eprintln!("\\ns: {e}"),
+            }
+        }
+        MetaCmd::NamedExec(ref name, ref args) => {
+            let nq = crate::named::NamedQueries::load();
+            match nq.get(name) {
+                Some(query) => {
+                    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+                    let sql = crate::named::NamedQueries::substitute(query, &arg_refs);
+                    execute_query(client, &sql, settings, tx).await;
+                }
+                None => eprintln!("\\n: unknown query \"{name}\""),
+            }
+        }
+        MetaCmd::NamedList => {
+            let nq = crate::named::NamedQueries::load();
+            let queries = nq.list();
+            if queries.is_empty() {
+                println!("No named queries saved.");
+            } else {
+                for (name, query) in queries {
+                    println!("  {name}: {query}");
+                }
+            }
+        }
+        MetaCmd::NamedDelete(ref name) => {
+            let mut nq = crate::named::NamedQueries::load();
+            if nq.delete(name) {
+                match nq.save() {
+                    Ok(()) => {
+                        if !settings.quiet {
+                            eprintln!("Deleted query \"{name}\".");
+                        }
+                    }
+                    Err(e) => eprintln!("\\nd: {e}"),
+                }
+            } else {
+                eprintln!("\\nd: unknown query \"{name}\"");
+            }
+        }
         // Describe-family commands — delegate to the describe module.
         ref describe_cmd
             if matches!(


### PR DESCRIPTION
## Summary

- Add `\ns name query` — save a named query to `~/.config/samo/named_queries.toml`
- Add `\n name [args...]` — execute a saved query with optional `$1`/`$2`/… substitution
- Add `\n+` — list all saved queries
- Add `\nd name` — delete a saved query

## Implementation

- `src/named.rs` — new module with `NamedQueries` struct (BTreeMap-backed, TOML persistence via `dirs` + `toml` crates already in Cargo.toml)
- `src/metacmd.rs` — new `NamedSave`, `NamedExec`, `NamedList`, `NamedDelete` variants + `parse_n_family` parser
- `src/repl.rs` — dispatch handlers for all four commands
- `src/main.rs` — `mod named;`

## Tests

19 new unit tests added (10 in `named.rs`, 9 in `metacmd.rs`). All 631 tests pass.

## Test plan

- [ ] `cargo test` — all 631+ tests pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `\ns my_q select version()` saves a query, `\n my_q` executes it
- [ ] `\n+` lists the saved query
- [ ] `\ns tbl select * from t order by $1 limit $2` then `\n tbl id 5` performs substitution
- [ ] `\nd my_q` deletes; `\n my_q` prints unknown-query error
- [ ] File is created at `~/.config/samo/named_queries.toml`

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)