### PR TITLE
feat: session conversation context with /clear and /compact

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -110,6 +110,17 @@ pub struct AiConfig {
     /// is configured.
     #[serde(default = "default_true")]
     pub auto_explain_errors: bool,
+    /// Approximate context window size (in tokens) for the configured model.
+    ///
+    /// Used by auto-compact: when the conversation context exceeds 70% of
+    /// this value, older entries are automatically summarized.
+    /// Defaults to 128000 (128k).
+    #[serde(default = "default_context_window")]
+    pub context_window: u32,
+}
+
+fn default_context_window() -> u32 {
+    128_000
 }
 
 fn default_true() -> bool {
@@ -126,6 +137,7 @@ impl Default for AiConfig {
             max_tokens: 4096,
             auto_execute_readonly: false,
             auto_explain_errors: true,
+            context_window: default_context_window(),
         }
     }
 }
@@ -224,6 +236,11 @@ fn merge_config(base: Config, overlay: Config) -> Config {
             auto_execute_readonly: overlay.ai.auto_execute_readonly
                 || base.ai.auto_execute_readonly,
             auto_explain_errors: overlay.ai.auto_explain_errors && base.ai.auto_explain_errors,
+            context_window: if overlay.ai.context_window == default_context_window() {
+                base.ai.context_window
+            } else {
+                overlay.ai.context_window
+            },
         },
         connections: {
             let mut merged = base.connections;
@@ -571,6 +588,7 @@ provider = "ollama"
                 max_tokens: 2048,
                 auto_execute_readonly: false,
                 auto_explain_errors: true,
+                context_window: 128_000,
             },
             ..Default::default()
         };
@@ -583,6 +601,7 @@ provider = "ollama"
                 max_tokens: 4096,
                 auto_execute_readonly: false,
                 auto_explain_errors: true,
+                context_window: 128_000,
             },
             ..Default::default()
         };
@@ -603,6 +622,7 @@ provider = "ollama"
                 max_tokens: 4096,
                 auto_execute_readonly: false,
                 auto_explain_errors: true,
+                context_window: 128_000,
             },
             ..Default::default()
         };

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -517,6 +517,18 @@ impl ConversationContext {
         self.approx_tokens
     }
 
+    /// Auto-compact if the approximate token count exceeds 70% of the
+    /// configured context window.  Returns `true` if compaction occurred.
+    fn auto_compact_if_needed(&mut self, context_window: u32) -> bool {
+        let threshold = (u64::from(context_window) * 70 / 100) as usize;
+        if self.approx_tokens > threshold && self.entries.len() > 4 {
+            self.compact(None);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Drop oldest entries until we're within `max_entries`.
     fn trim(&mut self) {
         while self.entries.len() > self.max_entries {
@@ -4797,6 +4809,14 @@ async fn handle_ai_ask(
         .conversation
         .push_assistant(format!("Generated SQL:\n```sql\n{sql}\n```"));
 
+    // Auto-compact when approaching the context window limit.
+    if settings
+        .conversation
+        .auto_compact_if_needed(settings.config.ai.context_window)
+    {
+        eprintln!("-- AI context auto-compacted to save tokens");
+    }
+
     // Display with syntax highlighting when available.
     if settings.no_highlight {
         println!("{sql}");
@@ -6709,5 +6729,37 @@ mod tests {
     fn repl_settings_conversation_default_is_empty() {
         let s = ReplSettings::default();
         assert!(s.conversation.is_empty());
+    }
+
+    #[test]
+    fn conversation_auto_compact_below_threshold() {
+        let mut ctx = ConversationContext::new();
+        ctx.push_user("short message".to_owned());
+        // With a 128k context window, a short message is well below 70%.
+        assert!(!ctx.auto_compact_if_needed(128_000));
+    }
+
+    #[test]
+    fn conversation_auto_compact_above_threshold() {
+        let mut ctx = ConversationContext::new();
+        // Push enough data to exceed 70% of a tiny context window (100 tokens).
+        // 100 tokens * 70% = 70 tokens. At ~4 chars/token, that's ~280 chars.
+        for i in 0..20 {
+            ctx.push_user(format!("message {i} with enough content to fill tokens"));
+        }
+        assert!(ctx.entries.len() > 4);
+        let compacted = ctx.auto_compact_if_needed(100);
+        assert!(compacted);
+        // After compaction: 1 summary + 4 recent.
+        assert_eq!(ctx.entries.len(), 5);
+    }
+
+    #[test]
+    fn conversation_auto_compact_too_few_entries() {
+        let mut ctx = ConversationContext::new();
+        // Even if tokens are high, don't compact if <= 4 entries.
+        ctx.push_user("x".repeat(2000));
+        assert_eq!(ctx.entries.len(), 1);
+        assert!(!ctx.auto_compact_if_needed(10)); // threshold = 7 tokens
     }
 }


### PR DESCRIPTION
## Summary

- Add `ConversationContext` struct to `ReplSettings` for multi-turn AI interactions
- `/ask` now includes prior conversation history, enabling follow-up queries (e.g. "now group that by month")
- `/clear` — clear AI conversation context entirely
- `/compact [focus]` — summarize older entries to save tokens, with optional focus topic
- Auto-compact at 70% of context window (configurable via `[ai] context_window`)
- `context_window` config option (default 128k) for model-specific tuning
- 18 new tests (744 total, up from 726)

Implements session context, `/clear`, `/compact`, and auto-compaction from Sprint S-2.2.

## Test plan
- [ ] Verify `/ask` follow-up queries reference prior context
- [ ] Verify `/clear` resets conversation state
- [ ] Verify `/compact` reduces entry count while preserving recent turns
- [ ] Verify auto-compact triggers at 70% of configured context window
- [ ] Verify `\?` help text includes new commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)