### PR TITLE
feat: pg_ash context integration, \dba waits, auto-EXPLAIN AI

### DIFF
--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -90,6 +90,111 @@ pub async fn build_schema_context(client: &tokio_postgres::Client) -> Result<Str
 }
 
 // ---------------------------------------------------------------------------
+// Wait event context builder
+// ---------------------------------------------------------------------------
+
+/// SQL to collect current wait event breakdown from `pg_stat_activity`.
+const WAIT_SNAPSHOT_SQL: &str = "\
+    SELECT \
+        coalesce(wait_event_type, 'CPU/Running') AS wait_type, \
+        coalesce(wait_event, 'active') AS wait_event, \
+        count(*) AS sessions \
+    FROM pg_stat_activity \
+    WHERE pid != pg_backend_pid() \
+      AND backend_type = 'client backend' \
+      AND state = 'active' \
+    GROUP BY wait_event_type, wait_event \
+    ORDER BY sessions DESC \
+    LIMIT 15";
+
+/// SQL to collect historical top waits from `pg_ash` (last 5 minutes).
+const PG_ASH_RECENT_WAITS_SQL: &str = "\
+    SELECT \
+        wait_event_type, \
+        wait_event, \
+        count(*) AS samples \
+    FROM ash.ash_log \
+    WHERE sample_time > now() - interval '5 minutes' \
+      AND wait_event IS NOT NULL \
+    GROUP BY wait_event_type, wait_event \
+    ORDER BY samples DESC \
+    LIMIT 15";
+
+/// Build a wait event context string for inclusion in LLM prompts.
+///
+/// When `pg_ash` is available, includes both a current snapshot from
+/// `pg_stat_activity` and recent historical data from `ash.ash_log`.
+/// Otherwise, only the current snapshot is included.
+///
+/// Returns an empty string if no wait data is found (quiet databases).
+pub async fn build_wait_context(client: &tokio_postgres::Client, pg_ash_available: bool) -> String {
+    let mut sections = Vec::new();
+
+    // Current wait snapshot from pg_stat_activity.
+    if let Ok(snapshot) = format_simple_query(client, WAIT_SNAPSHOT_SQL).await {
+        if !snapshot.is_empty() {
+            sections.push(format!(
+                "Current wait events (pg_stat_activity snapshot):\n{snapshot}"
+            ));
+        }
+    }
+
+    // Historical wait data from pg_ash (if available).
+    if pg_ash_available {
+        if let Ok(history) = format_simple_query(client, PG_ASH_RECENT_WAITS_SQL).await {
+            if !history.is_empty() {
+                sections.push(format!(
+                    "Recent wait events (pg_ash, last 5 minutes):\n{history}"
+                ));
+            }
+        }
+    }
+
+    sections.join("\n\n")
+}
+
+/// Execute a query and format results as pipe-delimited text.
+///
+/// Returns the formatted output or an error string. Returns an empty
+/// string when the query produces no rows.
+async fn format_simple_query(client: &tokio_postgres::Client, sql: &str) -> Result<String, String> {
+    let messages = client.simple_query(sql).await.map_err(|e| e.to_string())?;
+
+    let mut headers: Vec<String> = Vec::new();
+    let mut rows: Vec<Vec<String>> = Vec::new();
+
+    for msg in messages {
+        if let tokio_postgres::SimpleQueryMessage::Row(row) = msg {
+            if headers.is_empty() {
+                headers = (0..row.len())
+                    .map(|i| {
+                        row.columns()
+                            .get(i)
+                            .map_or_else(|| format!("col{i}"), |c| c.name().to_owned())
+                    })
+                    .collect();
+            }
+            let vals: Vec<String> = (0..row.len())
+                .map(|i| row.get(i).unwrap_or("").to_owned())
+                .collect();
+            rows.push(vals);
+        }
+    }
+
+    if rows.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut out = headers.join(" | ");
+    out.push('\n');
+    for row in &rows {
+        out.push_str(&row.join(" | "));
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
 // Unit tests (string-building logic, no DB required)
 // ---------------------------------------------------------------------------
 
@@ -179,5 +284,20 @@ mod tests {
         let rows = [("myschema", "mytable", "id", "int4", true)];
         let out = build_from_rows(&rows);
         assert!(out.contains("create table myschema.mytable ("));
+    }
+
+    #[test]
+    fn wait_snapshot_sql_is_valid_syntax() {
+        // Verify the SQL constant is non-empty and contains expected keywords.
+        assert!(super::WAIT_SNAPSHOT_SQL.contains("pg_stat_activity"));
+        assert!(super::WAIT_SNAPSHOT_SQL.contains("wait_event_type"));
+        assert!(super::WAIT_SNAPSHOT_SQL.contains("GROUP BY"));
+    }
+
+    #[test]
+    fn pg_ash_recent_waits_sql_is_valid_syntax() {
+        assert!(super::PG_ASH_RECENT_WAITS_SQL.contains("ash.ash_log"));
+        assert!(super::PG_ASH_RECENT_WAITS_SQL.contains("wait_event"));
+        assert!(super::PG_ASH_RECENT_WAITS_SQL.contains("5 minutes"));
     }
 }

--- a/src/dba.rs
+++ b/src/dba.rs
@@ -64,6 +64,10 @@ pub async fn execute(client: &Client, subcommand: &str, verbose: bool) -> bool {
             dba_config(client, verbose).await;
             true
         }
+        "waits" | "wait" => {
+            dba_waits(client, verbose).await;
+            true
+        }
         "" | "help" => {
             print_dba_help();
             true
@@ -215,6 +219,7 @@ fn print_dba_help() {
     println!("\\dba diagnostic commands:");
     println!("  \\dba activity    Active queries and sessions");
     println!("  \\dba locks       Lock tree (blocked/blocking)");
+    println!("  \\dba waits       Wait event breakdown");
     println!("  \\dba bloat       Table bloat estimates");
     println!("  \\dba vacuum      Vacuum status and dead tuples");
     println!("  \\dba tablesize   Largest tables");
@@ -225,7 +230,7 @@ fn print_dba_help() {
     println!("  \\dba replication Replication slot status");
     println!("  \\dba config      Non-default configuration parameters");
     println!();
-    println!("Aliases: act, lock, vac, ts, conn, unused, seq, cache, repl, conf");
+    println!("Aliases: act, lock, wait, vac, ts, conn, unused, seq, cache, repl, conf");
 }
 
 // ---------------------------------------------------------------------------
@@ -434,6 +439,22 @@ async fn dba_replication(client: &Client, _verbose: bool) {
         confirmed_flush_lsn \
     from pg_replication_slots \
     order by slot_name";
+    run_and_print(client, sql).await;
+}
+
+async fn dba_waits(client: &Client, _verbose: bool) {
+    let sql = "SELECT \
+        coalesce(wait_event_type, 'CPU/Running') AS wait_type, \
+        coalesce(wait_event, 'active') AS wait_event, \
+        count(*) AS sessions, \
+        count(*) FILTER (WHERE state = 'active') AS active, \
+        count(*) FILTER (WHERE now() - query_start > interval '5 seconds') AS slow \
+    FROM pg_stat_activity \
+    WHERE pid != pg_backend_pid() \
+      AND backend_type = 'client backend' \
+    GROUP BY wait_event_type, wait_event \
+    ORDER BY sessions DESC \
+    LIMIT 25";
     run_and_print(client, sql).await;
 }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -907,6 +907,7 @@ pub async fn execute_query(
     // Skip for statements that are already EXPLAIN, or for
     // non-query statements (SET, BEGIN, COMMIT, etc.).
     let auto_explained;
+    let mut auto_explain_active = false;
     let sql_to_send = if settings.auto_explain == AutoExplain::Off {
         interpolated.as_str()
     } else {
@@ -918,6 +919,7 @@ pub async fn execute_query(
         let already_explain = trimmed_upper.starts_with("EXPLAIN");
         if is_query && !already_explain {
             auto_explained = format!("{}{}", settings.auto_explain.prefix(), interpolated);
+            auto_explain_active = true;
             auto_explained.as_str()
         } else {
             interpolated.as_str()
@@ -959,6 +961,9 @@ pub async fn execute_query(
         None
     };
 
+    // Capture auto-EXPLAIN plan text for optional AI interpretation.
+    let mut auto_explain_plan: Option<String> = None;
+
     let success = match client.simple_query(sql_to_send).await {
         Ok(messages) => {
             use tokio_postgres::SimpleQueryMessage;
@@ -986,6 +991,20 @@ pub async fn execute_query(
                         rows.push(vals);
                     }
                     SimpleQueryMessage::CommandComplete(n) => {
+                        // Capture plan text from auto-EXPLAIN before clearing
+                        // rows. EXPLAIN output is a single-column result set.
+                        if auto_explain_active && result_set_index == 0 {
+                            let plan_text: String = rows
+                                .iter()
+                                .filter_map(|r| r.first())
+                                .cloned()
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            if !plan_text.is_empty() {
+                                auto_explain_plan = Some(plan_text);
+                            }
+                        }
+
                         // Flush the current result set, then reset for next
                         // statement in a multi-statement query.
                         // Capture rendered output so we can mirror to log.
@@ -1057,6 +1076,12 @@ pub async fn execute_query(
         let elapsed = t.elapsed();
         // Timing always goes to stdout regardless of output redirection.
         println!("Time: {:.3} ms", elapsed.as_secs_f64() * 1000.0);
+    }
+
+    // Auto-EXPLAIN AI interpretation: when AI is configured and auto-EXPLAIN
+    // produced plan output, stream a concise interpretation.
+    if let Some(ref plan_text) = auto_explain_plan {
+        interpret_auto_explain(plan_text, sql, settings).await;
     }
 
     // Store as the last successfully executed query (used by `\watch`).
@@ -4607,6 +4632,71 @@ async fn suggest_error_fix_inline(sql: &str, error_message: &str, settings: &mut
     }
 }
 
+/// Interpret an auto-EXPLAIN plan with AI.
+///
+/// Called automatically after auto-EXPLAIN output is displayed. Uses a
+/// concise system prompt to produce a brief interpretation of the plan.
+/// Skips silently when AI is not configured or the token budget is exhausted.
+async fn interpret_auto_explain(
+    plan_text: &str,
+    original_query: &str,
+    settings: &mut ReplSettings,
+) {
+    if check_token_budget(settings) {
+        return;
+    }
+
+    let provider_name = match settings.config.ai.provider.as_deref() {
+        Some(p) if !p.is_empty() => p,
+        _ => return,
+    };
+
+    let api_key = settings
+        .config
+        .ai
+        .api_key_env
+        .as_deref()
+        .and_then(|env_name| std::env::var(env_name).ok());
+
+    let Ok(provider) = crate::ai::create_provider(
+        provider_name,
+        api_key.as_deref(),
+        settings.config.ai.base_url.as_deref(),
+    ) else {
+        return;
+    };
+
+    let messages = vec![
+        crate::ai::Message {
+            role: crate::ai::Role::System,
+            content: "You are a PostgreSQL performance expert. \
+                      Give a brief (2-4 sentence) interpretation of the \
+                      EXPLAIN plan. Focus on: most expensive nodes, \
+                      sequential scans, row estimate errors, and one \
+                      actionable suggestion if applicable."
+                .to_owned(),
+        },
+        crate::ai::Message {
+            role: crate::ai::Role::User,
+            content: format!("Query: {original_query}\n\nPlan:\n{plan_text}"),
+        },
+    ];
+
+    let options = crate::ai::CompletionOptions {
+        model: settings.config.ai.model.clone().unwrap_or_default(),
+        max_tokens: 300,
+        temperature: 0.0,
+    };
+
+    if let Ok(result) = provider.complete(&messages, &options).await {
+        record_token_usage(settings, &result);
+        let interpretation = result.content.trim();
+        if !interpretation.is_empty() {
+            eprintln!("\x1b[2m{interpretation}\x1b[0m");
+        }
+    }
+}
+
 async fn stream_completion(
     provider: &dyn crate::ai::LlmProvider,
     messages: &[crate::ai::Message],
@@ -4874,17 +4964,31 @@ async fn handle_ai_ask(
         }
     };
 
+    // Collect wait event context for richer analysis.
+    let wait_ctx = crate::ai::context::build_wait_context(
+        client,
+        settings.db_capabilities.pg_ash.is_available(),
+    )
+    .await;
+
+    let wait_section = if wait_ctx.is_empty() {
+        String::new()
+    } else {
+        format!("\n\nDatabase activity:\n{wait_ctx}")
+    };
+
     let system_content = format!(
         "You are a PostgreSQL expert. \
          Generate SQL queries based on the user's request.\n\
          Database: {dbname}\n\n\
-         Schema:\n{schema}\n\n\
+         Schema:\n{schema}{wait}\n\n\
          Rules:\n\
          - Output ONLY the SQL query, nothing else\n\
          - Use standard PostgreSQL syntax\n\
          - If the request is ambiguous, make reasonable assumptions",
         dbname = params.dbname,
         schema = schema_ctx,
+        wait = wait_section,
     );
 
     // Build messages: system + conversation history + current prompt.
@@ -5342,6 +5446,22 @@ async fn handle_ai_explain(
         }
     };
 
+    // Collect wait event context for performance correlation.
+    let wait_ctx = crate::ai::context::build_wait_context(
+        client,
+        settings.db_capabilities.pg_ash.is_available(),
+    )
+    .await;
+
+    let wait_section = if wait_ctx.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\n\nDatabase activity (use to correlate plan behavior \
+             with current wait patterns):\n{wait_ctx}"
+        )
+    };
+
     let system_content = format!(
         "You are a PostgreSQL performance expert. \
          Analyse the EXPLAIN ANALYZE plan provided by the user and give \
@@ -5349,11 +5469,13 @@ async fn handle_ai_explain(
          - Identify the most expensive nodes\n\
          - Flag sequential scans on large tables\n\
          - Note any high row-estimate errors\n\
-         - Suggest specific indexes or query rewrites when applicable\n\n\
+         - Suggest specific indexes or query rewrites when applicable\n\
+         - If wait event data is provided, correlate plan behavior with waits\n\n\
          Database: {dbname}\n\n\
-         Schema:\n{schema}",
+         Schema:\n{schema}{wait}",
         dbname = params.dbname,
         schema = schema_ctx,
+        wait = wait_section,
     );
 
     let user_content = format!("Query:\n{target_query}\n\nEXPLAIN ANALYZE output:\n{plan_text}");


### PR DESCRIPTION
## Summary

- **pg_ash context integration**: `build_wait_context()` in `ai/context.rs` collects current wait events from `pg_stat_activity` and recent historical data from `pg_ash` (when available). This context is injected into `/ask` and `/explain` system prompts, enabling the LLM to correlate query analysis with live database activity patterns.
- **`\dba waits` command**: New diagnostic subcommand showing wait event breakdown with session counts, active counts, and slow query indicators. Aliases: `waits`, `wait`.
- **Auto-EXPLAIN AI interpretation**: When auto-EXPLAIN is active and AI is configured, automatically interprets the EXPLAIN plan output with a concise 2-4 sentence analysis (printed dimmed, similar to inline error suggestions).

## Changes

| File | What |
|------|------|
| `src/ai/context.rs` | `build_wait_context()`, `format_simple_query()`, wait SQL constants, 2 tests |
| `src/dba.rs` | `\dba waits` subcommand + help text update |
| `src/repl.rs` | Wait context in `/ask` and `/explain`, auto-EXPLAIN plan capture + `interpret_auto_explain()` |

## Test plan

- [x] 798 unit tests pass (796 → 798, +2 SQL constant validation tests)
- [x] `cargo clippy --all-targets` clean with `-D warnings`
- [x] `cargo fmt` clean
- [ ] Manual: connect to PG, run `\dba waits` → shows wait event breakdown
- [ ] Manual: enable `\explain` mode, run SELECT → plan + AI interpretation appears
- [ ] Manual: `/explain SELECT 1` → system prompt includes wait context section
- [ ] Manual: with pg_ash installed, verify historical wait data appears in context

Closes part of #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)