### PR TITLE
feat(dba): AI interpretation for \dba waits+ command

### DIFF
--- a/src/dba.rs
+++ b/src/dba.rs
@@ -19,78 +19,75 @@ use tokio_postgres::Client;
 /// `governance` is used for Supervised mode checks (index health proposals).
 /// `capabilities` provides version-gated feature detection.
 ///
-/// Returns `true` if the subcommand was recognised, `false` otherwise.
+/// Returns optional text for AI interpretation (e.g. `\dba waits+`).
 pub async fn execute(
     client: &Client,
     subcommand: &str,
     verbose: bool,
     governance: Option<&crate::config::GovernanceConfig>,
     capabilities: Option<&crate::capabilities::DbCapabilities>,
-) -> bool {
+) -> Option<String> {
     match subcommand {
         "activity" | "act" => {
             dba_activity(client, verbose).await;
-            true
+            None
         }
         "locks" | "lock" => {
             dba_locks(client, verbose).await;
-            true
+            None
         }
         "bloat" => {
             dba_bloat(client, verbose).await;
-            true
+            None
         }
         "vacuum" | "vac" => {
             dba_vacuum(client, verbose).await;
-            true
+            None
         }
         "tablesize" | "ts" => {
             dba_tablesize(client, verbose).await;
-            true
+            None
         }
         "connections" | "conn" => {
             dba_connections(client, verbose).await;
-            true
+            None
         }
         "unused-idx" | "unused" => {
             dba_unused_indexes(client, verbose).await;
-            true
+            None
         }
         "seq-scans" | "seq" => {
             dba_seq_scans(client, verbose).await;
-            true
+            None
         }
         "cache-hit" | "cache" => {
             dba_cache_hit(client, verbose).await;
-            true
+            None
         }
         "replication" | "repl" => {
             dba_replication(client, verbose).await;
-            true
+            None
         }
         "config" | "conf" => {
             dba_config(client, verbose).await;
-            true
+            None
         }
-        "waits" | "wait" => {
-            dba_waits(client, verbose).await;
-            true
-        }
+        "waits" | "wait" => dba_waits(client, verbose).await,
         "indexes" | "idx" => {
             dba_indexes(client, verbose, governance).await;
-            true
+            None
         }
         "progress" | "prog" => {
             dba_progress(client, None).await;
-            true
+            None
         }
         "io" => {
             dba_io(client, verbose, capabilities).await;
-            true
+            None
         }
         "" | "help" => {
             print_dba_help();
-            true
+            None
         }
         _ => {
             // Handle two-word subcommands: `\dba progress vacuum`, etc.
@@ -99,11 +96,11 @@ pub async fn execute(
                 .or_else(|| subcommand.strip_prefix("prog "))
             {
                 dba_progress(client, Some(rest.trim())).await;
-                return true;
+                return None;
             }
             eprintln!("\\dba: unknown subcommand \"{subcommand}\"");
             eprintln!("Try \\dba help for available subcommands.");
-            false
+            None
         }
     }
 }
@@ -247,7 +244,7 @@ fn print_dba_help() {
     println!("\\dba diagnostic commands:");
     println!("  \\dba activity    Active queries and sessions");
     println!("  \\dba locks       Lock tree (blocked/blocking)");
-    println!("  \\dba waits       Wait event breakdown");
+    println!("  \\dba waits       Wait event breakdown (+ for AI interpretation)");
     println!("  \\dba bloat       Table bloat estimates");
     println!("  \\dba vacuum      Vacuum status and dead tuples");
     println!("  \\dba tablesize   Largest tables");
@@ -482,7 +479,8 @@ async fn dba_replication(client: &Client, _verbose: bool) {
     run_and_print(client, sql).await;
 }
 
-async fn dba_waits(client: &Client, _verbose: bool) {
+/// Returns AI context text when `verbose` is true.
+async fn dba_waits(client: &Client, verbose: bool) -> Option<String> {
     let sql = "SELECT \
         coalesce(wait_event_type, 'CPU/Running') AS wait_type, \
         coalesce(wait_event, 'active') AS wait_event, \
@@ -496,6 +494,35 @@ async fn dba_waits(client: &Client, _verbose: bool) {
     ORDER BY sessions DESC \
     LIMIT 25";
     run_and_print(client, sql).await;
+
+    if !verbose {
+        return None;
+    }
+
+    // Collect the same data as text for AI interpretation.
+    let Ok(messages) = client.simple_query(sql).await else {
+        return None;
+    };
+
+    let mut lines = Vec::new();
+    for msg in messages {
+        if let tokio_postgres::SimpleQueryMessage::Row(row) = msg {
+            let wait_type = row.get(0).unwrap_or("?");
+            let wait_event = row.get(1).unwrap_or("?");
+            let sessions = row.get(2).unwrap_or("0");
+            let active = row.get(3).unwrap_or("0");
+            let slow = row.get(4).unwrap_or("0");
+            lines.push(format!(
+                "{wait_type}/{wait_event}: {sessions} sessions ({active} active, {slow} slow)"
+            ));
+        }
+    }
+
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
 }
 
 async fn dba_indexes(

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -3572,7 +3572,7 @@ async fn dispatch_meta(
         // Diagnostic commands — delegate to the dba module.
         MetaCmd::Dba => {
             let subcommand = parsed.pattern.as_deref().unwrap_or("");
-            crate::dba::execute(
+            let ai_context = crate::dba::execute(
                 client,
                 subcommand,
                 parsed.plus,
@@ -3580,6 +3580,10 @@ async fn dispatch_meta(
                 Some(&settings.db_capabilities),
             )
             .await;
+            // AI interpretation when the command returns context (e.g. \dba waits+).
+            if let Some(ref context) = ai_context {
+                interpret_dba_output(context, subcommand, settings).await;
+            }
         }
         // Named queries (#69).
         MetaCmd::NamedSave(ref name, ref query) => {
@@ -4831,6 +4835,70 @@ async fn interpret_auto_explain(
         temperature: 0.0,
     };
 
+    if let Ok(result) = provider.complete(&messages, &options).await {
+        record_token_usage(settings, &result);
+        let interpretation = result.content.trim();
+        if !interpretation.is_empty() {
+            eprintln!("\x1b[2m{interpretation}\x1b[0m");
+        }
+    }
+}
+
+/// Interpret `\dba` diagnostic output with AI.
+///
+/// Called when a `\dba` command returns AI context (e.g. `\dba waits+`).
+/// Produces a brief analysis of the diagnostic data. Skips silently when
+/// AI is not configured.
+async fn interpret_dba_output(context: &str, subcommand: &str, settings: &mut ReplSettings) {
+    if check_token_budget(settings) {
+        return;
+    }
+
+    let provider_name = match settings.config.ai.provider.as_deref() {
+        Some(p) if !p.is_empty() => p,
+        _ => {
+            eprintln!("-- AI interpretation requires [ai] provider to be configured");
+            return;
+        }
+    };
+
+    let api_key = settings
+        .config
+        .ai
+        .api_key_env
+        .as_deref()
+        .and_then(|env_name| std::env::var(env_name).ok());
+
+    let Ok(provider) = crate::ai::create_provider(
+        provider_name,
+        api_key.as_deref(),
+        settings.config.ai.base_url.as_deref(),
+    ) else {
+        return;
+    };
+
+    let messages = vec![
+        crate::ai::Message {
+            role: crate::ai::Role::System,
+            content: "You are a PostgreSQL performance expert. \
+                      Analyze the diagnostic output below and give a brief (3-5 sentence) \
+                      interpretation. Focus on: dominant wait events, potential bottlenecks, \
+                      and one actionable recommendation if applicable."
+                .to_owned(),
+        },
+        crate::ai::Message {
+            role: crate::ai::Role::User,
+            content: format!("\\dba {subcommand} output:\n\n{context}"),
+        },
+    ];
+
+    let options = crate::ai::CompletionOptions {
+        model: settings.config.ai.model.clone().unwrap_or_default(),
+        max_tokens: 400,
+        temperature: 0.0,
+    };
+
+    eprintln!("-- AI interpreting wait events...");
     if let Ok(result) = provider.complete(&messages, &options).await {
         record_token_usage(settings, &result);
         let interpretation = result.content.trim();


### PR DESCRIPTION
## Summary
- `\dba waits+` now passes wait event data to the configured AI provider for analysis
- AI provides brief interpretation: dominant wait events, bottlenecks, and actionable recommendations
- Without AI configured, shows a helpful message directing to `[ai] provider` config
- Without the `+` modifier, `\dba waits` behavior is unchanged
- Help text updated to indicate `+` support

Closes the `\dba waits AI interpretation mode` item from #94.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] All 930 tests pass
- [x] `\dba waits` (without +) works as before
- [x] `\dba waits+` collects data for AI (tested without AI provider — shows config message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)