### PR TITLE
fix(dba): use relname instead of tablename in bloat query

### DIFF
--- a/src/dba.rs
+++ b/src/dba.rs
@@ -334,11 +334,12 @@ async fn dba_locks(client: &Client, _verbose: bool) {
 }
 
 async fn dba_bloat(client: &Client, _verbose: bool) {
+    // pg_stat_user_tables uses `relname`, not `tablename`.
     let sql = "select \
         schemaname, \
-        tablename, \
+        relname as tablename, \
         pg_size_pretty(pg_total_relation_size( \
-            schemaname || '.' || tablename)) as total_size, \
+            schemaname || '.' || relname)) as total_size, \
         case when n_live_tup > 0 \
              then round(100.0 * n_dead_tup \
                       / (n_live_tup + n_dead_tup), 1) \


### PR DESCRIPTION
## Summary

- `\dba bloat` was returning `db error: column "tablename" does not exist`
- Root cause: `pg_stat_user_tables` exposes the table name as `relname`, not `tablename` — the query referenced the wrong column name in both the `SELECT` list and the `pg_total_relation_size()` call
- Fix: replace `tablename` with `relname` (aliased back to `tablename` for display consistency)

Fixes #126

## Test plan

- [ ] `cargo clippy --all-targets -- -D warnings` passes (verified)
- [ ] `cargo test` passes — 930/930 (verified)
- [ ] Run `\dba bloat` against a live PostgreSQL 14–18 instance; confirm table output instead of db error
- [ ] Run against a database with dead tuples (e.g. after an UPDATE without VACUUM) to confirm rows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)