### PR TITLE
fix(copy): handle column list without space before '('

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -928,8 +928,7 @@ mod tests {
     /// `WITH (FORMAT csv, HEADER)` parenthesised options block.
     #[test]
     fn test_parse_with_options_block() {
-        let spec =
-            parse_copy_args("t FROM '/f' WITH (FORMAT csv, HEADER)").unwrap();
+        let spec = parse_copy_args("t FROM '/f' WITH (FORMAT csv, HEADER)").unwrap();
         assert_eq!(spec.format, CopyFormat::Csv);
         assert!(spec.header);
     }
@@ -937,8 +936,7 @@ mod tests {
     /// `WITH (FORMAT text, DELIMITER ',')` options block.
     #[test]
     fn test_parse_with_options_block_delimiter() {
-        let spec =
-            parse_copy_args("t FROM '/f' WITH (FORMAT text, DELIMITER ',')").unwrap();
+        let spec = parse_copy_args("t FROM '/f' WITH (FORMAT text, DELIMITER ',')").unwrap();
         assert_eq!(spec.format, CopyFormat::Text);
         assert_eq!(spec.delimiter, Some(','));
     }


### PR DESCRIPTION
## Summary

- Fixes `\copy users(id, email, name, created_at) FROM ...` failing with `expected FROM or TO, got 'EMAIL,'`
- The tokenizer now stops a regular token at `(`, so `users(id,...)` is correctly split into `users` and `(id, ...)`
- Adds support for the `WITH (FORMAT csv, ...)` parenthesised option block (psql-compatible syntax)
- Extracts `parse_copy_options` helper to keep `parse_copy_args` under the 100-line clippy limit

## Root cause

`Tokenizer::advance()` treated `(` as non-whitespace and read `users(id,` as a single token. The subsequent token `email,` was then matched against `FROM`/`TO`, producing the misleading error.

## Test plan

- [x] New test `test_parse_columns_no_space_before_paren` reproduces the exact failing command from the bug report
- [x] New test `test_parse_columns_with_space_before_paren` confirms the spaced form still works  
- [x] New tests `test_parse_with_options_block` and `test_parse_with_options_block_delimiter` cover `WITH (...)` syntax
- [x] All 934 existing tests continue to pass
- [x] `cargo clippy --all-targets -- -D warnings` clean

Closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)