### PR TITLE
fix(describe): show WHERE clause for partial indexes

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -1352,6 +1352,7 @@ limit 1"
 
     // 2. Indexes — query returns raw fields; we format as psql indented text.
     // psql format: "name" PRIMARY KEY, btree (cols)  or  "name" btree (cols)
+    // col 6: pg_get_expr(indpred) is non-NULL for partial indexes (WHERE clause)
     let idx_sql = format!(
         "select
     i.relname as idx_name,
@@ -1364,7 +1365,8 @@ limit 1"
      where conrelid = ix.indrelid
        and conindid = i.oid
        and contype in ('p','u')
-     limit 1) as con_name
+     limit 1) as con_name,
+    pg_catalog.pg_get_expr(ix.indpred, ix.indrelid) as idx_pred
 from pg_catalog.pg_index as ix
 join pg_catalog.pg_class as i
     on i.oid = ix.indexrelid
@@ -1440,8 +1442,8 @@ order by 1, 2"
     }
     if let Ok(messages) = client.simple_query(&idx_sql).await {
         use tokio_postgres::SimpleQueryMessage;
-        // Collect: (idx_name, is_primary, is_unique, amname, idx_oid_str)
-        let mut index_rows: Vec<(String, bool, bool, String, String)> = Vec::new();
+        // Collect: (idx_name, is_primary, is_unique, amname, idx_oid_str, idx_pred)
+        let mut index_rows: Vec<(String, bool, bool, String, String, String)> = Vec::new();
         for msg in messages {
             if let SimpleQueryMessage::Row(row) = msg {
                 let idx_name = row.get(0).unwrap_or("").to_owned();
@@ -1450,12 +1452,21 @@ order by 1, 2"
                 let amname = row.get(3).unwrap_or("").to_owned();
                 let idx_oid_str = row.get(4).unwrap_or("0").to_owned();
                 // col 5 = con_name (used implicitly via is_primary/is_unique flags)
-                index_rows.push((idx_name, is_primary, is_unique, amname, idx_oid_str));
+                // col 6 = pg_get_expr(indpred): non-empty for partial indexes
+                let idx_pred = row.get(6).unwrap_or("").to_owned();
+                index_rows.push((
+                    idx_name,
+                    is_primary,
+                    is_unique,
+                    amname,
+                    idx_oid_str,
+                    idx_pred,
+                ));
             }
         }
         if !index_rows.is_empty() {
             println!("Indexes:");
-            for (idx_name, is_primary, is_unique, amname, idx_oid_str) in &index_rows {
+            for (idx_name, is_primary, is_unique, amname, idx_oid_str, idx_pred) in &index_rows {
                 // Extract column list from pg_get_indexdef (the part inside parens).
                 let indexdef_sql =
                     format!("select pg_catalog.pg_get_indexdef({idx_oid_str}, 0, true)");
@@ -1483,7 +1494,13 @@ order by 1, 2"
                     String::new()
                 };
 
-                println!("    \"{idx_name}\"{type_label} {amname} {col_expr}");
+                let pred_suffix = if idx_pred.is_empty() {
+                    String::new()
+                } else {
+                    format!(" WHERE {idx_pred}")
+                };
+
+                println!("    \"{idx_name}\"{type_label} {amname} {col_expr}{pred_suffix}");
             }
         }
     }

--- a/tests/integration_smoke.rs
+++ b/tests/integration_smoke.rs
@@ -593,6 +593,42 @@ async fn describe_d_table() {
     );
 }
 
+/// `\d products` shows the partial index WHERE clause for `products_active_idx`.
+///
+/// Regression test for issue #144: partial index predicates must appear in
+/// `\d <table>` output as `WHERE <predicate>`, matching psql behaviour.
+#[tokio::test]
+#[serial]
+async fn describe_d_table_partial_index_where_clause() {
+    let db = connect_or_skip!();
+    db.teardown_schema().await.expect("teardown failed");
+    db.run_fixture("schema.sql")
+        .await
+        .expect("schema fixture failed");
+
+    let (stdout, stderr, code) = run_samo(&["-c", r"\d products"]);
+    db.teardown_schema().await.expect("teardown failed");
+
+    assert_eq!(
+        code, 0,
+        "\\d products should exit 0\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    // The fixture creates `products_active_idx` as a partial index with
+    // `WHERE active = true`. The output must include the predicate.
+    assert!(
+        stdout.contains("products_active_idx"),
+        "\\d products should list 'products_active_idx':\n{stdout}"
+    );
+    assert!(
+        stdout.contains("WHERE"),
+        "\\d products should show WHERE clause for partial index:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("active"),
+        "\\d products WHERE clause should contain predicate column:\n{stdout}"
+    );
+}
+
 /// `\d` (no args) lists all relations.
 #[tokio::test]
 #[serial]


### PR DESCRIPTION
## Summary

- Adds `pg_catalog.pg_get_expr(ix.indpred, ix.indrelid)` as column `idx_pred` to the index query in `describe_table()`
- Appends ` WHERE <predicate>` to the index output line when `idx_pred` is non-empty, matching psql behaviour
- Adds integration test `describe_d_table_partial_index_where_clause` verifying that `\d products` shows the WHERE clause for `products_active_idx` (already present in the test fixture)

Closes #144

## Test plan

- [ ] `cargo clippy --all-targets -- -D warnings` passes (verified)
- [ ] `cargo fmt` passes (verified)
- [ ] `cargo test` passes — 936 unit tests (verified)
- [ ] Integration test `describe_d_table_partial_index_where_clause` passes against a live DB (`cargo test --features integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)