### PR TITLE
test(compat): add verbose describe tests; update SPEC.md progress

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2788,6 +2788,13 @@ Each step's output determines what to ask next. The LLM doesn't follow a rigid s
 - [x] `pg_stat_progress_*` in `\dba` (VACUUM, CREATE INDEX, CLUSTER, ANALYZE progress monitoring)
 - [x] `\dba waits+` AI interpretation of wait event data (PR #131)
 - [x] `\l` PG version compatibility fix — correct column set for PG 14-18 (PR #123)
+- [x] `\dt`, `\di`, `\dv` etc. specific titles matching psql (PR #136)
+- [x] Error message display with full SQLSTATE/detail/hint context (PR #137)
+- [x] Multiple `-c` flag support (PR #138)
+- [x] `\copy` column list parsing fix (PR #140)
+- [x] Partial index WHERE clause in `\d` output (PR #145)
+- [x] Verbose describe columns for `\dn+`, `\du+`, `\dv+`, `\dm+`, `\ds+` (PR #146)
+- [x] Golden file compat tests for describe commands (PR #133, #139)
 
 ---
 

--- a/tests/compat/test-compat.sh
+++ b/tests/compat/test-compat.sh
@@ -237,6 +237,21 @@ compare "\\dm" \
 compare "\\di+" \
   "\\di+"
 
+compare "\\dn+" \
+  "\\dn+"
+
+compare "\\du+" \
+  "\\du+"
+
+compare "\\dv+" \
+  "\\dv+"
+
+compare "\\dm+" \
+  "\\dm+"
+
+compare "\\ds+" \
+  "\\ds+"
+
 # \d products and \d+ products disabled — partial index WHERE clause missing (#144)
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `\dn+`, `\du+`, `\dv+`, `\dm+`, `\ds+` golden file compat tests to `tests/compat/test-compat.sh` (after `\di+`); these were previously failing and are now fixed by PR #146
- Records 7 newly completed Phase 4 checklist items in `SPEC.md`: PR #136–140, #145, #146, #133, #139

## Test plan

- [ ] CI compat test run passes with the new verbose describe test cases
- [ ] SPEC.md Phase 4 checklist visually reviewed for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)