### PR TITLE
feat(describe): implement \dy list event triggers (#155)

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -53,6 +53,7 @@ pub async fn execute(client: &Client, meta: &ParsedMeta, pg_major_version: Optio
         MetaCmd::ListFdws => list_fdws(client, meta).await,
         MetaCmd::ListForeignTablesViaFdw => list_foreign_tables_via_fdw(client, meta).await,
         MetaCmd::ListUserMappings => list_user_mappings(client, meta).await,
+        MetaCmd::ListEventTriggers => list_event_triggers(client, meta).await,
         // Non-describe commands should never reach this function.
         _ => false,
     }
@@ -1452,6 +1453,85 @@ order by 1, 2"
 }
 
 // ---------------------------------------------------------------------------
+// \dy — list event triggers
+// ---------------------------------------------------------------------------
+
+/// List event triggers.
+///
+/// Matches psql's `\dy [pattern]` output: Name, Event, Owner, Enabled,
+/// Function, Tags.  With `+`, also adds a Description column.
+///
+/// Event triggers are global objects (no schema qualifier).
+async fn list_event_triggers(client: &Client, meta: &ParsedMeta) -> bool {
+    let name_filter = pattern::where_clause(meta.pattern.as_deref(), "e.evtname", None);
+
+    let where_clause = if name_filter.is_empty() {
+        String::new()
+    } else {
+        format!("where {name_filter}")
+    };
+
+    let sql = if meta.plus {
+        format!(
+            "select
+    e.evtname as \"Name\",
+    e.evtevent as \"Event\",
+    pg_catalog.pg_get_userbyid(e.evtowner) as \"Owner\",
+    case e.evtenabled
+        when 'O' then 'enabled'
+        when 'R' then 'replica'
+        when 'A' then 'always'
+        when 'D' then 'disabled'
+    end as \"Enabled\",
+    e.evtfoid::pg_catalog.regproc as \"Function\",
+    pg_catalog.array_to_string(
+        array(
+            select x
+            from pg_catalog.unnest(e.evttags) as t(x)
+        ),
+        ', '
+    ) as \"Tags\",
+    coalesce(pg_catalog.obj_description(e.oid, 'pg_event_trigger'), '') as \"Description\"
+from pg_catalog.pg_event_trigger as e
+{where_clause}
+order by 1"
+        )
+    } else {
+        format!(
+            "select
+    e.evtname as \"Name\",
+    e.evtevent as \"Event\",
+    pg_catalog.pg_get_userbyid(e.evtowner) as \"Owner\",
+    case e.evtenabled
+        when 'O' then 'enabled'
+        when 'R' then 'replica'
+        when 'A' then 'always'
+        when 'D' then 'disabled'
+    end as \"Enabled\",
+    e.evtfoid::pg_catalog.regproc as \"Function\",
+    pg_catalog.array_to_string(
+        array(
+            select x
+            from pg_catalog.unnest(e.evttags) as t(x)
+        ),
+        ', '
+    ) as \"Tags\"
+from pg_catalog.pg_event_trigger as e
+{where_clause}
+order by 1"
+        )
+    };
+
+    run_and_print_titled(
+        client,
+        &sql,
+        meta.echo_hidden,
+        Some("List of event triggers"),
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
 // \d [table] — describe a specific table, or list all relations
 // ---------------------------------------------------------------------------
 
@@ -2479,6 +2559,129 @@ order by 1, 2";
         assert!(
             sql.contains("pg_relation_size"),
             "view plus SQL should use pg_relation_size: {sql}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // list_event_triggers SQL generation
+    // -----------------------------------------------------------------------
+
+    /// Verify that the non-verbose SQL for `\dy` includes the six expected
+    /// columns and queries `pg_event_trigger`.
+    #[test]
+    fn list_event_triggers_sql_has_required_columns() {
+        let name_filter = pattern::where_clause(None, "e.evtname", None);
+        let where_clause = if name_filter.is_empty() {
+            String::new()
+        } else {
+            format!("where {name_filter}")
+        };
+
+        let sql = format!(
+            "select
+    e.evtname as \"Name\",
+    e.evtevent as \"Event\",
+    pg_catalog.pg_get_userbyid(e.evtowner) as \"Owner\",
+    case e.evtenabled
+        when 'O' then 'enabled'
+        when 'R' then 'replica'
+        when 'A' then 'always'
+        when 'D' then 'disabled'
+    end as \"Enabled\",
+    e.evtfoid::pg_catalog.regproc as \"Function\",
+    pg_catalog.array_to_string(
+        array(
+            select x
+            from pg_catalog.unnest(e.evttags) as t(x)
+        ),
+        ', '
+    ) as \"Tags\"
+from pg_catalog.pg_event_trigger as e
+{where_clause}
+order by 1"
+        );
+
+        assert!(sql.contains("\"Name\""), "SQL must have Name column: {sql}");
+        assert!(
+            sql.contains("\"Event\""),
+            "SQL must have Event column: {sql}"
+        );
+        assert!(
+            sql.contains("\"Owner\""),
+            "SQL must have Owner column: {sql}"
+        );
+        assert!(
+            sql.contains("\"Enabled\""),
+            "SQL must have Enabled column: {sql}"
+        );
+        assert!(
+            sql.contains("\"Function\""),
+            "SQL must have Function column: {sql}"
+        );
+        assert!(sql.contains("\"Tags\""), "SQL must have Tags column: {sql}");
+        assert!(
+            sql.contains("pg_event_trigger"),
+            "SQL must query pg_event_trigger: {sql}"
+        );
+        assert!(
+            !sql.contains("\"Description\""),
+            "non-verbose SQL must not have Description: {sql}"
+        );
+    }
+
+    /// Verify that verbose `\dy+` SQL adds a Description column via
+    /// `obj_description`.
+    #[test]
+    fn list_event_triggers_plus_sql_has_description_column() {
+        let sql = "select
+    e.evtname as \"Name\",
+    e.evtevent as \"Event\",
+    pg_catalog.pg_get_userbyid(e.evtowner) as \"Owner\",
+    case e.evtenabled
+        when 'O' then 'enabled'
+        when 'R' then 'replica'
+        when 'A' then 'always'
+        when 'D' then 'disabled'
+    end as \"Enabled\",
+    e.evtfoid::pg_catalog.regproc as \"Function\",
+    pg_catalog.array_to_string(
+        array(
+            select x
+            from pg_catalog.unnest(e.evttags) as t(x)
+        ),
+        ', '
+    ) as \"Tags\",
+    coalesce(pg_catalog.obj_description(e.oid, 'pg_event_trigger'), '') as \"Description\"
+from pg_catalog.pg_event_trigger as e
+order by 1";
+
+        assert!(
+            sql.contains("\"Description\""),
+            "verbose SQL must have Description column: {sql}"
+        );
+        assert!(
+            sql.contains("obj_description"),
+            "verbose SQL must use obj_description: {sql}"
+        );
+        assert!(
+            sql.contains("pg_event_trigger"),
+            "verbose SQL must query pg_event_trigger: {sql}"
+        );
+    }
+
+    /// Verify that a pattern filter is applied to `evtname`.
+    #[test]
+    fn list_event_triggers_pattern_filter_applied() {
+        let name_filter = pattern::where_clause(Some("my_trigger"), "e.evtname", None);
+        let where_clause = format!("where {name_filter}");
+
+        assert!(
+            where_clause.contains("e.evtname"),
+            "filter must reference e.evtname: {where_clause}"
+        );
+        assert!(
+            where_clause.contains("my_trigger"),
+            "filter must include pattern value: {where_clause}"
         );
     }
 }

--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -76,6 +76,8 @@ pub enum MetaCmd {
     ListForeignTablesViaFdw,
     /// `\deu [pattern]` — list user mappings.
     ListUserMappings,
+    /// `\dy [pattern]` — list event triggers.
+    ListEventTriggers,
 
     // -- Session commands (stubs; handlers will be added in #28) -----------
     /// `\sf [funcname]` — show function source.
@@ -313,6 +315,7 @@ impl MetaCmd {
             Self::ListFdws => "\\dew",
             Self::ListForeignTablesViaFdw => "\\det",
             Self::ListUserMappings => "\\deu",
+            Self::ListEventTriggers => "\\dy",
             Self::ShowFunctionSource => "\\sf",
             Self::ShowViewDef => "\\sv",
             Self::Reconnect => "\\c",
@@ -573,7 +576,10 @@ fn parse_m_family(input: &str) -> ParsedMeta {
     ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()))
 }
 
-/// Parse `\yolo` — enter YOLO execution mode.
+/// Parse `\y` family: `\yolo` and `\dy [+] [pattern]`.
+///
+/// Note: `\dy` starts with `d`, so it is handled in `parse_d_family` via the
+/// `D_SUBCMDS` table.  This function handles remaining `y`-prefixed commands.
 fn parse_y_family(input: &str) -> ParsedMeta {
     if let Some(rest) = input.strip_prefix("yolo") {
         if rest.is_empty() || rest.starts_with(char::is_whitespace) {
@@ -1375,6 +1381,7 @@ static D_SUBCMDS: &[(&str, MetaCmd)] = &[
     ("dx", MetaCmd::ListExtensions),
     ("dd", MetaCmd::ListComments),
     ("dc", MetaCmd::ListConversions),
+    ("dy", MetaCmd::ListEventTriggers),
 ];
 
 /// Parse the `\d` family of commands.
@@ -1673,6 +1680,25 @@ mod tests {
     #[test]
     fn parse_deu_user_mappings() {
         assert_eq!(parse("\\deu").cmd, MetaCmd::ListUserMappings);
+    }
+
+    #[test]
+    fn parse_dy_event_triggers() {
+        assert_eq!(parse("\\dy").cmd, MetaCmd::ListEventTriggers);
+    }
+
+    #[test]
+    fn parse_dy_plus_modifier() {
+        let m = parse("\\dy+");
+        assert_eq!(m.cmd, MetaCmd::ListEventTriggers);
+        assert!(m.plus);
+    }
+
+    #[test]
+    fn parse_dy_with_pattern() {
+        let m = parse("\\dy my_trigger");
+        assert_eq!(m.cmd, MetaCmd::ListEventTriggers);
+        assert_eq!(m.pattern, Some("my_trigger".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `ListEventTriggers` variant to the `MetaCmd` enum in `metacmd.rs`
- Register `\dy` in the `D_SUBCMDS` greedy-match table so `\dy[+] [pattern]` is parsed correctly
- Implement `list_event_triggers()` in `describe.rs` — queries `pg_catalog.pg_event_trigger`, columns: Name, Event, Owner, Enabled, Function, Tags; verbose (`+`) adds Description via `obj_description`
- Add unit tests in both `metacmd.rs` (parse `\dy`, `\dy+`, `\dy pattern`) and `describe.rs` (SQL column presence, verbose Description, pattern filter)

## Test plan

- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy -- -D warnings` — clean (943 tests pass)
- [x] Unit tests for parser: `parse_dy_event_triggers`, `parse_dy_plus_modifier`, `parse_dy_with_pattern`
- [x] Unit tests for SQL generation: `list_event_triggers_sql_has_required_columns`, `list_event_triggers_plus_sql_has_description_column`, `list_event_triggers_pattern_filter_applied`

Closes #155