### PR TITLE
fix(describe): \dm+ access method and size (#159)

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -2658,7 +2658,7 @@ order by 1, 2";
     /// Regression test for bug #159: `\dm+` was missing the Access method
     /// column and reported "0 bytes" because matviews were incorrectly grouped
     /// with views/sequences in the `is_view_or_seq` branch.  Matviews are
-    /// heap-stored and must use the default branch (pg_table_size + Access
+    /// heap-stored and must use the default branch (`pg_table_size` + Access
     /// method).
     #[test]
     fn matview_plus_sql_has_access_method_and_table_size() {


### PR DESCRIPTION
## Summary

- Remove `"m"` from the `is_view_or_seq` guard in `list_relations` so materialized views fall through to the default `\dt+`-style branch that includes the Access method column and uses `pg_table_size()` instead of `pg_relation_size()`
- Add `#[expect(dead_code)]` on the pre-existing unused `run_and_print` helper to fix a pre-existing clippy error that blocked CI
- Add regression test `matview_plus_sql_has_access_method_and_table_size` verifying the correct columns and size function

Fixes #159

## Test plan

- [ ] `cargo test` passes (944 tests, 0 failures)
- [ ] `cargo clippy -- -D warnings` passes
- [ ] New test `describe::tests::matview_plus_sql_has_access_method_and_table_size` confirms Access method column is present and `pg_table_size` is used for `\dm+`