### PR TITLE
fix(repl): wire \do and \dy to describe dispatch (#175)

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -3743,6 +3743,7 @@ async fn dispatch_meta(
                     | MetaCmd::ListTablespaces
                     | MetaCmd::ListTypes
                     | MetaCmd::ListDomains
+                    | MetaCmd::ListEventTriggers
                     | MetaCmd::ListPrivileges
                     | MetaCmd::ListConversions
                     | MetaCmd::ListCasts
@@ -3750,6 +3751,7 @@ async fn dispatch_meta(
                     | MetaCmd::ListForeignServers
                     | MetaCmd::ListFdws
                     | MetaCmd::ListForeignTablesViaFdw
+                    | MetaCmd::ListOperators
                     | MetaCmd::ListUserMappings
             ) =>
         {


### PR DESCRIPTION
## Summary
- Add `MetaCmd::ListOperators` and `MetaCmd::ListEventTriggers` to the describe dispatch match arm in `repl.rs`
- These commands had implementations in `describe.rs` and parsing in `metacmd.rs` but were falling through to "not yet implemented" stub

Fixes #175

## Test plan
- [ ] `\do` shows "List of operators" with proper headers (even with 0 rows)
- [ ] `\dy` shows "List of event triggers" with proper headers (even with 0 rows)
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)