### PR TITLE
fix: config file not found on macOS (~/.config/ vs ~/Library/)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -327,7 +327,28 @@ pub fn load_config() -> (Config, Vec<String>) {
 /// Return the path to the user config file, or `None` if the config
 /// directory cannot be determined.
 fn user_config_path() -> Option<PathBuf> {
+    // Check XDG-style path first (~/.config/samo/config.toml) since that's
+    // what our docs and error messages reference.  On macOS `dirs::config_dir`
+    // returns ~/Library/Application Support/ which is unexpected for CLI
+    // tools, so we prefer the XDG path when it exists.
+    if let Some(home) = dirs::home_dir() {
+        let xdg_path = home.join(".config").join("samo").join("config.toml");
+        if xdg_path.exists() {
+            return Some(xdg_path);
+        }
+    }
+    // Fall back to the platform-native config dir.
     dirs::config_dir().map(|d| d.join("samo").join("config.toml"))
+}
+
+/// Return a human-readable path string for the user config file (for error
+/// messages).  Prefers `~/.config/samo/config.toml` since that's cross-platform.
+pub fn user_config_path_display() -> String {
+    if let Some(home) = dirs::home_dir() {
+        format!("{}/.config/samo/config.toml", home.display())
+    } else {
+        "~/.config/samo/config.toml".to_owned()
+    }
 }
 
 /// Read and parse a single TOML config file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -605,8 +605,8 @@ async fn main() {
         } else {
             eprintln!("samo: unknown profile \"@{name}\"");
             eprintln!(
-                "Configure profiles in ~/.config/samo/config.toml \
-                 under [connections.{name}]"
+                "Configure profiles in {} under [connections.{name}]",
+                config::user_config_path_display()
             );
             std::process::exit(2);
         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -3894,9 +3894,8 @@ async fn dispatch_meta(
                     } else {
                         eprintln!("\\c: unknown profile \"@{name}\"");
                         eprintln!(
-                            "Configure profiles in \
-                             ~/.config/samo/config.toml \
-                             under [connections.{name}]"
+                            "Configure profiles in {} under [connections.{name}]",
+                            crate::config::user_config_path_display()
                         );
                         return MetaResult::Continue;
                     }
@@ -5522,8 +5521,8 @@ async fn handle_ai_ask(
 
     if provider_name.is_empty() {
         eprintln!(
-            "AI not configured. \
-             Add an [ai] section to ~/.config/samo/config.toml"
+            "AI not configured. Add an [ai] section to {}",
+            crate::config::user_config_path_display()
         );
         eprintln!("Supported providers: anthropic, openai, ollama");
         eprintln!("Example:");
@@ -5753,8 +5752,8 @@ async fn handle_ai_plan(
 
     if provider_name.is_empty() {
         eprintln!(
-            "AI not configured. \
-             Add an [ai] section to ~/.config/samo/config.toml"
+            "AI not configured. Add an [ai] section to {}",
+            crate::config::user_config_path_display()
         );
         return;
     }
@@ -5885,8 +5884,8 @@ async fn handle_ai_fix(client: &Client, settings: &mut ReplSettings, params: &Co
 
     if provider_name.is_empty() {
         eprintln!(
-            "AI not configured. \
-             Add an [ai] section to ~/.config/samo/config.toml"
+            "AI not configured. Add an [ai] section to {}",
+            crate::config::user_config_path_display()
         );
         eprintln!("Supported providers: anthropic, openai, ollama");
         eprintln!("Example:");
@@ -6286,7 +6285,8 @@ async fn handle_ai_optimize(
     if provider_name.is_empty() {
         eprintln!(
             "\nAI not configured — showing raw plan only. \
-             Add an [ai] section to ~/.config/samo/config.toml for optimization suggestions."
+             Add an [ai] section to {} for optimization suggestions.",
+            crate::config::user_config_path_display()
         );
         return;
     }
@@ -6374,8 +6374,8 @@ async fn handle_ai_describe(
     let provider_name = settings.config.ai.provider.as_deref().unwrap_or("");
     if provider_name.is_empty() {
         eprintln!(
-            "AI not configured. \
-             Add an [ai] section to ~/.config/samo/config.toml"
+            "AI not configured. Add an [ai] section to {}",
+            crate::config::user_config_path_display()
         );
         return;
     }


### PR DESCRIPTION
**Bug:** On macOS, `dirs::config_dir()` returns `~/Library/Application Support/`, not `~/.config/`. When users follow our error message and put their config at `~/.config/samo/config.toml`, Samo doesn't find it. This causes `AI not configured` even when the config exists.

**Fix:** Check `~/.config/samo/config.toml` first (XDG-style, cross-platform), fall back to platform-native dir. Also adds `user_config_path_display()` helper for future error message improvements.

**Reproducer:**
```bash
# On macOS:
mkdir -p ~/.config/samo
cat > ~/.config/samo/config.toml << EOF
[ai]
provider = "openai"
api_key_env = "OPENAI_API_KEY"
EOF
export OPENAI_API_KEY="sk-test"
samo postgres
/ask hello
# Before fix: AI not configured
# After fix: works (or proper API error)
```