### PR TITLE
fix(describe): \dC match psql cast list format (#174)

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -1266,38 +1266,67 @@ order by 1, 3, 2"
 ///
 /// Matches psql's `\dC [pattern]` output: Source type, Target type,
 /// Function, Implicit?
+///
+/// The visibility filter (`pg_type_is_visible`) mirrors psql: only casts
+/// where the source **or** target type is visible in the current
+/// `search_path` are shown.  When a pattern is supplied it is matched
+/// against both `typname` and the formatted type name (`format_type()`),
+/// using the same `~` regex operator that psql uses.
 async fn list_casts(client: &Client, meta: &ParsedMeta) -> bool {
-    // Filter on source or target type name when a pattern is given.
-    let name_filter = pattern::where_clause(meta.pattern.as_deref(), "st.typname", None);
-
-    let where_clause = if name_filter.is_empty() {
-        String::new()
-    } else {
-        // Also match on target type name.
-        let target_filter = pattern::where_clause(meta.pattern.as_deref(), "tt.typname", None);
-        format!("where ({name_filter} or {target_filter})")
+    // Build the WHERE clause.  psql always applies a visibility filter; when
+    // a pattern is present it is also matched against type names via regex.
+    let where_clause = match meta.pattern.as_deref() {
+        None => {
+            // No pattern: show any cast where source or target is visible.
+            "where (
+    pg_catalog.pg_type_is_visible(ts.oid)
+    or pg_catalog.pg_type_is_visible(tt.oid)
+)"
+            .to_owned()
+        }
+        Some(pat) => {
+            // Pattern: match on typname OR format_type(), with visibility.
+            let re = pattern::to_regex(pat);
+            format!(
+                "where (
+    (ts.typname operator(pg_catalog.~) '{re}' collate pg_catalog.default
+        or pg_catalog.format_type(ts.oid, null) operator(pg_catalog.~) '{re}' collate pg_catalog.default)
+    and pg_catalog.pg_type_is_visible(ts.oid)
+)
+or (
+    (tt.typname operator(pg_catalog.~) '{re}' collate pg_catalog.default
+        or pg_catalog.format_type(tt.oid, null) operator(pg_catalog.~) '{re}' collate pg_catalog.default)
+    and pg_catalog.pg_type_is_visible(tt.oid)
+)"
+            )
+        }
     };
 
     let sql = format!(
         "select
     pg_catalog.format_type(c.castsource, null) as \"Source type\",
     pg_catalog.format_type(c.casttarget, null) as \"Target type\",
-    case when c.castfunc = 0 then '(binary coercible)'
-         else p.proname
+    case
+        when c.castmethod = 'b' then '(binary coercible)'
+        when c.castmethod = 'i' then '(with inout)'
+        else p.proname
     end as \"Function\",
-    case c.castcontext
-        when 'e' then 'no'
-        when 'a' then 'in assignment'
-        when 'i' then 'yes'
-        else c.castcontext::text
+    case
+        when c.castcontext = 'e' then 'no'
+        when c.castcontext = 'a' then 'in assignment'
+        else 'yes'
     end as \"Implicit?\"
 from pg_catalog.pg_cast as c
-left join pg_catalog.pg_type as st
-    on st.oid = c.castsource
-left join pg_catalog.pg_type as tt
-    on tt.oid = c.casttarget
 left join pg_catalog.pg_proc as p
-    on p.oid = c.castfunc
+    on c.castfunc = p.oid
+left join pg_catalog.pg_type as ts
+    on c.castsource = ts.oid
+left join pg_catalog.pg_namespace as ns
+    on ns.oid = ts.typnamespace
+left join pg_catalog.pg_type as tt
+    on c.casttarget = tt.oid
+left join pg_catalog.pg_namespace as nt
+    on nt.oid = tt.typnamespace
 {where_clause}
 order by 1, 2"
     );

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -128,6 +128,40 @@ pub fn where_clause(pattern: Option<&str>, column: &str, schema_column: Option<&
     }
 }
 
+/// Convert a psql-style pattern to a `PostgreSQL` regex string.
+///
+/// psql's `\dC` (and a few other commands) filter type names using the `~`
+/// regex operator rather than `LIKE`.  The conversion rules are:
+///
+/// - `*`  → `.*`   (any sequence of characters)
+/// - `?`  → `.`    (any single character)
+/// - All other characters are treated as literals and must be regex-escaped.
+///
+/// The returned string is wrapped in the `^(…)$` anchor that psql uses, and
+/// is ready to embed inside a single-quoted SQL string literal (single quotes
+/// inside the value are doubled).
+pub fn to_regex(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len() + 8);
+    out.push_str("^(");
+    for ch in pattern.chars() {
+        match ch {
+            // psql wildcards → regex equivalents
+            '*' => out.push_str(".*"),
+            '?' => out.push('.'),
+            // SQL single-quote escape
+            '\'' => out.push_str("''"),
+            // Escape regex metacharacters that are literals in psql patterns
+            '.' | '^' | '$' | '+' | '{' | '}' | '[' | ']' | '(' | ')' | '|' | '\\' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            other => out.push(other),
+        }
+    }
+    out.push_str(")$");
+    out
+}
+
 /// Build a single-column filter clause (helper for [`where_clause`]).
 fn build_name_clause(pattern: &str, column: &str) -> String {
     if pattern.is_empty() {
@@ -278,5 +312,38 @@ mod tests {
             where_clause(Some(".users"), "relname", Some("nspname")),
             "relname = 'users'"
         );
+    }
+
+    // -- to_regex --------------------------------------------------------------
+
+    #[test]
+    fn to_regex_plain_literal() {
+        assert_eq!(to_regex("integer"), "^(integer)$");
+    }
+
+    #[test]
+    fn to_regex_star_wildcard() {
+        assert_eq!(to_regex("int*"), "^(int.*)$");
+    }
+
+    #[test]
+    fn to_regex_question_wildcard() {
+        assert_eq!(to_regex("int?"), "^(int.)$");
+    }
+
+    #[test]
+    fn to_regex_escapes_dot() {
+        // A literal dot in the pattern must not act as a regex wildcard.
+        assert_eq!(to_regex("a.b"), "^(a\\.b)$");
+    }
+
+    #[test]
+    fn to_regex_escapes_single_quote() {
+        assert_eq!(to_regex("o'clock"), "^(o''clock)$");
+    }
+
+    #[test]
+    fn to_regex_escapes_regex_metacharacters() {
+        assert_eq!(to_regex("a(b)"), "^(a\\(b\\))$");
     }
 }


### PR DESCRIPTION
## Summary
- Fix `\dC` to match psql's cast list format

Fixes #174

## Test plan
- [ ] `\dC` output matches psql
- [ ] `cargo test` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)