### PR TITLE
fix(describe): \df+ hide function body in Internal name for SQL/plpgsql (#189)

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -581,7 +581,7 @@ async fn list_functions(client: &Client, meta: &ParsedMeta) -> bool {
     case when p.prosecdef then 'definer' else 'invoker' end as \"Security\",
     pg_catalog.array_to_string(p.proacl, E'\\n') as \"Access privileges\",
     l.lanname as \"Language\",
-    coalesce(p.prosrc, '') as \"Internal name\",
+    case when l.lanname in ('internal', 'c') then p.prosrc end as \"Internal name\",
     pg_catalog.obj_description(p.oid, 'pg_proc') as \"Description\"
 from pg_catalog.pg_proc as p
 left join pg_catalog.pg_namespace as n


### PR DESCRIPTION
## Summary
- Fix `\df+` Internal name column: show empty for SQL/plpgsql functions instead of the function body
- psql's `\df+` uses `prosrc` which for C functions is the C function name, but for SQL/plpgsql functions the body is stored differently (prosqlbody in PG14+)

Fixes #189

## Test plan
- [ ] `\df+` output matches psql (Internal name empty for SQL functions)
- [ ] `cargo test` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)