### PR TITLE
fix(describe): \do add Description, \db+ add verbose columns (#178, #188)

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -3126,8 +3126,7 @@ order by 1, 2, 3, 4";
     /// `pg_operator_is_visible`, matching psql's exact query.
     #[test]
     fn list_operators_system_filter_excludes_pg_catalog() {
-        let sys_filter =
-            "n.nspname <> 'pg_catalog'\n    and n.nspname <> 'information_schema'";
+        let sys_filter = "n.nspname <> 'pg_catalog'\n    and n.nspname <> 'information_schema'";
         let visibility_filter = "pg_catalog.pg_operator_is_visible(o.oid)";
         let where_clause = format!("where {sys_filter}\n    and {visibility_filter}");
 


### PR DESCRIPTION
## Summary
- Fix `\do` to include Description column in basic mode (matching psql)
- Fix `\db+` to include verbose columns: Access privileges, Options, Size, Description
- Does NOT change `\dx` or `\dx+` (complex psql behavior, deferred)

Fixes #188
Partially fixes #178 (\db+ fixed, \dx+ deferred)

## Test plan
- [ ] `\do` output matches psql (includes Description column)
- [ ] `\db+` output matches psql
- [ ] Basic `\dx` still passes compat test
- [ ] `cargo test` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)