### PR TITLE
fix: \password implementation to match psql (#198)

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -3439,12 +3439,11 @@ async fn dispatch_password(user: Option<&str>, client: &Client) {
                         None
                     }
                 });
-                match name {
-                    Some(n) => n,
-                    None => {
-                        eprintln!("\\password: could not determine current user");
-                        return;
-                    }
+                if let Some(n) = name {
+                    n
+                } else {
+                    eprintln!("\\password: could not determine current user");
+                    return;
                 }
             }
             Err(e) => {


### PR DESCRIPTION
## Summary

- **Prompt text**: always `Enter new password for user "<user>": ` (psql style); when no argument is given, resolve the current role via `select current_user` instead of using an empty prompt
- **Confirmation prompt**: changed from `Confirm new password: ` to `Enter it again: ` (exact psql text)
- **Mismatch error**: changed from `\password: passwords do not match` to `Passwords didn't match.` (exact psql text, no prefix)
- **Wired to server**: actually executes `alter user "<ident>" password '<escaped>'` via `simple_query`; username escaped as SQL identifier, password escaped as SQL string literal to prevent injection
- **Async**: `dispatch_password` is now `async` and receives `&Client`

## Known gap (documented in code)

psql calls `PQencryptPasswordConn` to hash the password client-side before sending, so cleartext never appears in server logs or `pg_stat_activity`. We send cleartext and let the server hash it per `password_encryption`. This is noted in the function doc-comment as future work.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — clean  
- [x] `cargo test` — 971 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)