### PR TITLE
test(compat): add conditional and \gset compat tests

### DIFF
--- a/tests/compat/test-compat.sh
+++ b/tests/compat/test-compat.sh
@@ -372,6 +372,30 @@ compare "\\copyright" \
   "\\copyright"
 
 # ---------------------------------------------------------------------------
+# Conditional execution (\if / \else / \endif)
+# ---------------------------------------------------------------------------
+
+compare "if true branch" \
+  "\\if true
+select 'yes' as result;
+\\endif"
+
+compare "if false with else" \
+  "\\if false
+select 'wrong' as result;
+\\else
+select 'right' as result;
+\\endif"
+
+# ---------------------------------------------------------------------------
+# Query execution variants
+# ---------------------------------------------------------------------------
+
+compare_flags "gset and reuse" \
+  -c "select 42 as myval \\gset
+select :myval as result;"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `\if` / `\else` / `\endif` conditional execution tests (true branch and false-with-else branch)
- Add `\gset` + variable reuse test via `compare_flags`

## Test plan

- [ ] Both new sections placed before the Summary section
- [ ] `compare` used for `\if` multi-line commands
- [ ] `compare_flags` used for `\gset` (passed via `-c`)
- [ ] No `\gx` test added (formatting differences)
- [ ] Existing tests unmodified

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)