### PR TITLE
fix: remove trailing record separator in unaligned output

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -655,13 +655,18 @@ pub fn format_unaligned(out: &mut String, rs: &RowSet, cfg: &PsetConfig) {
         out.push_str(&cfg.record_sep);
     }
 
-    for row in rows {
+    for (i, row) in rows.iter().enumerate() {
+        if i > 0 {
+            out.push_str(&cfg.record_sep);
+        }
         let cells: Vec<String> = row
             .iter()
             .map(|v| v.as_deref().unwrap_or(&cfg.null_display).to_owned())
             .collect();
         out.push_str(&cells.join(&cfg.field_sep));
-        out.push_str(&cfg.record_sep);
+    }
+    if !rows.is_empty() {
+        out.push('\n');
     }
 
     if !cfg.tuples_only && cfg.footer {
@@ -1345,6 +1350,29 @@ mod tests {
         let mut out = String::new();
         format_unaligned(&mut out, &rs, &cfg);
         assert!(out.contains("[NULL]"), "null display: {out}");
+    }
+
+    /// Verify that a custom record separator is used between rows but not
+    /// appended after the last row — matching psql `-A -R '|' -t` behaviour.
+    #[test]
+    fn test_unaligned_no_trailing_record_sep() {
+        let rs = RowSet {
+            columns: vec![mk_col("n", false)],
+            rows: vec![
+                mk_row(&[Some("1")]),
+                mk_row(&[Some("2")]),
+                mk_row(&[Some("3")]),
+            ],
+        };
+        let cfg = PsetConfig {
+            record_sep: "|".to_owned(),
+            tuples_only: true,
+            ..Default::default()
+        };
+        let mut out = String::new();
+        format_unaligned(&mut out, &rs, &cfg);
+        // Rows separated by `|`, final row ends with `\n` only (no trailing `|`).
+        assert_eq!(out, "1|2|3\n", "no trailing record sep: {out:?}");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- In `format_unaligned()`, the `record_sep` was appended after every row including the last, producing a trailing separator (e.g. `1|2|3|` instead of `1|2|3`).
- Changed to use `record_sep` as a between-rows separator; the last row now ends with `\n` only, matching psql behaviour with `-A -R '|' -t`.
- Added `test_unaligned_no_trailing_record_sep` unit test to cover this case.

Closes #236

## Test plan

- [ ] `cargo clippy --all-targets -- -D warnings` passes with no warnings
- [ ] `cargo test` passes (997 tests, including new `test_unaligned_no_trailing_record_sep`)
- [ ] Manual check: `samo -A -R '|' -t -c "select 1, 2, 3"` now outputs `1|2|3` (no trailing `|`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)