### PR TITLE
feat(repl): add prompt format code interpolation

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -268,10 +268,7 @@ pub fn expand_prompt(template: &str, ctx: &PromptContext<'_>) -> String {
             }
             'm' => {
                 // Short host: everything before the first `.`.
-                let short = ctx
-                    .host
-                    .split_once('.')
-                    .map_or(ctx.host, |(left, _)| left);
+                let short = ctx.host.split_once('.').map_or(ctx.host, |(left, _)| left);
                 out.push_str(short);
             }
             '>' => {
@@ -7370,8 +7367,7 @@ mod tests {
             user: "alice".to_owned(),
             ..ConnParams::default()
         };
-        let result =
-            build_prompt_from_settings(&settings, &params, TxState::InTransaction, false);
+        let result = build_prompt_from_settings(&settings, &params, TxState::InTransaction, false);
         assert_eq!(result, "mydb=*> ");
     }
 


### PR DESCRIPTION
## Summary

- Add `PromptContext` struct and `expand_prompt()` function that evaluates psql-compatible format codes (`%/`, `%~`, `%n`, `%M`, `%m`, `%>`, `%#`, `%R`, `%x`, `%l`, `%p`, `%%`); unrecognised codes pass through verbatim
- Add `build_prompt_from_settings()` that reads PROMPT1/PROMPT2 from the variable store and calls `expand_prompt`, enabling `\set PROMPT1 ...` customisation
- Update interactive REPL loops (readline and dumb) to use `build_prompt_from_settings` instead of hardcoded logic
- Retain `build_prompt()` for backward compatibility with mode-tag tests
- Add 30 new unit tests covering all format codes, edge cases, and the settings-driven path

The default `%/%R%x%# ` produces identical output to the previous hardcoded prompt, preserving backward compatibility.

Closes #230

## Test plan

- [x] `cargo build` — clean (no warnings with `RUSTFLAGS="-D warnings"`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 1021 tests pass (0 failures)
- [ ] Manual: connect to Postgres, run `\set PROMPT1 '%n@%m/%> '` and verify the prompt changes
- [ ] Manual: verify default prompt (`%/%R%x%# `) produces `dbname=> ` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)