### PR TITLE
test(compat): uncomment record separator test

### DIFF
--- a/tests/compat/test-compat.sh
+++ b/tests/compat/test-compat.sh
@@ -323,9 +323,8 @@ compare_flags "unaligned csv from table" \
 compare_flags "unaligned with custom field separator" \
   -A -F '|' -c "select 1 as a, 2 as b, 3 as c"
 
-## trailing record separator bug (#236)
-# compare_flags "unaligned with custom record separator" \
-#   -A -R '|' -t -c "select generate_series(1,3) as n"
+compare_flags "unaligned with custom record separator" \
+  -A -R '|' -t -c "select generate_series(1,3) as n"
 
 # ---------------------------------------------------------------------------
 # Expanded display mode


### PR DESCRIPTION
Uncomments the record separator compat test now that the trailing separator bug is fixed (PR #237, closes #236).