### PR TITLE
feat(named): add named queries with parameter substitution

### DIFF
--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -270,6 +270,8 @@ pub enum MetaCmd {
     NamedList,
     /// `\nd name` — delete a named query.
     NamedDelete(String),
+    /// `\np name` — print (show) a named query without executing.
+    NamedPrint(String),
 
     // -- Input mode --------------------------------------------------------
     /// `\sql` — switch to SQL input mode.
@@ -1281,11 +1283,12 @@ fn parse_b_family(input: &str) -> ParsedMeta {
 // \n family parser — named queries (#69)
 // ---------------------------------------------------------------------------
 
-/// Parse `\ns name query`, `\nd name`, `\n+`, and `\n name [args...]`.
+/// Parse `\ns name query`, `\nd name`, `\np name`, `\n+`, and `\n name [args...]`.
 ///
 /// Disambiguation order (longest match first):
 ///   `ns` → [`MetaCmd::NamedSave`]
 ///   `nd` → [`MetaCmd::NamedDelete`]
+///   `np` → [`MetaCmd::NamedPrint`]
 ///   `n+` → [`MetaCmd::NamedList`]
 ///   `n`  → [`MetaCmd::NamedExec`]
 fn parse_n_family(input: &str) -> ParsedMeta {
@@ -1311,6 +1314,17 @@ fn parse_n_family(input: &str) -> ParsedMeta {
                 return ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()));
             }
             return ParsedMeta::simple(MetaCmd::NamedDelete(name));
+        }
+    }
+
+    // `\np name` — print a named query without executing.  Must come before bare `\n`.
+    if let Some(rest) = input.strip_prefix("np") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            let name = rest.trim().to_owned();
+            if name.is_empty() {
+                return ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()));
+            }
+            return ParsedMeta::simple(MetaCmd::NamedPrint(name));
         }
     }
 
@@ -2993,6 +3007,25 @@ mod tests {
     fn parse_named_delete_missing_name_is_unknown() {
         let m = parse("\\nd");
         assert!(matches!(m.cmd, MetaCmd::Unknown(_)));
+    }
+
+    #[test]
+    fn parse_named_print() {
+        let m = parse("\\np top_tables");
+        assert_eq!(m.cmd, MetaCmd::NamedPrint("top_tables".to_owned()));
+    }
+
+    #[test]
+    fn parse_named_print_missing_name_is_unknown() {
+        let m = parse("\\np");
+        assert!(matches!(m.cmd, MetaCmd::Unknown(_)));
+    }
+
+    #[test]
+    fn parse_named_print_np_not_confused_with_n() {
+        // `\np` must not be mistaken for `\n` with arg `p`.
+        let m = parse("\\np my_q");
+        assert!(matches!(m.cmd, MetaCmd::NamedPrint(_)));
     }
 
     // -- Input mode commands ---------------------------------------------------

--- a/src/named.rs
+++ b/src/named.rs
@@ -63,6 +63,14 @@ impl NamedQueries {
         &self.queries
     }
 
+    /// Return `true` if `name` is a valid named-query identifier.
+    ///
+    /// Valid names consist only of ASCII alphanumeric characters and
+    /// underscores, and must be non-empty.
+    pub fn is_valid_name(name: &str) -> bool {
+        !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    }
+
     /// Substitute positional parameters (`$1`, `$2`, …) in a query.
     ///
     /// Parameters are replaced in order: `$1` → `args[0]`, `$2` → `args[1]`,
@@ -154,5 +162,72 @@ mod tests {
         // $3 left as-is when only 2 args provided
         let result = NamedQueries::substitute("$1 $2 $3", &["a", "b"]);
         assert_eq!(result, "a b $3");
+    }
+
+    // -- is_valid_name -------------------------------------------------------
+
+    #[test]
+    fn test_valid_name_alphanumeric() {
+        assert!(NamedQueries::is_valid_name("top_tables"));
+        assert!(NamedQueries::is_valid_name("query1"));
+        assert!(NamedQueries::is_valid_name("a"));
+    }
+
+    #[test]
+    fn test_valid_name_empty_rejected() {
+        assert!(!NamedQueries::is_valid_name(""));
+    }
+
+    #[test]
+    fn test_valid_name_hyphen_rejected() {
+        assert!(!NamedQueries::is_valid_name("my-query"));
+    }
+
+    #[test]
+    fn test_valid_name_space_rejected() {
+        assert!(!NamedQueries::is_valid_name("my query"));
+    }
+
+    #[test]
+    fn test_valid_name_dot_rejected() {
+        assert!(!NamedQueries::is_valid_name("my.query"));
+    }
+
+    // -- TOML round-trip -----------------------------------------------------
+
+    #[test]
+    fn test_toml_round_trip() {
+        let mut nq = NamedQueries::default();
+        nq.set(
+            "active",
+            "select * from pg_stat_activity where state = 'active'",
+        );
+        nq.set(
+            "top_tables",
+            "select * from pg_stat_user_tables order by $1 desc limit $2",
+        );
+
+        let serialized = toml::to_string_pretty(&nq).expect("serialization failed");
+        let deserialized: NamedQueries =
+            toml::from_str(&serialized).expect("deserialization failed");
+
+        assert_eq!(
+            deserialized.get("active"),
+            Some("select * from pg_stat_activity where state = 'active'")
+        );
+        assert_eq!(
+            deserialized.get("top_tables"),
+            Some("select * from pg_stat_user_tables order by $1 desc limit $2")
+        );
+        assert_eq!(deserialized.list().len(), 2);
+    }
+
+    #[test]
+    fn test_toml_empty_round_trip() {
+        let nq = NamedQueries::default();
+        let serialized = toml::to_string_pretty(&nq).expect("serialization failed");
+        let deserialized: NamedQueries =
+            toml::from_str(&serialized).expect("deserialization failed");
+        assert!(deserialized.list().is_empty());
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -2668,6 +2668,13 @@ AI commands:
   /compact [focus]  compact conversation context (optional focus topic)
   /budget           show token usage and remaining budget
 
+Named queries:
+  \ns <name> <query>  save a named query (name: alphanumerics + underscores)
+  \n  <name> [args…]  execute a named query; $1,$2,… replaced by args
+  \n+                 list all named queries with their SQL
+  \nd <name>          delete a named query
+  \np <name>          print a named query without executing
+
 Input/execution modes:
   \sql              switch to SQL input mode (default)
   \text2sql / \t2s  switch to text2sql input mode
@@ -4112,15 +4119,22 @@ async fn dispatch_meta(
         }
         // Named queries (#69).
         MetaCmd::NamedSave(ref name, ref query) => {
-            let mut nq = crate::named::NamedQueries::load();
-            nq.set(name, query);
-            match nq.save() {
-                Ok(()) => {
-                    if !settings.quiet {
-                        eprintln!("Saved query \"{name}\".");
+            if crate::named::NamedQueries::is_valid_name(name) {
+                let mut nq = crate::named::NamedQueries::load();
+                nq.set(name, query);
+                match nq.save() {
+                    Ok(()) => {
+                        if !settings.quiet {
+                            eprintln!("Saved query \"{name}\".");
+                        }
                     }
+                    Err(e) => eprintln!("\\ns: {e}"),
                 }
-                Err(e) => eprintln!("\\ns: {e}"),
+            } else {
+                eprintln!(
+                    "\\ns: invalid query name \"{name}\": \
+                     names must contain only alphanumerics and underscores"
+                );
             }
         }
         MetaCmd::NamedExec(ref name, ref args) => {
@@ -4158,6 +4172,13 @@ async fn dispatch_meta(
                 }
             } else {
                 eprintln!("\\nd: unknown query \"{name}\"");
+            }
+        }
+        MetaCmd::NamedPrint(ref name) => {
+            let nq = crate::named::NamedQueries::load();
+            match nq.get(name) {
+                Some(query) => println!("{query}"),
+                None => eprintln!("\\np: unknown query \"{name}\""),
             }
         }
         // Describe-family commands — delegate to the describe module.


### PR DESCRIPTION
## Summary

- Add `\np name` command to print a named query without executing it
- Add `NamedQueries::is_valid_name()` to validate query names (alphanumerics + underscores only)
- Apply name validation in `\ns` dispatch handler, rejecting invalid names with a clear error
- Add `NamedPrint(String)` variant to `MetaCmd` and parsing in `parse_n_family`
- Add unit tests for `is_valid_name`, TOML round-trip serialization/deserialization, and `\np` parsing
- Update `\?` help text with a Named queries section covering all five commands

The full set of named query commands is now implemented:
- `\ns name query` — save a named query
- `\n name [args…]` — execute with `$1`/`$2` parameter substitution
- `\n+` — list all saved queries
- `\nd name` — delete a named query
- `\np name` — print query SQL without executing

Storage: `~/.config/samo/named_queries.toml`

## Test plan

- [ ] `cargo test` passes (1085 tests, 10 new)
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] `\ns foo "select 1"` saves and prints "Saved query"
- [ ] `\n foo` executes the query
- [ ] `\np foo` prints the SQL without executing
- [ ] `\nd foo` deletes; `\nd foo` again prints "unknown query"
- [ ] `\n+` lists saved queries
- [ ] `\ns "bad-name" ...` prints "invalid query name" error
- [ ] Named queries with `$1 $2` parameters substitute correctly

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)