### PR TITLE
feat(pager): support external pager and pager_min_lines setting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -478,6 +478,13 @@ fn build_settings(cli: &Cli, cfg: &config::Config) -> repl::ReplSettings {
     let pager_enabled = cfg.display.pager;
     let timing = cfg.display.timing;
 
+    // Initialise pager_command from the PAGER environment variable.
+    // A non-empty PAGER that is not "on"/"off" sets an external pager.
+    // An empty or absent PAGER leaves the built-in pager as default.
+    let pager_command = std::env::var("PAGER")
+        .ok()
+        .filter(|v| !v.is_empty() && v != "on" && v != "off");
+
     // Keep ReplSettings.expanded in sync with pset.expanded so that both the
     // REPL path and the -c path see a consistent expanded mode.
     let expanded = pset.expanded;
@@ -498,6 +505,7 @@ fn build_settings(cli: &Cli, cfg: &config::Config) -> repl::ReplSettings {
         debug: cli.debug,
         no_highlight,
         pager_enabled,
+        pager_command,
         timing,
         config: cfg.clone(),
         exec_mode: if cli.yolo {

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -19,7 +19,8 @@
 //! horizontal scrolling. A `│` separator is drawn between frozen and
 //! scrollable columns. The status bar shows "Frozen: N" when N > 0.
 
-use std::io;
+use std::io::{self, Write};
+use std::process::{Command, Stdio};
 
 use crossterm::{
     event::{self, Event, KeyCode, KeyModifiers},
@@ -68,6 +69,30 @@ pub fn run_pager(content: &str) -> io::Result<()> {
     let _ = execute!(io::stdout(), LeaveAlternateScreen);
 
     result
+}
+
+/// Pipe `content` to an external pager command.
+///
+/// Spawns `cmd` as a child process, writes all of `content` to its stdin,
+/// drops stdin (signalling EOF), and waits for the child to exit.
+///
+/// Returns `Ok(())` if the child was spawned and exited (any exit code is
+/// treated as success from the caller's perspective — the pager ran).
+/// Returns an `Err` if the child could not be spawned.
+pub fn run_pager_external(cmd: &str, content: &str) -> io::Result<()> {
+    let mut child = Command::new("sh")
+        .args(["-c", cmd])
+        .stdin(Stdio::piped())
+        .spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        // Best-effort write; ignore partial-write errors (e.g. the user
+        // quit the pager before reading all output).
+        let _ = stdin.write_all(content.as_bytes());
+    }
+
+    child.wait()?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -740,6 +765,25 @@ pub fn needs_paging(content: &str, rows: usize) -> bool {
     content.lines().count() > rows
 }
 
+/// Check whether `content` needs paging, also honouring a `min_lines`
+/// threshold.
+///
+/// Returns `true` only when **both** conditions hold:
+/// - The content exceeds the terminal height (`rows`).
+/// - The content line count exceeds `min_lines` (when `min_lines > 0`).
+///
+/// When `min_lines` is 0 the threshold is disabled and the result is
+/// identical to [`needs_paging`].
+pub fn needs_paging_with_min(content: &str, rows: usize, min_lines: usize) -> bool {
+    if !needs_paging(content, rows) {
+        return false;
+    }
+    if min_lines > 0 && content.lines().count() <= min_lines {
+        return false;
+    }
+    true
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -748,7 +792,7 @@ pub fn needs_paging(content: &str, rows: usize) -> bool {
 mod tests {
     use super::{
         detect_col_boundaries, find_matches, first_match_from, is_divider_line, last_match_before,
-        needs_paging,
+        needs_paging, needs_paging_with_min,
     };
 
     // --- needs_paging ---
@@ -985,5 +1029,49 @@ mod tests {
             .collect();
         assert_eq!(boundaries, expected);
         assert_eq!(boundaries.len(), 2);
+    }
+
+    // --- needs_paging_with_min ---
+
+    #[test]
+    fn test_needs_paging_with_min_zero_disabled() {
+        // min_lines = 0 → same as needs_paging.
+        let content = "line1\nline2\nline3\nline4";
+        assert!(needs_paging_with_min(content, 3, 0));
+    }
+
+    #[test]
+    fn test_needs_paging_with_min_fits_in_terminal() {
+        // Content fits in terminal → no paging even with large min_lines.
+        let content = "line1\nline2\nline3";
+        assert!(!needs_paging_with_min(content, 24, 0));
+    }
+
+    #[test]
+    fn test_needs_paging_with_min_exceeds_terminal_below_min() {
+        // 4 lines, terminal = 3, but min_lines = 10 → no paging.
+        let content = "line1\nline2\nline3\nline4";
+        assert!(!needs_paging_with_min(content, 3, 10));
+    }
+
+    #[test]
+    fn test_needs_paging_with_min_exceeds_both() {
+        // 10 lines, terminal = 3, min_lines = 5 → needs paging.
+        let content = "1\n2\n3\n4\n5\n6\n7\n8\n9\n10";
+        assert!(needs_paging_with_min(content, 3, 5));
+    }
+
+    #[test]
+    fn test_needs_paging_with_min_exact_min() {
+        // 5 lines, terminal = 3, min_lines = 5 → 5 <= 5, so no paging.
+        let content = "1\n2\n3\n4\n5";
+        assert!(!needs_paging_with_min(content, 3, 5));
+    }
+
+    #[test]
+    fn test_needs_paging_with_min_just_above_min() {
+        // 6 lines, terminal = 3, min_lines = 5 → paging activated.
+        let content = "1\n2\n3\n4\n5\n6";
+        assert!(needs_paging_with_min(content, 3, 5));
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -911,6 +911,21 @@ pub struct ReplSettings {
     /// `PAGER` environment variable to an external pager command.
     /// Only activates in interactive mode (not with `-c`, `-f`, or piped input).
     pub pager_enabled: bool,
+    /// External pager command to run instead of the built-in TUI pager.
+    ///
+    /// `None` uses the built-in pager.  `Some(cmd)` spawns `cmd` via a shell
+    /// and pipes output to its stdin.
+    ///
+    /// Set by `\set PAGER <cmd>` when `<cmd>` is not `on`/`off`, or
+    /// initialised from the `PAGER` environment variable at startup.
+    pub pager_command: Option<String>,
+    /// Minimum number of result lines before the pager activates.
+    ///
+    /// When `> 0`, the pager only activates if the output exceeds *both*
+    /// the terminal height *and* this threshold.  Defaults to `0` (disabled).
+    ///
+    /// Set by `\pset pager_min_lines N`.
+    pub pager_min_lines: usize,
     /// Warn before executing destructive statements (DROP, TRUNCATE, etc.).
     ///
     /// Defaults to `true`. Disable with `\set DESTRUCTIVE_WARNING off`.
@@ -1009,6 +1024,8 @@ impl std::fmt::Debug for ReplSettings {
             )
             .field("no_highlight", &self.no_highlight)
             .field("pager_enabled", &self.pager_enabled)
+            .field("pager_command", &self.pager_command)
+            .field("pager_min_lines", &self.pager_min_lines)
             .field("destructive_warning", &self.destructive_warning)
             .field("safety_enabled", &self.safety_enabled)
             .field("config_profiles", &self.config.connections.len())
@@ -1061,6 +1078,8 @@ impl Default for ReplSettings {
             no_highlight: false,
             // Pager is enabled by default in interactive mode.
             pager_enabled: true,
+            pager_command: None,
+            pager_min_lines: 0,
             // Warn before destructive statements by default.
             destructive_warning: true,
             // Safety prompts enabled by default.
@@ -1868,12 +1887,12 @@ async fn execute_query_interactive(
         .map(|(_, h)| h as usize)
         .unwrap_or(24);
 
-    if crate::pager::needs_paging(&text, term_rows.saturating_sub(2)) {
-        if let Err(e) = crate::pager::run_pager(&text) {
-            eprintln!("samo: pager error: {e}");
-            // Fallback: print directly.
-            let _ = io::stdout().write_all(&captured);
-        }
+    if crate::pager::needs_paging_with_min(
+        &text,
+        term_rows.saturating_sub(2),
+        settings.pager_min_lines,
+    ) {
+        run_pager_for_text(settings, &text, &captured);
     } else {
         let _ = io::stdout().write_all(&captured);
     }
@@ -1914,16 +1933,34 @@ async fn execute_query_extended_interactive(
         .map(|(_, h)| h as usize)
         .unwrap_or(24);
 
-    if crate::pager::needs_paging(&text, term_rows.saturating_sub(2)) {
-        if let Err(e) = crate::pager::run_pager(&text) {
-            eprintln!("samo: pager error: {e}");
-            let _ = io::stdout().write_all(&captured);
-        }
+    if crate::pager::needs_paging_with_min(
+        &text,
+        term_rows.saturating_sub(2),
+        settings.pager_min_lines,
+    ) {
+        run_pager_for_text(settings, &text, &captured);
     } else {
         let _ = io::stdout().write_all(&captured);
     }
 
     ok
+}
+
+/// Activate the appropriate pager for `text`.
+///
+/// Uses the external pager command when `settings.pager_command` is set,
+/// falling back to the built-in TUI pager otherwise.  On any pager error,
+/// falls back to printing directly to stdout.
+fn run_pager_for_text(settings: &ReplSettings, text: &str, raw_bytes: &[u8]) {
+    if let Some(ref cmd) = settings.pager_command {
+        if let Err(e) = crate::pager::run_pager_external(cmd, text) {
+            eprintln!("samo: pager error: {e}");
+            let _ = io::stdout().write_all(raw_bytes);
+        }
+    } else if let Err(e) = crate::pager::run_pager(text) {
+        eprintln!("samo: pager error: {e}");
+        let _ = io::stdout().write_all(raw_bytes);
+    }
 }
 
 /// Execute `buf`, then execute each non-NULL result cell as a separate SQL
@@ -2864,9 +2901,22 @@ fn apply_set(settings: &mut ReplSettings, name: &str, value: &str) {
     if name == "HIGHLIGHT" {
         settings.no_highlight = value == "off";
     }
-    // Mirror PAGER on/off into the pager_enabled flag.
+    // Mirror PAGER into pager_enabled / pager_command.
     if name == "PAGER" {
-        settings.pager_enabled = value != "off";
+        match value {
+            "off" => {
+                settings.pager_enabled = false;
+                settings.pager_command = None;
+            }
+            "on" => {
+                settings.pager_enabled = true;
+                settings.pager_command = None;
+            }
+            cmd => {
+                settings.pager_enabled = true;
+                settings.pager_command = Some(cmd.to_owned());
+            }
+        }
     }
     // Mirror DESTRUCTIVE_WARNING on/off into the destructive_warning flag.
     if name == "DESTRUCTIVE_WARNING" {
@@ -3036,6 +3086,14 @@ fn apply_pset(settings: &mut ReplSettings, option: &str, value: Option<&str>) {
                 "Expanded display is {}.",
                 expanded_mode_str(settings.pset.expanded)
             );
+        }
+        "pager_min_lines" => {
+            if let Some(n) = value.and_then(|s| s.parse::<usize>().ok()) {
+                settings.pager_min_lines = n;
+                println!("Pager minimum lines is {n}.");
+            } else {
+                eprintln!("\\pset: invalid pager_min_lines value");
+            }
         }
         other => {
             eprintln!("\\pset: unknown option \"{other}\"");


### PR DESCRIPTION
## Summary

- Add `pager_command: Option<String>` to `ReplSettings`: when set, output is piped to the external command via `sh -c` instead of the built-in TUI pager. Falls back to direct stdout on spawn error.
- Add `pager_min_lines: usize` to `ReplSettings` (default `0`): pager only activates when output exceeds **both** terminal height and this threshold. When `0`, behaviour is unchanged.
- `\set PAGER off` disables paging; `\set PAGER on` re-enables the built-in pager; any other value (e.g. `less`, `less -S`) sets the external command.
- `\pset pager_min_lines N` sets the threshold live.
- `PAGER` environment variable is checked at startup: if non-empty and not `on`/`off`, it is used as the initial external pager command.

## Implementation notes

- `run_pager_external(cmd, content)` in `pager.rs`: spawns via `sh -c`, writes to child stdin, drops it, then `wait()`s.
- `needs_paging_with_min(content, rows, min_lines)` in `pager.rs`: delegates to `needs_paging` then applies the min-lines guard.
- A new private helper `run_pager_for_text` in `repl.rs` unifies the dispatch logic between built-in and external pager, eliminating duplication between the two interactive-mode functions.
- 6 new unit tests for `needs_paging_with_min`.

## Test plan

- [ ] `\set PAGER less` → subsequent query output piped to `less`
- [ ] `\set PAGER off` → pager disabled entirely
- [ ] `\set PAGER on` → back to built-in TUI pager
- [ ] `PAGER=less samo` at shell → starts with `less` as pager
- [ ] `\pset pager_min_lines 50` → pager only triggers for >50-line results even when they exceed terminal height
- [ ] `cargo test pager` passes all 27 tests

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)