### PR TITLE
fix(repl): use real settings in exec_command meta-dispatch

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -2349,14 +2349,43 @@ pub async fn exec_command(
         let interpolated = settings.vars.interpolate(sql.trim());
         let mut parsed = crate::metacmd::parse(&interpolated);
         parsed.echo_hidden = settings.echo_hidden;
-        let mut dummy_settings = ReplSettings {
-            echo_hidden: settings.echo_hidden,
-            db_capabilities: settings.db_capabilities.clone(),
-            config: settings.config.clone(),
-            ..Default::default()
-        };
         let mut tx = TxState::default();
-        dispatch_meta(parsed, client, params, &mut dummy_settings, &mut tx).await;
+        let result = dispatch_meta(parsed, client, params, settings, &mut tx).await;
+        // Handle results that produce output or modify settings.
+        match result {
+            MetaResult::ShowMode => {
+                let input_label = match settings.input_mode {
+                    InputMode::Sql => "sql",
+                    InputMode::Text2Sql => "text2sql",
+                };
+                let exec_label = match settings.exec_mode {
+                    ExecMode::Interactive => "interactive",
+                    ExecMode::Plan => "plan",
+                    ExecMode::Yolo => "yolo",
+                    ExecMode::Observe => "observe",
+                };
+                eprintln!("Input mode: {input_label}  Execution mode: {exec_label}");
+            }
+            MetaResult::SetInputMode(mode) => {
+                settings.input_mode = mode;
+                let label = match mode {
+                    InputMode::Sql => "sql",
+                    InputMode::Text2Sql => "text2sql",
+                };
+                eprintln!("Input mode: {label}");
+            }
+            MetaResult::SetExecMode(mode) => {
+                settings.exec_mode = mode;
+                let label = match mode {
+                    ExecMode::Interactive => "interactive",
+                    ExecMode::Plan => "plan",
+                    ExecMode::Yolo => "yolo",
+                    ExecMode::Observe => "observe",
+                };
+                eprintln!("Execution mode: {label}");
+            }
+            _ => {}
+        }
         return 0;
     }
     let mut tx = TxState::default();


### PR DESCRIPTION
## Summary

- `exec_command` (the `-c` flag handler) was creating a throw-away `dummy_settings` object for meta-command dispatch, causing `\mode` to silently produce no output and mode-switching commands (`\plan`, `\yolo`, `\sql`, `\text2sql`) to have no effect on subsequent `-c` commands in the same invocation.
- Fixed by passing the real `settings` pointer to `dispatch_meta` and handling `ShowMode`, `SetInputMode`, and `SetExecMode` results in `exec_command`.

## Bug details

Before this fix:
```
$ samo -c "\mode"
# (no output)

$ samo -c "\plan" -c "\mode"
# (no output — mode change silently discarded)
```

After this fix:
```
$ samo -c "\mode"
Input mode: sql  Execution mode: interactive

$ samo -c "\plan" -c "\mode"
Execution mode: plan
Input mode: sql  Execution mode: plan
```

## Test plan

- [x] Build passes (`cargo build --release`)
- [x] All 1110 unit tests pass (`cargo test`)
- [x] `\mode` in `-c` mode now prints current input and execution mode
- [x] `\plan` / `\yolo` / `\sql` / `\text2sql` now persist across multiple `-c` commands in the same invocation
- [x] All other meta-commands (`\dt`, `\di`, `\dv`, `\dn`, `\du`, `\df`, `\l`, `\dx`, `\ds`, `\dm`, `\d <table>`, `\sf`, `\sv`, `\?`, `\copyright`, `\conninfo`, `\dba *`, `\session list`) continue to work correctly
- [x] Full test matrix (connectivity, output formats, file execution, multi-statement, variable substitution, error handling, piped input) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)