### PR TITLE
refactor: code quality cleanup — dead code, dedup, docs

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -820,7 +820,7 @@ async fn connect_plain(
 
     tokio::spawn(async move {
         if let Err(e) = connection.await {
-            eprintln!("connection error: {e}");
+            eprintln!("samo: connection error: {e}");
         }
     });
 
@@ -842,7 +842,7 @@ async fn connect_tls(
 
     tokio::spawn(async move {
         if let Err(e) = connection.await {
-            eprintln!("connection error: {e}");
+            eprintln!("samo: connection error: {e}");
         }
     });
 

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -64,16 +64,10 @@ pub async fn execute(client: &Client, meta: &ParsedMeta, pg_major_version: Optio
 // Internal execution helper
 // ---------------------------------------------------------------------------
 
-/// Execute `sql` via `simple_query`, print an aligned table (with an optional
-/// centered title), and return `false` (never exits the REPL).
+/// Execute `sql` via `simple_query`, print an aligned table with an optional
+/// centered title, and return `false` (never exits the REPL).
 ///
 /// When `echo_hidden` is `true` the SQL is echoed to stderr first.
-#[allow(dead_code)]
-async fn run_and_print(client: &Client, sql: &str, echo_hidden: bool) -> bool {
-    run_and_print_titled(client, sql, echo_hidden, None).await
-}
-
-/// Like `run_and_print` but also prints a centered title above the table.
 async fn run_and_print_titled(
     client: &Client,
     sql: &str,

--- a/src/index_health.rs
+++ b/src/index_health.rs
@@ -14,6 +14,9 @@
 //! | Missing index | Heuristic | High seq_scan count on large tables |
 //! | Redundant index | Heuristic | Column prefix match |
 
+// Phase 3 infrastructure — consumers arrive in subsequent PRs.
+#![allow(dead_code)]
+
 use crate::governance::{EvidenceClass, Severity};
 
 use std::fmt::Write as _;

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -8,6 +8,9 @@
 //!
 //! Template-based issue content ensures consistent formatting.
 
+// Phase 3 infrastructure — consumers arrive in subsequent PRs.
+#![allow(dead_code)]
+
 use std::fmt::Write as _;
 
 use crate::governance::{ActionProposal, Severity};

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -136,7 +136,6 @@ pub fn error(component: &str, msg: &str) {
 }
 
 /// Log at `Warn` level.
-#[allow(dead_code)]
 pub fn warn(component: &str, msg: &str) {
     log(Level::Warn, component, msg);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,9 @@
 
 use clap::Parser;
 
+// Core modules.
 mod actor;
 mod ai;
-#[allow(dead_code)]
-mod anomaly;
 mod capabilities;
 mod complete;
 mod conditional;
@@ -21,30 +20,28 @@ mod dba;
 mod describe;
 mod governance;
 mod highlight;
-#[allow(dead_code)]
-mod index_health;
 mod io;
-#[allow(dead_code)]
-mod issues;
 mod logging;
 mod metacmd;
 mod named;
-#[allow(dead_code)]
 mod output;
 mod pager;
 mod pattern;
-#[allow(dead_code)]
 mod query;
 mod rca;
-#[allow(dead_code)]
-mod rca_actions;
 mod repl;
 mod safety;
 mod session;
 mod session_store;
 mod setup;
 mod vars;
-#[allow(dead_code)]
+
+// Phase 2/3 infrastructure — compiled but not yet wired into the main
+// dispatch loop. Each module suppresses dead_code at the item level.
+mod anomaly;
+mod index_health;
+mod issues;
+mod rca_actions;
 mod verification;
 
 /// Build-time git commit hash injected by `build.rs`.

--- a/src/output.rs
+++ b/src/output.rs
@@ -37,8 +37,12 @@ pub enum ExpandedMode {
 // ---------------------------------------------------------------------------
 
 /// Controls how query results are rendered.
+///
+/// Not yet wired to the REPL output path (issue #21); used by the
+/// `format_outcome` / `format_aligned` pipeline that is in progress.
 #[derive(Debug, Clone, Default)]
 #[allow(clippy::struct_excessive_bools)]
+#[allow(dead_code)]
 pub struct OutputConfig {
     /// String to display for SQL NULL values (psql default: empty string).
     pub null_string: String,
@@ -173,6 +177,8 @@ pub fn format_rowset_pset(out: &mut String, rs: &RowSet, cfg: &PsetConfig) {
 /// Format all results from a [`QueryOutcome`] into a single `String`.
 ///
 /// Each statement result is separated by a blank line (matching psql).
+/// Not yet called from the REPL dispatch path (issue #21).
+#[allow(dead_code)]
 pub fn format_outcome(outcome: &QueryOutcome, cfg: &OutputConfig) -> String {
     let mut out = String::new();
     let n = outcome.results.len();
@@ -220,6 +226,7 @@ pub fn format_outcome(outcome: &QueryOutcome, cfg: &OutputConfig) -> String {
 ///   1 | Alice | alice@example.com
 /// (1 row)
 /// ```
+#[allow(dead_code)]
 pub fn format_aligned(out: &mut String, rs: &RowSet, cfg: &OutputConfig) -> usize {
     let cols = &rs.columns;
     let rows = &rs.rows;
@@ -461,6 +468,7 @@ fn write_expanded_header(out: &mut String, record_num: usize, max_data_width: us
 /// UPDATE 2
 /// DELETE 1
 /// ```
+#[allow(dead_code)]
 pub fn format_command_tag(out: &mut String, ct: &CommandTag) {
     let _ = writeln!(out, "{}", ct.tag);
     // `ct.rows_affected` is available for callers that need the numeric count
@@ -573,6 +581,7 @@ fn write_error_position(out: &mut String, sql: &str, pos: &tokio_postgres::error
 // ---------------------------------------------------------------------------
 
 /// Format a [`Duration`] as `X.XXX ms`.
+#[allow(dead_code)]
 pub fn format_duration(d: Duration) -> String {
     let ms = d.as_secs_f64() * 1000.0;
     format!("{ms:.3} ms")

--- a/src/query.rs
+++ b/src/query.rs
@@ -37,6 +37,7 @@ pub enum QueryError {
 
 /// A single result set from one SQL statement.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum StatementResult {
     /// A query that returned rows (SELECT, TABLE, VALUES, RETURNING, …).
     Rows(RowSet),
@@ -70,6 +71,7 @@ pub struct ColumnMeta {
 
 /// The result of a non-SELECT statement.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct CommandTag {
     /// The command tag as returned by Postgres (e.g. `INSERT 0 3`).
     pub tag: String,
@@ -82,6 +84,7 @@ pub struct CommandTag {
 
 /// The outcome of executing one or more SQL statements.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct QueryOutcome {
     /// One entry per statement that was executed.
     pub results: Vec<StatementResult>,


### PR DESCRIPTION
## Summary

- **Dead code removal:** Removed stale `#[allow(dead_code)]` from `logging::warn` (actively used by daemon, governance, rca_actions) and removed the unused `run_and_print` wrapper in `describe.rs` (dead delegating function, eliminated entirely).
- **Better dead code annotation placement:** Phase 3 modules (`index_health`, `issues`) now carry `#![allow(dead_code)]` inside themselves, consistent with `actor`/`governance`/`rca` — removing module-level suppressions from `main.rs`. Similarly, `output.rs` and `query.rs` items not yet wired to the REPL (issues #20/#21) now have targeted `#[allow(dead_code)]` with brief doc comments explaining the pending work.
- **Module organisation:** `main.rs` module declarations split into a "Core modules" block and a "Phase 2/3 infrastructure" block with an explanatory comment, making it clear which modules are pending wiring.
- **Error message consistency:** Background-task connection errors now use the `"samo: "` prefix, consistent with all other error messages in the binary.

## Test plan

- [x] `cargo test` — 1110 unit tests pass, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings -W clippy::pedantic` — zero warnings
- [x] `cargo build` with `RUSTFLAGS="-D warnings"` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)