### PR TITLE
fix(repl): handle Ctrl-C like psql — cancel query or clear line, never exit

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -4559,6 +4559,7 @@ pub async fn run_repl(
 }
 
 /// Run with rustyline readline support.
+#[allow(clippy::too_many_lines)]
 async fn run_readline_loop(
     client: &mut Client,
     params: &mut ConnParams,
@@ -4612,10 +4613,42 @@ async fn run_readline_loop(
 
         match rl.readline(&prompt) {
             Ok(line) => {
-                // Ctrl-C on empty line: stay at prompt (readline already
-                // handles Ctrl-C during input by returning Interrupted).
+                // Obtain a cancel token *before* the query executes so that
+                // a concurrent Ctrl-C handler can send a CancelRequest to the
+                // server mid-query.
+                let cancel_token = client.cancel_token();
+
+                // Spawn a background task that listens for Ctrl-C while the
+                // current line (and any query it triggers) is being processed.
+                // When Ctrl-C arrives it sends a PostgreSQL CancelRequest so
+                // the server aborts the running query; the query future then
+                // resolves with an error and control returns to the prompt.
+                // A oneshot channel lets us tear down the task once the line
+                // has been handled without a spurious cancel on the next query.
+                let (cancel_done_tx, cancel_done_rx) = tokio::sync::oneshot::channel::<()>();
+                tokio::spawn(async move {
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => {
+                            // Best-effort: ignore send errors (connection may
+                            // have already closed or no query was running).
+                            let _ = cancel_token
+                                .cancel_query(tokio_postgres::NoTls)
+                                .await;
+                        }
+                        _ = cancel_done_rx => {
+                            // Line processing finished before Ctrl-C — nothing
+                            // to do.
+                        }
+                    }
+                });
+
                 let result =
                     handle_line(&line, &mut buf, &mut stmt_buf, client, params, settings, tx).await;
+
+                // Signal the cancel-guard task that we are done with this
+                // line; if Ctrl-C has not fired yet it can exit cleanly.
+                // Ignore the error — the task may have already completed.
+                let _ = cancel_done_tx.send(());
 
                 // If buf is empty a statement was completed — add the full
                 // accumulated statement text to history.
@@ -4646,12 +4679,14 @@ async fn run_readline_loop(
                 }
             }
             Err(ReadlineError::Interrupted) => {
-                // Ctrl-C: clear current buffer, back to prompt.
+                // Ctrl-C at idle prompt: psql prints a blank line and
+                // re-prompts.  Clear any partial multi-line buffer so the
+                // user gets a clean slate.
+                println!();
                 if !buf.is_empty() {
                     buf.clear();
                     stmt_buf.clear();
                 }
-                // On empty line Ctrl-C does nothing (just re-prompt).
             }
             Err(ReadlineError::Eof) => {
                 // Ctrl-D on empty line: exit cleanly.


### PR DESCRIPTION
## Summary

- **During query execution**: Ctrl-C now sends a PostgreSQL `CancelRequest` via `client.cancel_token().cancel_query(NoTls)`. The server aborts the running query and returns a `canceling statement due to user request` error; control returns to the prompt. Previously, the signal was not intercepted during execution.
- **At idle prompt**: Ctrl-C now prints a blank line (matching psql behavior) and clears any partial multi-line buffer, then re-prompts. Previously the blank line was missing.
- **Ctrl-C never exits samo** — only `\q`, `quit`, or Ctrl-D (EOF) exits. This was already true but is now more explicitly correct.

## Implementation

Per-line lifecycle: before calling `handle_line`, a `tokio::sync::oneshot` channel is created and a background task is spawned that races `tokio::signal::ctrl_c()` against a done signal. If Ctrl-C fires first, the task calls `cancel_token.cancel_query(tokio_postgres::NoTls)` (best-effort, errors ignored). When `handle_line` returns, the done signal is sent, tearing down the guard task cleanly and preventing a spurious cancel from reaching the next query.

## Test plan

- [ ] Run a long query (`select pg_sleep(30)`) and press Ctrl-C — query should be cancelled with `ERROR: canceling statement due to user request`, prompt returns
- [ ] At idle prompt with partial input (`select 1` without semicolon), press Ctrl-C — blank line printed, buffer cleared, fresh prompt
- [ ] At empty prompt, press Ctrl-C — blank line printed, fresh prompt, samo does not exit
- [ ] Ctrl-D at empty prompt — samo exits cleanly
- [ ] `cargo clippy` and `cargo fmt` pass with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)