### PR TITLE
fix(help): align \h SQL syntax help with psql output

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -303,111 +303,730 @@ fn build_view_def_sql(schema_filter: Option<&str>, view_name: &str) -> String {
 // \h — SQL help
 // ---------------------------------------------------------------------------
 
-/// Static help table: (`command_name`, synopsis).
+/// One entry in the SQL help table.
+struct SqlHelpEntry {
+    /// SQL command name (uppercase), e.g. `"SELECT"`.
+    name: &'static str,
+    /// Short description matching psql's output.
+    description: &'static str,
+    /// Full syntax synopsis — printed verbatim, no extra indentation.
+    synopsis: &'static str,
+    /// `PostgreSQL` documentation URL for the command.
+    url: &'static str,
+}
+
+/// Static help table sourced from `PostgreSQL` 18 `sql_help.h`.
 ///
-/// Kept intentionally terse — just enough to be useful at the prompt.
-static SQL_HELP: &[(&str, &str)] = &[
-    (
-        "SELECT",
-        "select [distinct] <expressions>\n\
-         from <table>\n\
-         [where <condition>]\n\
-         [group by <expressions>]\n\
-         [having <condition>]\n\
-         [order by <expressions> [asc|desc]]\n\
-         [limit <n>] [offset <n>];",
-    ),
-    (
-        "INSERT",
-        "insert into <table> [(<columns>)]\n\
-         values (<values>) [, ...];\n\
-         -- or --\n\
-         insert into <table> [(<columns>)] <select>;",
-    ),
-    (
-        "UPDATE",
-        "update <table>\n\
-         set <column> = <value> [, ...]\n\
-         [where <condition>];",
-    ),
-    (
-        "DELETE",
-        "delete from <table>\n\
-         [where <condition>];",
-    ),
-    (
-        "CREATE TABLE",
-        "create [temp] table [if not exists] <table> (\n\
-         <column> <type> [<constraints>] [, ...]\n\
-         [, table_constraint [, ...]]\n\
-         );",
-    ),
-    (
-        "CREATE INDEX",
-        "create [unique] index [concurrently] [<name>]\n\
-         on <table> [using <method>] (<column> [asc|desc] [, ...]);",
-    ),
-    (
-        "ALTER TABLE",
-        "alter table <table>\n\
-         <action> [, ...];\n\
-         -- actions: add column, drop column, alter column,\n\
-         --          add constraint, drop constraint, rename, …",
-    ),
-    (
-        "DROP TABLE",
-        "drop table [if exists] <table> [, ...]\n\
-         [cascade | restrict];",
-    ),
-    (
-        "BEGIN",
-        "begin [isolation level <level>];\n\
-         -- or: start transaction [isolation level <level>];",
-    ),
-    (
-        "COMMIT",
-        "commit;\n\
-         -- or: end;",
-    ),
-    (
-        "ROLLBACK",
-        "rollback;\n\
-         -- to a savepoint: rollback to [savepoint] <name>;",
-    ),
-    (
-        "GRANT",
-        "grant <privileges> on <object> to <role> [, ...];\n\
-         -- privileges: select, insert, update, delete, all, …",
-    ),
-    (
-        "REVOKE",
-        "revoke <privileges> on <object> from <role> [, ...];",
-    ),
-    ("EXPLAIN", "explain [analyze] [verbose] [buffers] <query>;"),
-    (
-        "VACUUM",
-        "vacuum [full] [analyze] [<table> [(<column> [, ...])]];",
-    ),
-    ("ANALYZE", "analyze [<table> [(<column> [, ...])]];"),
-    (
-        "COPY",
-        "copy <table> [(<columns>)] from {{stdin | '<file>'}}\n\
-         [with (format <fmt>, ...)];",
-    ),
-    (
-        "CREATE FUNCTION",
-        "create [or replace] function <name>(<args>)\n\
-         returns <type>\n\
-         language <lang>\n\
-         as $$\n\
-           <body>\n\
-         $$;",
-    ),
-    (
-        "CREATE VIEW",
-        "create [or replace] view <name> [(<columns>)] as\n\
-         <select>;",
-    ),
+/// Entries cover the most commonly used SQL commands.  The synopsis text
+/// matches psql's output exactly so that `diff`-based comparison tests pass.
+static SQL_HELP: &[SqlHelpEntry] = &[
+    SqlHelpEntry {
+        name: "SELECT",
+        description: "retrieve rows from a table or view",
+        synopsis: "[ WITH [ RECURSIVE ] with_query [, ...] ]\n\
+SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ] ]\n\
+    [ { * | expression [ [ AS ] output_name ] } [, ...] ]\n\
+    [ FROM from_item [, ...] ]\n\
+    [ WHERE condition ]\n\
+    [ GROUP BY [ ALL | DISTINCT ] grouping_element [, ...] ]\n\
+    [ HAVING condition ]\n\
+    [ WINDOW window_name AS ( window_definition ) [, ...] ]\n\
+    [ { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] select ]\n\
+    [ ORDER BY expression [ ASC | DESC | USING operator ] [ NULLS { FIRST | LAST } ] [, ...] ]\n\
+    [ LIMIT { count | ALL } ]\n\
+    [ OFFSET start [ ROW | ROWS ] ]\n\
+    [ FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } { ONLY | WITH TIES } ]\n\
+    [ FOR { UPDATE | NO KEY UPDATE | SHARE | KEY SHARE } [ OF from_reference [, ...] ] [ NOWAIT | SKIP LOCKED ] [...] ]\n\
+\n\
+where from_item can be one of:\n\
+\n\
+    [ ONLY ] table_name [ * ] [ [ AS ] alias [ ( column_alias [, ...] ) ] ]\n\
+                [ TABLESAMPLE sampling_method ( argument [, ...] ) [ REPEATABLE ( seed ) ] ]\n\
+    [ LATERAL ] ( select ) [ [ AS ] alias [ ( column_alias [, ...] ) ] ]\n\
+    with_query_name [ [ AS ] alias [ ( column_alias [, ...] ) ] ]\n\
+    [ LATERAL ] function_name ( [ argument [, ...] ] )\n\
+                [ WITH ORDINALITY ] [ [ AS ] alias [ ( column_alias [, ...] ) ] ]\n\
+    [ LATERAL ] function_name ( [ argument [, ...] ] ) [ AS ] alias ( column_definition [, ...] )\n\
+    [ LATERAL ] function_name ( [ argument [, ...] ] ) AS ( column_definition [, ...] )\n\
+    [ LATERAL ] ROWS FROM( function_name ( [ argument [, ...] ] ) [ AS ( column_definition [, ...] ) ] [, ...] )\n\
+                [ WITH ORDINALITY ] [ [ AS ] alias [ ( column_alias [, ...] ) ] ]\n\
+    from_item join_type from_item { ON join_condition | USING ( join_column [, ...] ) [ AS join_using_alias ] }\n\
+    from_item NATURAL join_type from_item\n\
+    from_item CROSS JOIN from_item\n\
+\n\
+and grouping_element can be one of:\n\
+\n\
+    ( )\n\
+    expression\n\
+    ( expression [, ...] )\n\
+    ROLLUP ( { expression | ( expression [, ...] ) } [, ...] )\n\
+    CUBE ( { expression | ( expression [, ...] ) } [, ...] )\n\
+    GROUPING SETS ( grouping_element [, ...] )\n\
+\n\
+and with_query is:\n\
+\n\
+    with_query_name [ ( column_name [, ...] ) ] AS [ [ NOT ] MATERIALIZED ] ( select | values | insert | update | delete | merge )\n\
+        [ SEARCH { BREADTH | DEPTH } FIRST BY column_name [, ...] SET search_seq_col_name ]\n\
+        [ CYCLE column_name [, ...] SET cycle_mark_col_name [ TO cycle_mark_value DEFAULT cycle_mark_default ] USING cycle_path_col_name ]\n\
+\n\
+TABLE [ ONLY ] table_name [ * ]",
+        url: "https://www.postgresql.org/docs/18/sql-select.html",
+    },
+    SqlHelpEntry {
+        name: "INSERT",
+        description: "create new rows in a table",
+        synopsis: "[ WITH [ RECURSIVE ] with_query [, ...] ]\n\
+INSERT INTO table_name [ AS alias ] [ ( column_name [, ...] ) ]\n\
+    [ OVERRIDING { SYSTEM | USER } VALUE ]\n\
+    { DEFAULT VALUES | VALUES ( { expression | DEFAULT } [, ...] ) [, ...] | query }\n\
+    [ ON CONFLICT [ conflict_target ] conflict_action ]\n\
+    [ RETURNING [ WITH ( { OLD | NEW } AS output_alias [, ...] ) ]\n\
+                { * | output_expression [ [ AS ] output_name ] } [, ...] ]\n\
+\n\
+where conflict_target can be one of:\n\
+\n\
+    ( { index_column_name | ( index_expression ) } [ COLLATE collation ] [ opclass ] [, ...] ) [ WHERE index_predicate ]\n\
+    ON CONSTRAINT constraint_name\n\
+\n\
+and conflict_action is one of:\n\
+\n\
+    DO NOTHING\n\
+    DO UPDATE SET { column_name = { expression | DEFAULT } |\n\
+                    ( column_name [, ...] ) = [ ROW ] ( { expression | DEFAULT } [, ...] ) |\n\
+                    ( column_name [, ...] ) = ( sub-SELECT )\n\
+                  } [, ...]\n\
+              [ WHERE condition ]",
+        url: "https://www.postgresql.org/docs/18/sql-insert.html",
+    },
+    SqlHelpEntry {
+        name: "UPDATE",
+        description: "update rows of a table",
+        synopsis: "[ WITH [ RECURSIVE ] with_query [, ...] ]\n\
+UPDATE [ ONLY ] table_name [ * ] [ [ AS ] alias ]\n\
+    SET { column_name = { expression | DEFAULT } |\n\
+          ( column_name [, ...] ) = [ ROW ] ( { expression | DEFAULT } [, ...] ) |\n\
+          ( column_name [, ...] ) = ( sub-SELECT )\n\
+        } [, ...]\n\
+    [ FROM from_item [, ...] ]\n\
+    [ WHERE condition | WHERE CURRENT OF cursor_name ]\n\
+    [ RETURNING [ WITH ( { OLD | NEW } AS output_alias [, ...] ) ]\n\
+                { * | output_expression [ [ AS ] output_name ] } [, ...] ]",
+        url: "https://www.postgresql.org/docs/18/sql-update.html",
+    },
+    SqlHelpEntry {
+        name: "DELETE",
+        description: "delete rows of a table",
+        synopsis: "[ WITH [ RECURSIVE ] with_query [, ...] ]\n\
+DELETE FROM [ ONLY ] table_name [ * ] [ [ AS ] alias ]\n\
+    [ USING from_item [, ...] ]\n\
+    [ WHERE condition | WHERE CURRENT OF cursor_name ]\n\
+    [ RETURNING [ WITH ( { OLD | NEW } AS output_alias [, ...] ) ]\n\
+                { * | output_expression [ [ AS ] output_name ] } [, ...] ]",
+        url: "https://www.postgresql.org/docs/18/sql-delete.html",
+    },
+    SqlHelpEntry {
+        name: "CREATE TABLE",
+        description: "define a new table",
+        synopsis: "CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXISTS ] table_name ( [\n\
+  { column_name data_type [ STORAGE { PLAIN | EXTERNAL | EXTENDED | MAIN | DEFAULT } ] [ COMPRESSION compression_method ] [ COLLATE collation ] [ column_constraint [ ... ] ]\n\
+    | table_constraint\n\
+    | LIKE source_table [ like_option ... ] }\n\
+    [, ... ]\n\
+] )\n\
+[ INHERITS ( parent_table [, ... ] ) ]\n\
+[ PARTITION BY { RANGE | LIST | HASH } ( { column_name | ( expression ) } [ COLLATE collation ] [ opclass ] [, ... ] ) ]\n\
+[ USING method ]\n\
+[ WITH ( storage_parameter [= value] [, ... ] ) | WITHOUT OIDS ]\n\
+[ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]\n\
+[ TABLESPACE tablespace_name ]\n\
+\n\
+CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXISTS ] table_name\n\
+    OF type_name [ (\n\
+  { column_name [ WITH OPTIONS ] [ column_constraint [ ... ] ]\n\
+    | table_constraint }\n\
+    [, ... ]\n\
+) ]\n\
+[ PARTITION BY { RANGE | LIST | HASH } ( { column_name | ( expression ) } [ COLLATE collation ] [ opclass ] [, ... ] ) ]\n\
+[ USING method ]\n\
+[ WITH ( storage_parameter [= value] [, ... ] ) | WITHOUT OIDS ]\n\
+[ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]\n\
+[ TABLESPACE tablespace_name ]\n\
+\n\
+CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXISTS ] table_name\n\
+    PARTITION OF parent_table [ (\n\
+  { column_name [ WITH OPTIONS ] [ column_constraint [ ... ] ]\n\
+    | table_constraint }\n\
+    [, ... ]\n\
+) ] { FOR VALUES partition_bound_spec | DEFAULT }\n\
+[ PARTITION BY { RANGE | LIST | HASH } ( { column_name | ( expression ) } [ COLLATE collation ] [ opclass ] [, ... ] ) ]\n\
+[ USING method ]\n\
+[ WITH ( storage_parameter [= value] [, ... ] ) | WITHOUT OIDS ]\n\
+[ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]\n\
+[ TABLESPACE tablespace_name ]\n\
+\n\
+where column_constraint is:\n\
+\n\
+[ CONSTRAINT constraint_name ]\n\
+{ NOT NULL [ NO INHERIT ]  |\n\
+  NULL |\n\
+  CHECK ( expression ) [ NO INHERIT ] |\n\
+  DEFAULT default_expr |\n\
+  GENERATED ALWAYS AS ( generation_expr ) [ STORED | VIRTUAL ] |\n\
+  GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( sequence_options ) ] |\n\
+  UNIQUE [ NULLS [ NOT ] DISTINCT ] index_parameters |\n\
+  PRIMARY KEY index_parameters |\n\
+  REFERENCES reftable [ ( refcolumn ) ] [ MATCH FULL | MATCH PARTIAL | MATCH SIMPLE ]\n\
+    [ ON DELETE referential_action ] [ ON UPDATE referential_action ] }\n\
+[ DEFERRABLE | NOT DEFERRABLE ] [ INITIALLY DEFERRED | INITIALLY IMMEDIATE ] [ ENFORCED | NOT ENFORCED ]\n\
+\n\
+and table_constraint is:\n\
+\n\
+[ CONSTRAINT constraint_name ]\n\
+{ CHECK ( expression ) [ NO INHERIT ] |\n\
+  NOT NULL column_name [ NO INHERIT ] |\n\
+  UNIQUE [ NULLS [ NOT ] DISTINCT ] ( column_name [, ... ] [, column_name WITHOUT OVERLAPS ] ) index_parameters |\n\
+  PRIMARY KEY ( column_name [, ... ] [, column_name WITHOUT OVERLAPS ] ) index_parameters |\n\
+  EXCLUDE [ USING index_method ] ( exclude_element WITH operator [, ... ] ) index_parameters [ WHERE ( predicate ) ] |\n\
+  FOREIGN KEY ( column_name [, ... ] [, PERIOD column_name ] ) REFERENCES reftable [ ( refcolumn [, ... ] [, PERIOD refcolumn ] ) ]\n\
+    [ MATCH FULL | MATCH PARTIAL | MATCH SIMPLE ] [ ON DELETE referential_action ] [ ON UPDATE referential_action ] }\n\
+[ DEFERRABLE | NOT DEFERRABLE ] [ INITIALLY DEFERRED | INITIALLY IMMEDIATE ] [ ENFORCED | NOT ENFORCED ]\n\
+\n\
+and like_option is:\n\
+\n\
+{ INCLUDING | EXCLUDING } { COMMENTS | COMPRESSION | CONSTRAINTS | DEFAULTS | GENERATED | IDENTITY | INDEXES | STATISTICS | STORAGE | ALL }\n\
+\n\
+and partition_bound_spec is:\n\
+\n\
+IN ( partition_bound_expr [, ...] ) |\n\
+FROM ( { partition_bound_expr | MINVALUE | MAXVALUE } [, ...] )\n\
+  TO ( { partition_bound_expr | MINVALUE | MAXVALUE } [, ...] ) |\n\
+WITH ( MODULUS numeric_literal, REMAINDER numeric_literal )\n\
+\n\
+index_parameters in UNIQUE, PRIMARY KEY, and EXCLUDE constraints are:\n\
+\n\
+[ INCLUDE ( column_name [, ... ] ) ]\n\
+[ WITH ( storage_parameter [= value] [, ... ] ) ]\n\
+[ USING INDEX TABLESPACE tablespace_name ]\n\
+\n\
+exclude_element in an EXCLUDE constraint is:\n\
+\n\
+{ column_name | ( expression ) } [ COLLATE collation ] [ opclass [ ( opclass_parameter = value [, ... ] ) ] ] [ ASC | DESC ] [ NULLS { FIRST | LAST } ]\n\
+\n\
+referential_action in a FOREIGN KEY/REFERENCES constraint is:\n\
+\n\
+{ NO ACTION | RESTRICT | CASCADE | SET NULL [ ( column_name [, ... ] ) ] | SET DEFAULT [ ( column_name [, ... ] ) ] }",
+        url: "https://www.postgresql.org/docs/18/sql-createtable.html",
+    },
+    SqlHelpEntry {
+        name: "CREATE INDEX",
+        description: "define a new index",
+        synopsis: "CREATE [ UNIQUE ] INDEX [ CONCURRENTLY ] [ [ IF NOT EXISTS ] name ] ON [ ONLY ] table_name [ USING method ]\n\
+    ( { column_name | ( expression ) } [ COLLATE collation ] [ opclass [ ( opclass_parameter = value [, ... ] ) ] ] [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] )\n\
+    [ INCLUDE ( column_name [, ...] ) ]\n\
+    [ NULLS [ NOT ] DISTINCT ]\n\
+    [ WITH ( storage_parameter [= value] [, ... ] ) ]\n\
+    [ TABLESPACE tablespace_name ]\n\
+    [ WHERE predicate ]",
+        url: "https://www.postgresql.org/docs/18/sql-createindex.html",
+    },
+    SqlHelpEntry {
+        name: "ALTER TABLE",
+        description: "change the definition of a table",
+        synopsis: "ALTER TABLE [ IF EXISTS ] [ ONLY ] name [ * ]\n\
+    action [, ... ]\n\
+ALTER TABLE [ IF EXISTS ] [ ONLY ] name [ * ]\n\
+    RENAME [ COLUMN ] column_name TO new_column_name\n\
+ALTER TABLE [ IF EXISTS ] [ ONLY ] name [ * ]\n\
+    RENAME CONSTRAINT constraint_name TO new_constraint_name\n\
+ALTER TABLE [ IF EXISTS ] name\n\
+    RENAME TO new_name\n\
+ALTER TABLE [ IF EXISTS ] name\n\
+    SET SCHEMA new_schema\n\
+ALTER TABLE ALL IN TABLESPACE name [ OWNED BY role_name [, ... ] ]\n\
+    SET TABLESPACE new_tablespace [ NOWAIT ]\n\
+ALTER TABLE [ IF EXISTS ] name\n\
+    ATTACH PARTITION partition_name { FOR VALUES partition_bound_spec | DEFAULT }\n\
+ALTER TABLE [ IF EXISTS ] name\n\
+    DETACH PARTITION partition_name [ CONCURRENTLY | FINALIZE ]\n\
+\n\
+where action is one of:\n\
+\n\
+    ADD [ COLUMN ] [ IF NOT EXISTS ] column_name data_type [ COLLATE collation ] [ column_constraint [ ... ] ]\n\
+    DROP [ COLUMN ] [ IF EXISTS ] column_name [ RESTRICT | CASCADE ]\n\
+    ALTER [ COLUMN ] column_name [ SET DATA ] TYPE data_type [ COLLATE collation ] [ USING expression ]\n\
+    ALTER [ COLUMN ] column_name SET DEFAULT expression\n\
+    ALTER [ COLUMN ] column_name DROP DEFAULT\n\
+    ALTER [ COLUMN ] column_name { SET | DROP } NOT NULL\n\
+    ALTER [ COLUMN ] column_name SET EXPRESSION AS ( expression )\n\
+    ALTER [ COLUMN ] column_name DROP EXPRESSION [ IF EXISTS ]\n\
+    ALTER [ COLUMN ] column_name ADD GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( sequence_options ) ]\n\
+    ALTER [ COLUMN ] column_name { SET GENERATED { ALWAYS | BY DEFAULT } | SET sequence_option | RESTART [ [ WITH ] restart ] } [...]\n\
+    ALTER [ COLUMN ] column_name DROP IDENTITY [ IF EXISTS ]\n\
+    ALTER [ COLUMN ] column_name SET STATISTICS { integer | DEFAULT }\n\
+    ALTER [ COLUMN ] column_name SET ( attribute_option = value [, ... ] )\n\
+    ALTER [ COLUMN ] column_name RESET ( attribute_option [, ... ] )\n\
+    ALTER [ COLUMN ] column_name SET STORAGE { PLAIN | EXTERNAL | EXTENDED | MAIN | DEFAULT }\n\
+    ALTER [ COLUMN ] column_name SET COMPRESSION compression_method\n\
+    ADD table_constraint [ NOT VALID ]\n\
+    ADD table_constraint_using_index\n\
+    ALTER CONSTRAINT constraint_name [ DEFERRABLE | NOT DEFERRABLE ] [ INITIALLY DEFERRED | INITIALLY IMMEDIATE ] [ ENFORCED | NOT ENFORCED ]\n\
+    ALTER CONSTRAINT constraint_name [ INHERIT | NO INHERIT ]\n\
+    VALIDATE CONSTRAINT constraint_name\n\
+    DROP CONSTRAINT [ IF EXISTS ]  constraint_name [ RESTRICT | CASCADE ]\n\
+    DISABLE TRIGGER [ trigger_name | ALL | USER ]\n\
+    ENABLE TRIGGER [ trigger_name | ALL | USER ]\n\
+    ENABLE REPLICA TRIGGER trigger_name\n\
+    ENABLE ALWAYS TRIGGER trigger_name\n\
+    DISABLE RULE rewrite_rule_name\n\
+    ENABLE RULE rewrite_rule_name\n\
+    ENABLE REPLICA RULE rewrite_rule_name\n\
+    ENABLE ALWAYS RULE rewrite_rule_name\n\
+    DISABLE ROW LEVEL SECURITY\n\
+    ENABLE ROW LEVEL SECURITY\n\
+    FORCE ROW LEVEL SECURITY\n\
+    NO FORCE ROW LEVEL SECURITY\n\
+    CLUSTER ON index_name\n\
+    SET WITHOUT CLUSTER\n\
+    SET WITHOUT OIDS\n\
+    SET ACCESS METHOD { new_access_method | DEFAULT }\n\
+    SET TABLESPACE new_tablespace\n\
+    SET { LOGGED | UNLOGGED }\n\
+    SET ( storage_parameter [= value] [, ... ] )\n\
+    RESET ( storage_parameter [, ... ] )\n\
+    INHERIT parent_table\n\
+    NO INHERIT parent_table\n\
+    OF type_name\n\
+    NOT OF\n\
+    OWNER TO { new_owner | CURRENT_ROLE | CURRENT_USER | SESSION_USER }\n\
+    REPLICA IDENTITY { DEFAULT | USING INDEX index_name | FULL | NOTHING }\n\
+\n\
+and partition_bound_spec is:\n\
+\n\
+IN ( partition_bound_expr [, ...] ) |\n\
+FROM ( { partition_bound_expr | MINVALUE | MAXVALUE } [, ...] )\n\
+  TO ( { partition_bound_expr | MINVALUE | MAXVALUE } [, ...] ) |\n\
+WITH ( MODULUS numeric_literal, REMAINDER numeric_literal )\n\
+\n\
+and column_constraint is:\n\
+\n\
+[ CONSTRAINT constraint_name ]\n\
+{ NOT NULL [ NO INHERIT ] |\n\
+  NULL |\n\
+  CHECK ( expression ) [ NO INHERIT ] |\n\
+  DEFAULT default_expr |\n\
+  GENERATED ALWAYS AS ( generation_expr ) [ STORED | VIRTUAL ] |\n\
+  GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( sequence_options ) ] |\n\
+  UNIQUE [ NULLS [ NOT ] DISTINCT ] index_parameters |\n\
+  PRIMARY KEY index_parameters |\n\
+  REFERENCES reftable [ ( refcolumn ) ] [ MATCH FULL | MATCH PARTIAL | MATCH SIMPLE ]\n\
+    [ ON DELETE referential_action ] [ ON UPDATE referential_action ] }\n\
+[ DEFERRABLE | NOT DEFERRABLE ] [ INITIALLY DEFERRED | INITIALLY IMMEDIATE ] [ ENFORCED | NOT ENFORCED ]\n\
+\n\
+and table_constraint is:\n\
+\n\
+[ CONSTRAINT constraint_name ]\n\
+{ CHECK ( expression ) [ NO INHERIT ] |\n\
+  NOT NULL column_name [ NO INHERIT ] |\n\
+  UNIQUE [ NULLS [ NOT ] DISTINCT ] ( column_name [, ... ] [, column_name WITHOUT OVERLAPS ] ) index_parameters |\n\
+  PRIMARY KEY ( column_name [, ... ] [, column_name WITHOUT OVERLAPS ] ) index_parameters |\n\
+  EXCLUDE [ USING index_method ] ( exclude_element WITH operator [, ... ] ) index_parameters [ WHERE ( predicate ) ] |\n\
+  FOREIGN KEY ( column_name [, ... ] [, PERIOD column_name ] ) REFERENCES reftable [ ( refcolumn [, ... ]  [, PERIOD refcolumn ] ) ]\n\
+    [ MATCH FULL | MATCH PARTIAL | MATCH SIMPLE ] [ ON DELETE referential_action ] [ ON UPDATE referential_action ] }\n\
+[ DEFERRABLE | NOT DEFERRABLE ] [ INITIALLY DEFERRED | INITIALLY IMMEDIATE ] [ ENFORCED | NOT ENFORCED ]\n\
+\n\
+and table_constraint_using_index is:\n\
+\n\
+    [ CONSTRAINT constraint_name ]\n\
+    { UNIQUE | PRIMARY KEY } USING INDEX index_name\n\
+    [ DEFERRABLE | NOT DEFERRABLE ] [ INITIALLY DEFERRED | INITIALLY IMMEDIATE ]\n\
+\n\
+index_parameters in UNIQUE, PRIMARY KEY, and EXCLUDE constraints are:\n\
+\n\
+[ INCLUDE ( column_name [, ... ] ) ]\n\
+[ WITH ( storage_parameter [= value] [, ... ] ) ]\n\
+[ USING INDEX TABLESPACE tablespace_name ]\n\
+\n\
+exclude_element in an EXCLUDE constraint is:\n\
+\n\
+{ column_name | ( expression ) } [ COLLATE collation ] [ opclass [ ( opclass_parameter = value [, ... ] ) ] ] [ ASC | DESC ] [ NULLS { FIRST | LAST } ]\n\
+\n\
+referential_action in a FOREIGN KEY/REFERENCES constraint is:\n\
+\n\
+{ NO ACTION | RESTRICT | CASCADE | SET NULL [ ( column_name [, ... ] ) ] | SET DEFAULT [ ( column_name [, ... ] ) ] }",
+        url: "https://www.postgresql.org/docs/18/sql-altertable.html",
+    },
+    SqlHelpEntry {
+        name: "DROP TABLE",
+        description: "remove a table",
+        synopsis: "DROP TABLE [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]",
+        url: "https://www.postgresql.org/docs/18/sql-droptable.html",
+    },
+    SqlHelpEntry {
+        name: "BEGIN",
+        description: "start a transaction block",
+        synopsis: "BEGIN [ WORK | TRANSACTION ] [ transaction_mode [, ...] ]\n\
+\n\
+where transaction_mode is one of:\n\
+\n\
+    ISOLATION LEVEL { SERIALIZABLE | REPEATABLE READ | READ COMMITTED | READ UNCOMMITTED }\n\
+    READ WRITE | READ ONLY\n\
+    [ NOT ] DEFERRABLE",
+        url: "https://www.postgresql.org/docs/18/sql-begin.html",
+    },
+    SqlHelpEntry {
+        name: "COMMIT",
+        description: "commit the current transaction",
+        synopsis: "COMMIT [ WORK | TRANSACTION ] [ AND [ NO ] CHAIN ]",
+        url: "https://www.postgresql.org/docs/18/sql-commit.html",
+    },
+    SqlHelpEntry {
+        name: "ROLLBACK",
+        description: "abort the current transaction",
+        synopsis: "ROLLBACK [ WORK | TRANSACTION ] [ AND [ NO ] CHAIN ]",
+        url: "https://www.postgresql.org/docs/18/sql-rollback.html",
+    },
+    SqlHelpEntry {
+        name: "GRANT",
+        description: "define access privileges",
+        synopsis: "GRANT { { SELECT | INSERT | UPDATE | DELETE | TRUNCATE | REFERENCES | TRIGGER | MAINTAIN }\n\
+    [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON { [ TABLE ] table_name [, ...]\n\
+         | ALL TABLES IN SCHEMA schema_name [, ...] }\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { { SELECT | INSERT | UPDATE | REFERENCES } ( column_name [, ...] )\n\
+    [, ...] | ALL [ PRIVILEGES ] ( column_name [, ...] ) }\n\
+    ON [ TABLE ] table_name [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { { USAGE | SELECT | UPDATE }\n\
+    [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON { SEQUENCE sequence_name [, ...]\n\
+         | ALL SEQUENCES IN SCHEMA schema_name [, ...] }\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { { CREATE | CONNECT | TEMPORARY | TEMP } [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON DATABASE database_name [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON DOMAIN domain_name [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON FOREIGN DATA WRAPPER fdw_name [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON FOREIGN SERVER server_name [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { EXECUTE | ALL [ PRIVILEGES ] }\n\
+    ON { { FUNCTION | PROCEDURE | ROUTINE } routine_name [ ( [ [ argmode ] [ arg_name ] arg_type [, ...] ] ) ] [, ...]\n\
+         | ALL { FUNCTIONS | PROCEDURES | ROUTINES } IN SCHEMA schema_name [, ...] }\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON LANGUAGE lang_name [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { { SELECT | UPDATE } [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON LARGE OBJECT loid [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { { SET | ALTER SYSTEM } [, ... ] | ALL [ PRIVILEGES ] }\n\
+    ON PARAMETER configuration_parameter [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { { CREATE | USAGE } [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON SCHEMA schema_name [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { CREATE | ALL [ PRIVILEGES ] }\n\
+    ON TABLESPACE tablespace_name [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON TYPE type_name [, ...]\n\
+    TO role_specification [, ...] [ WITH GRANT OPTION ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+GRANT role_name [, ...] TO role_specification [, ...]\n\
+    [ WITH { ADMIN | INHERIT | SET } { OPTION | TRUE | FALSE } ]\n\
+    [ GRANTED BY role_specification ]\n\
+\n\
+where role_specification can be:\n\
+\n\
+    [ GROUP ] role_name\n\
+  | PUBLIC\n\
+  | CURRENT_ROLE\n\
+  | CURRENT_USER\n\
+  | SESSION_USER",
+        url: "https://www.postgresql.org/docs/18/sql-grant.html",
+    },
+    SqlHelpEntry {
+        name: "REVOKE",
+        description: "remove access privileges",
+        synopsis: "REVOKE [ GRANT OPTION FOR ]\n\
+    { { SELECT | INSERT | UPDATE | DELETE | TRUNCATE | REFERENCES | TRIGGER | MAINTAIN }\n\
+    [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON { [ TABLE ] table_name [, ...]\n\
+         | ALL TABLES IN SCHEMA schema_name [, ...] }\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { { SELECT | INSERT | UPDATE | REFERENCES } ( column_name [, ...] )\n\
+    [, ...] | ALL [ PRIVILEGES ] ( column_name [, ...] ) }\n\
+    ON [ TABLE ] table_name [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { { USAGE | SELECT | UPDATE }\n\
+    [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON { SEQUENCE sequence_name [, ...]\n\
+         | ALL SEQUENCES IN SCHEMA schema_name [, ...] }\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { { CREATE | CONNECT | TEMPORARY | TEMP } [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON DATABASE database_name [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON DOMAIN domain_name [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON FOREIGN DATA WRAPPER fdw_name [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON FOREIGN SERVER server_name [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { EXECUTE | ALL [ PRIVILEGES ] }\n\
+    ON { { FUNCTION | PROCEDURE | ROUTINE } function_name [ ( [ [ argmode ] [ arg_name ] arg_type [, ...] ] ) ] [, ...]\n\
+         | ALL { FUNCTIONS | PROCEDURES | ROUTINES } IN SCHEMA schema_name [, ...] }\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON LANGUAGE lang_name [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { { SELECT | UPDATE } [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON LARGE OBJECT loid [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { { SET | ALTER SYSTEM } [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON PARAMETER configuration_parameter [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { { CREATE | USAGE } [, ...] | ALL [ PRIVILEGES ] }\n\
+    ON SCHEMA schema_name [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { CREATE | ALL [ PRIVILEGES ] }\n\
+    ON TABLESPACE tablespace_name [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ GRANT OPTION FOR ]\n\
+    { USAGE | ALL [ PRIVILEGES ] }\n\
+    ON TYPE type_name [, ...]\n\
+    FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+REVOKE [ { ADMIN | INHERIT | SET } OPTION FOR ]\n\
+    role_name [, ...] FROM role_specification [, ...]\n\
+    [ GRANTED BY role_specification ]\n\
+    [ CASCADE | RESTRICT ]\n\
+\n\
+where role_specification can be:\n\
+\n\
+    [ GROUP ] role_name\n\
+  | PUBLIC\n\
+  | CURRENT_ROLE\n\
+  | CURRENT_USER\n\
+  | SESSION_USER",
+        url: "https://www.postgresql.org/docs/18/sql-revoke.html",
+    },
+    SqlHelpEntry {
+        name: "EXPLAIN",
+        description: "show the execution plan of a statement",
+        synopsis: "EXPLAIN [ ( option [, ...] ) ] statement\n\
+\n\
+where option can be one of:\n\
+\n\
+    ANALYZE [ boolean ]\n\
+    VERBOSE [ boolean ]\n\
+    COSTS [ boolean ]\n\
+    SETTINGS [ boolean ]\n\
+    GENERIC_PLAN [ boolean ]\n\
+    BUFFERS [ boolean ]\n\
+    SERIALIZE [ { NONE | TEXT | BINARY } ]\n\
+    WAL [ boolean ]\n\
+    TIMING [ boolean ]\n\
+    SUMMARY [ boolean ]\n\
+    MEMORY [ boolean ]\n\
+    FORMAT { TEXT | XML | JSON | YAML }",
+        url: "https://www.postgresql.org/docs/18/sql-explain.html",
+    },
+    SqlHelpEntry {
+        name: "VACUUM",
+        description: "garbage-collect and optionally analyze a database",
+        synopsis: "VACUUM [ ( option [, ...] ) ] [ table_and_columns [, ...] ]\n\
+\n\
+where option can be one of:\n\
+\n\
+    FULL [ boolean ]\n\
+    FREEZE [ boolean ]\n\
+    VERBOSE [ boolean ]\n\
+    ANALYZE [ boolean ]\n\
+    DISABLE_PAGE_SKIPPING [ boolean ]\n\
+    SKIP_LOCKED [ boolean ]\n\
+    INDEX_CLEANUP { AUTO | ON | OFF }\n\
+    PROCESS_MAIN [ boolean ]\n\
+    PROCESS_TOAST [ boolean ]\n\
+    TRUNCATE [ boolean ]\n\
+    PARALLEL integer\n\
+    SKIP_DATABASE_STATS [ boolean ]\n\
+    ONLY_DATABASE_STATS [ boolean ]\n\
+    BUFFER_USAGE_LIMIT size\n\
+\n\
+and table_and_columns is:\n\
+\n\
+    [ ONLY ] table_name [ * ] [ ( column_name [, ...] ) ]",
+        url: "https://www.postgresql.org/docs/18/sql-vacuum.html",
+    },
+    SqlHelpEntry {
+        name: "ANALYZE",
+        description: "collect statistics about a database",
+        synopsis: "ANALYZE [ ( option [, ...] ) ] [ table_and_columns [, ...] ]\n\
+\n\
+where option can be one of:\n\
+\n\
+    VERBOSE [ boolean ]\n\
+    SKIP_LOCKED [ boolean ]\n\
+    BUFFER_USAGE_LIMIT size\n\
+\n\
+and table_and_columns is:\n\
+\n\
+    [ ONLY ] table_name [ * ] [ ( column_name [, ...] ) ]",
+        url: "https://www.postgresql.org/docs/18/sql-analyze.html",
+    },
+    SqlHelpEntry {
+        name: "COPY",
+        description: "copy data between a file and a table",
+        synopsis: "COPY table_name [ ( column_name [, ...] ) ]\n\
+    FROM { 'filename' | PROGRAM 'command' | STDIN }\n\
+    [ [ WITH ] ( option [, ...] ) ]\n\
+    [ WHERE condition ]\n\
+\n\
+COPY { table_name [ ( column_name [, ...] ) ] | ( query ) }\n\
+    TO { 'filename' | PROGRAM 'command' | STDOUT }\n\
+    [ [ WITH ] ( option [, ...] ) ]\n\
+\n\
+where option can be one of:\n\
+\n\
+    FORMAT format_name\n\
+    FREEZE [ boolean ]\n\
+    DELIMITER 'delimiter_character'\n\
+    NULL 'null_string'\n\
+    DEFAULT 'default_string'\n\
+    HEADER [ boolean | MATCH ]\n\
+    QUOTE 'quote_character'\n\
+    ESCAPE 'escape_character'\n\
+    FORCE_QUOTE { ( column_name [, ...] ) | * }\n\
+    FORCE_NOT_NULL { ( column_name [, ...] ) | * }\n\
+    FORCE_NULL { ( column_name [, ...] ) | * }\n\
+    ON_ERROR error_action\n\
+    REJECT_LIMIT maxerror\n\
+    ENCODING 'encoding_name'\n\
+    LOG_VERBOSITY verbosity",
+        url: "https://www.postgresql.org/docs/18/sql-copy.html",
+    },
+    SqlHelpEntry {
+        name: "CREATE FUNCTION",
+        description: "define a new function",
+        synopsis: "CREATE [ OR REPLACE ] FUNCTION\n\
+    name ( [ [ argmode ] [ argname ] argtype [ { DEFAULT | = } default_expr ] [, ...] ] )\n\
+    [ RETURNS rettype\n\
+      | RETURNS TABLE ( column_name column_type [, ...] ) ]\n\
+  { LANGUAGE lang_name\n\
+    | TRANSFORM { FOR TYPE type_name } [, ... ]\n\
+    | WINDOW\n\
+    | { IMMUTABLE | STABLE | VOLATILE }\n\
+    | [ NOT ] LEAKPROOF\n\
+    | { CALLED ON NULL INPUT | RETURNS NULL ON NULL INPUT | STRICT }\n\
+    | { [ EXTERNAL ] SECURITY INVOKER | [ EXTERNAL ] SECURITY DEFINER }\n\
+    | PARALLEL { UNSAFE | RESTRICTED | SAFE }\n\
+    | COST execution_cost\n\
+    | ROWS result_rows\n\
+    | SUPPORT support_function\n\
+    | SET configuration_parameter { TO value | = value | FROM CURRENT }\n\
+    | AS 'definition'\n\
+    | AS 'obj_file', 'link_symbol'\n\
+    | sql_body\n\
+  } ...",
+        url: "https://www.postgresql.org/docs/18/sql-createfunction.html",
+    },
+    SqlHelpEntry {
+        name: "CREATE VIEW",
+        description: "define a new view",
+        synopsis: "CREATE [ OR REPLACE ] [ TEMP | TEMPORARY ] [ RECURSIVE ] VIEW name [ ( column_name [, ...] ) ]\n\
+    [ WITH ( view_option_name [= view_option_value] [, ... ] ) ]\n\
+    AS query\n\
+    [ WITH [ CASCADED | LOCAL ] CHECK OPTION ]",
+        url: "https://www.postgresql.org/docs/18/sql-createview.html",
+    },
 ];
 
 /// Print SQL syntax help.
@@ -424,44 +1043,61 @@ pub fn sql_help(topic: Option<&str>) {
 }
 
 /// Print a two-column list of available SQL help topics.
+///
+/// Format matches psql: two columns, left column 33 characters wide,
+/// each entry indented by 2 spaces.
 fn print_help_topics() {
+    // psql uses a fixed column width of 33 characters for the left column.
+    const COL_W: usize = 33;
+
     println!("Available help:");
     println!();
 
     // Collect names and lay them out in two columns.
-    let names: Vec<&str> = SQL_HELP.iter().map(|(n, _)| *n).collect();
+    let names: Vec<&str> = SQL_HELP.iter().map(|e| e.name).collect();
     let half = names.len().div_ceil(2);
-    let col_w = names.iter().map(|n| n.len()).max().unwrap_or(0) + 4;
 
     for i in 0..half {
         let left = names[i];
         let right = names.get(i + half).copied().unwrap_or("");
-        println!("  {left:<col_w$}{right}");
+        if right.is_empty() {
+            println!("  {left}");
+        } else {
+            println!("  {left:<COL_W$}{right}");
+        }
     }
 
     println!();
-    println!("Type \\h <command> for syntax. Example: \\h select");
+    println!("Type \\h <command-name> for help on a specific command");
 }
 
 /// Print the synopsis for a specific SQL command (case-insensitive).
+///
+/// Output format matches psql exactly:
+/// ```text
+/// Command:     NAME
+/// Description: short description
+/// Syntax:
+/// <synopsis lines, no leading indentation>
+///
+/// URL: https://...
+/// ```
 fn print_help_topic(topic: &str) {
     let upper = topic.trim().to_uppercase();
 
     // Look for an exact match first, then a prefix match.
     let entry = SQL_HELP
         .iter()
-        .find(|(name, _)| *name == upper)
-        .or_else(|| SQL_HELP.iter().find(|(name, _)| name.starts_with(&upper)));
+        .find(|e| e.name == upper)
+        .or_else(|| SQL_HELP.iter().find(|e| e.name.starts_with(&upper)));
 
-    if let Some((name, synopsis)) = entry {
-        println!("Command:     {name}");
-        println!("Description: SQL syntax help");
+    if let Some(e) = entry {
+        println!("Command:     {}", e.name);
+        println!("Description: {}", e.description);
         println!("Syntax:");
+        println!("{}", e.synopsis);
         println!();
-        for line in synopsis.lines() {
-            println!("  {line}");
-        }
-        println!();
+        println!("URL: {}", e.url);
     } else {
         eprintln!("No help available for \"{topic}\".");
         eprintln!("Try \\h with no argument to list available topics.");
@@ -618,9 +1254,14 @@ mod tests {
         // Trust the output because SQL_HELP is static.
         let entry = SQL_HELP
             .iter()
-            .find(|(n, _)| *n == "SELECT")
+            .find(|e| e.name == "SELECT")
             .expect("SELECT entry missing");
-        assert!(entry.1.contains("from"));
+        // Synopsis must contain the FROM keyword (from psql's output).
+        assert!(entry.synopsis.contains("FROM"));
+        // Description must match psql's exact wording.
+        assert_eq!(entry.description, "retrieve rows from a table or view");
+        // URL must point to the PostgreSQL docs.
+        assert!(entry.url.contains("sql-select"));
     }
 
     #[test]
@@ -648,7 +1289,7 @@ mod tests {
         ];
         for cmd in required {
             assert!(
-                SQL_HELP.iter().any(|(n, _)| *n == cmd),
+                SQL_HELP.iter().any(|e| e.name == cmd),
                 "missing SQL help topic: {cmd}"
             );
         }
@@ -660,9 +1301,28 @@ mod tests {
         let upper = "CREATE".to_uppercase();
         let entry = SQL_HELP
             .iter()
-            .find(|(n, _)| *n == upper)
-            .or_else(|| SQL_HELP.iter().find(|(n, _)| n.starts_with(&upper)));
+            .find(|e| e.name == upper)
+            .or_else(|| SQL_HELP.iter().find(|e| e.name.starts_with(&upper)));
         assert!(entry.is_some(), "CREATE prefix should match something");
+    }
+
+    #[test]
+    fn sql_help_descriptions_non_empty() {
+        // Every entry must have a non-empty description and URL.
+        for e in SQL_HELP {
+            assert!(
+                !e.description.is_empty(),
+                "empty description for {}",
+                e.name
+            );
+            assert!(!e.url.is_empty(), "empty URL for {}", e.name);
+            assert!(
+                e.url.starts_with("https://www.postgresql.org/"),
+                "unexpected URL for {}: {}",
+                e.name,
+                e.url
+            );
+        }
     }
 
     // -- split_schema_name ---------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace the terse hand-written `\h` synopsis table with verbatim PostgreSQL 18 syntax sourced directly from psql's output
- Introduce `SqlHelpEntry` struct carrying `name`, `description`, `synopsis`, and `url` fields — enabling the full three-line psql header format (`Command:` / `Description:` / `Syntax:` + trailing `URL:`)
- Rewrite all 19 covered commands with exact psql-matching text: SELECT, INSERT, UPDATE, DELETE, CREATE TABLE, CREATE INDEX, ALTER TABLE, DROP TABLE, BEGIN, COMMIT, ROLLBACK, GRANT, REVOKE, EXPLAIN, VACUUM, ANALYZE, COPY, CREATE FUNCTION, CREATE VIEW
- Use fixed 33-char left column in the `\h` topic list and update footer wording to match psql
- Update tests: assert `description` and `url` fields are populated, check `FROM` keyword (uppercase, per psql), verify all entries have valid postgresql.org URLs

## Test plan

- [ ] `cargo test sql_help` — all 8 tests pass
- [ ] `cargo clippy` — no warnings
- [ ] `cargo fmt -- --check` — clean
- [ ] Manual diff: `diff <(psql --no-psqlrc -c "\h SELECT" postgres) <(./target/debug/samo -c "\h SELECT" postgres)` — identical output
- [ ] Manual: `\h` (no arg) shows two-column list matching psql format

🤖 Generated with [Claude Code](https://claude.com/claude-code)