### PR TITLE
fix(ci): use macos-14 for darwin-x86_64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,9 @@ jobs:
             use_cross: true
             artifact: samo-linux-aarch64
           # macOS (native runners)
+          # x86_64 cross-compiled on aarch64 runner (macos-13 deprecated)
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
             use_cross: false
             artifact: samo-darwin-x86_64
           - target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary
- Switch darwin-x86_64 build from macos-13 to macos-14 runner
- macos-13 runners are being deprecated by GitHub Actions and frequently unavailable/cancelled
- x86_64 target is cross-compiled on the aarch64 runner

## Test plan
- [ ] CI build for darwin-x86_64 completes without cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)