### PR TITLE
feat(repl): support quit/exit as bare-word exit commands

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -2723,6 +2723,8 @@ fn print_help() {
     println!(
         r"Backslash commands:
   \q              quit samo
+  quit            quit samo (interactive mode only)
+  exit            quit samo (interactive mode only)
   \timing [on|off]      toggle/set query timing display
   \x [on|off|auto]      toggle/set expanded display
   \conninfo       show connection information
@@ -5214,6 +5216,16 @@ async fn handle_line(
 ) -> HandleLineResult {
     // AI commands use a `/` prefix and are handled before backslash commands.
     let trimmed = line.trim();
+
+    // `quit` and `exit` as bare words at the primary prompt exit interactively
+    // (PostgreSQL 11+ behaviour).  Only applies when the query buffer is empty
+    // (i.e. we are at the primary prompt, not mid-statement).
+    if buf.is_empty() {
+        let lower = trimmed.to_ascii_lowercase();
+        if lower == "quit" || lower == "exit" {
+            return HandleLineResult::Quit;
+        }
+    }
     if trimmed.starts_with('/') {
         stmt_buf.clear();
         stmt_buf.push_str(line);
@@ -8851,5 +8863,73 @@ mod tests {
             ..Default::default()
         };
         print_profiles(&config);
+    }
+
+    // -- quit/exit bare-word detection ----------------------------------------
+
+    /// Helper that mirrors the bare-word quit/exit logic from `handle_line`
+    /// without requiring a live DB connection.
+    fn bare_word_quits(line: &str, buf_empty: bool) -> bool {
+        let trimmed = line.trim();
+        if buf_empty {
+            let lower = trimmed.to_ascii_lowercase();
+            if lower == "quit" || lower == "exit" {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn quit_bare_word_empty_buf_quits() {
+        assert!(bare_word_quits("quit", true));
+    }
+
+    #[test]
+    fn exit_bare_word_empty_buf_quits() {
+        assert!(bare_word_quits("exit", true));
+    }
+
+    #[test]
+    fn quit_uppercase_empty_buf_quits() {
+        assert!(bare_word_quits("QUIT", true));
+    }
+
+    #[test]
+    fn exit_mixed_case_empty_buf_quits() {
+        assert!(bare_word_quits("Exit", true));
+    }
+
+    #[test]
+    fn quit_with_whitespace_empty_buf_quits() {
+        // Leading/trailing whitespace is stripped by `line.trim()`.
+        assert!(bare_word_quits("  quit  ", true));
+    }
+
+    #[test]
+    fn quit_mid_statement_does_not_quit() {
+        // Buffer is non-empty — we are in continuation mode.
+        assert!(!bare_word_quits("quit", false));
+    }
+
+    #[test]
+    fn exit_mid_statement_does_not_quit() {
+        assert!(!bare_word_quits("exit", false));
+    }
+
+    #[test]
+    fn quit_with_args_does_not_quit() {
+        // "quit foo" is not a bare word.
+        assert!(!bare_word_quits("quit foo", true));
+    }
+
+    #[test]
+    fn exit_with_args_does_not_quit() {
+        assert!(!bare_word_quits("exit now", true));
+    }
+
+    #[test]
+    fn regular_sql_does_not_trigger_quit() {
+        assert!(!bare_word_quits("select 1", true));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `quit` and `exit` as bare-word exit commands in interactive mode, matching PostgreSQL 11+ behaviour
- Detection is case-insensitive and only fires when the query buffer is empty (primary prompt, not mid-statement)
- Piped/non-interactive input is unaffected — `quit`/`exit` still pass through as SQL in scripts
- Documents both keywords in `\?` help output alongside `\q`

## Implementation

The check is inserted at the top of `handle_line` in `src/repl.rs`. Since `handle_line` is only called from `run_readline_loop` (the interactive path), no changes are needed in `run_dumb_loop` — piped mode naturally excludes the new behaviour.

## Test plan

- [x] `quit_bare_word_empty_buf_quits` — lowercase `quit` with empty buffer
- [x] `exit_bare_word_empty_buf_quits` — lowercase `exit` with empty buffer
- [x] `quit_uppercase_empty_buf_quits` — `QUIT` (case-insensitive)
- [x] `exit_mixed_case_empty_buf_quits` — `Exit` (case-insensitive)
- [x] `quit_with_whitespace_empty_buf_quits` — surrounding whitespace stripped
- [x] `quit_mid_statement_does_not_quit` — ignored when buffer is non-empty
- [x] `exit_mid_statement_does_not_quit` — ignored when buffer is non-empty
- [x] `quit_with_args_does_not_quit` — `quit foo` is not a bare word
- [x] `exit_with_args_does_not_quit` — `exit now` is not a bare word
- [x] `regular_sql_does_not_trigger_quit` — normal SQL unaffected
- [x] All 1131 existing tests pass; clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)