### PR TITLE
feat: add version display and build info for v0.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,7 +2239,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "samo"
-version = "0.1.0-dev"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samo"
-version = "0.1.0-dev"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Self-driving Postgres agent and psql-compatible terminal"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,10 @@
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn main() {
     // Embed git commit hash into the binary at compile time.
+    // Falls back to "unknown" gracefully when git is unavailable
+    // (e.g., CI builds from tarballs or environments without git).
     let hash = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
@@ -12,6 +15,12 @@ fn main() {
 
     println!("cargo:rustc-env=SAMO_GIT_HASH={hash}");
 
+    // Embed the build date (UTC, YYYY-MM-DD format).
+    // Uses the SOURCE_DATE_EPOCH env var for reproducible builds when set;
+    // otherwise falls back to the current UTC date.
+    let build_date = build_date();
+    println!("cargo:rustc-env=SAMO_BUILD_DATE={build_date}");
+
     // Re-run if HEAD changes (branch switch).
     println!("cargo:rerun-if-changed=.git/HEAD");
 
@@ -21,4 +30,46 @@ fn main() {
             println!("cargo:rerun-if-changed=.git/{}", ref_path.trim());
         }
     }
+}
+
+/// Return the build date as `YYYY-MM-DD` (UTC).
+///
+/// Respects `SOURCE_DATE_EPOCH` for reproducible builds; falls back to the
+/// system clock when the variable is absent or unparseable.
+fn build_date() -> String {
+    // Try SOURCE_DATE_EPOCH first (seconds since Unix epoch).
+    if let Ok(epoch_str) = std::env::var("SOURCE_DATE_EPOCH") {
+        if let Ok(epoch) = epoch_str.trim().parse::<i64>() {
+            return epoch_to_date(epoch);
+        }
+    }
+
+    // Fall back to the current UTC time via std::time.
+    // UNIX_EPOCH is always before SystemTime::now(), so the subtraction
+    // cannot underflow; i64 is sufficient for dates past year 2000.
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0_i64, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
+    epoch_to_date(secs)
+}
+
+/// Convert Unix epoch seconds to a `YYYY-MM-DD` string (UTC, no external deps).
+fn epoch_to_date(epoch: i64) -> String {
+    // Days since Unix epoch.
+    let days = epoch / 86_400;
+
+    // Gregorian calendar computation (valid for dates after 1970-01-01).
+    // Algorithm: civil_from_days — Howard Hinnant, public domain.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // day of era [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // year of era
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day of year [0, 365]
+    let mp = (5 * doy + 2) / 153; // month prime [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // day [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // month [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!("{y:04}-{m:02}-{d:02}")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,27 @@ mod verification;
 /// Build-time git commit hash injected by `build.rs`.
 const GIT_HASH: &str = env!("SAMO_GIT_HASH");
 
+/// Build-time date (UTC, `YYYY-MM-DD`) injected by `build.rs`.
+const BUILD_DATE: &str = env!("SAMO_BUILD_DATE");
+
+/// One-line version string: `samo 0.1.0 (abc1234, built 2026-03-13)`.
+///
+/// Exposed as `pub` so that meta-command handlers can print it without
+/// duplicating the formatting logic.
+pub fn version_string() -> &'static str {
+    // Leak is fine: called at most a handful of times, lives for the
+    // process lifetime.
+    Box::leak(
+        format!(
+            "samo {} ({}, built {})",
+            env!("CARGO_PKG_VERSION"),
+            GIT_HASH,
+            BUILD_DATE,
+        )
+        .into_boxed_str(),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Autonomy levels (samo-specific)
 // ---------------------------------------------------------------------------
@@ -70,10 +91,9 @@ enum Autonomy {
 // CLI definition
 // ---------------------------------------------------------------------------
 
-/// Assemble a long version string like `0.1.0-dev (abc1234)`.
+/// Assemble the clap version string: delegates to [`version_string`].
 fn long_version() -> &'static str {
-    // Leak is fine: called once at startup, lives for the process lifetime.
-    Box::leak(format!("{} ({})", env!("CARGO_PKG_VERSION"), GIT_HASH).into_boxed_str())
+    version_string()
 }
 
 /// Samo — self-driving Postgres agent and psql-compatible terminal.
@@ -642,7 +662,12 @@ async fn main() {
             );
             let is_piped = !cli.interactive && !std::io::stdin().is_terminal();
             let is_scripting = !cli.command.is_empty() || cli.file.is_some();
-            if !cli.quiet && !is_scripting && !is_piped {
+            let is_interactive = !is_scripting && !is_piped;
+            if !cli.quiet && is_interactive {
+                // Version banner — matches psql's style of showing version on
+                // connect. Only shown for interactive sessions, not -c/-f/pipe.
+                println!("{}", version_string());
+                println!("Type \\? for help, \\q to quit.");
                 println!("{}", connection::connection_info(&resolved));
             }
 
@@ -653,7 +678,7 @@ async fn main() {
             if let capabilities::PgAshStatus::Available { ref version } =
                 settings.db_capabilities.pg_ash
             {
-                if !cli.quiet && !is_scripting && !is_piped {
+                if !cli.quiet && is_interactive {
                     let ver = version.as_deref().unwrap_or("unknown version");
                     logging::info("capabilities", &format!("pg_ash detected: {ver}"));
                 }

--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -253,6 +253,8 @@ pub enum MetaCmd {
     // -- Info commands ------------------------------------------------------
     /// `\copyright` — show `PostgreSQL` copyright and distribution terms.
     Copyright,
+    /// `\version` — show samo version and build information.
+    Version,
 
     // -- Diagnostic commands (#66) -----------------------------------------
     /// `\dba [subcommand]` — run a database diagnostic sub-command.
@@ -462,6 +464,7 @@ pub fn parse(input: &str) -> ParsedMeta {
         Some('s') => parse_s_family(input),
         Some('t') => parse_t_family(input),
         Some('u') => parse_unset(input),
+        Some('v') => parse_v_family(input),
         Some('w') => parse_w(input),
         Some('x') => parse_x(input),
         Some('b') => parse_b_family(input),
@@ -768,6 +771,16 @@ fn parse_x(input: &str) -> ParsedMeta {
         _ => ExpandedMode::Toggle,
     };
     ParsedMeta::simple(MetaCmd::Expanded(mode))
+}
+
+/// Parse `\version` or unknown `\v…`.
+fn parse_v_family(input: &str) -> ParsedMeta {
+    if let Some(rest) = input.strip_prefix("version") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            return ParsedMeta::simple(MetaCmd::Version);
+        }
+    }
+    ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()))
 }
 
 /// Parse `\conninfo`, `\crosstabview`, `\copy`, `\close_prepared`, `\copyright`, `\cd`, `\c`, or unknown `\c…`.
@@ -2860,6 +2873,20 @@ mod tests {
         assert_eq!(parse("\\copyright").cmd, MetaCmd::Copyright);
         assert_eq!(parse("\\conninfo").cmd, MetaCmd::ConnInfo);
         assert_eq!(parse("\\cd /tmp").cmd, MetaCmd::Chdir);
+    }
+
+    // -- \version ------------------------------------------------------------
+
+    #[test]
+    fn parse_version() {
+        assert_eq!(parse("\\version").cmd, MetaCmd::Version);
+    }
+
+    #[test]
+    fn parse_version_not_confused_with_other_v_prefixes() {
+        // \version must parse cleanly; a partial match like \v alone is Unknown.
+        assert_eq!(parse("\\version").cmd, MetaCmd::Version);
+        assert!(matches!(parse("\\v").cmd, MetaCmd::Unknown(_)));
     }
 
     // -- \dba (#66) ----------------------------------------------------------

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -2720,13 +2720,16 @@ pub(crate) async fn exec_lines(
 
 /// Print the backslash command help text.
 fn print_help() {
+    println!("{}", crate::version_string());
     println!(
-        r"Backslash commands:
+        r"
+Backslash commands:
   \q              quit samo
   \timing [on|off]      toggle/set query timing display
   \x [on|off|auto]      toggle/set expanded display
   \conninfo       show connection information
   \copyright      show PostgreSQL usage and distribution terms
+  \version        show samo version and build information
   \?              show this help
 
 Session commands:
@@ -4129,6 +4132,9 @@ async fn dispatch_meta(
         }
         MetaCmd::Copyright => {
             print_copyright();
+        }
+        MetaCmd::Version => {
+            println!("{}", crate::version_string());
         }
         MetaCmd::SqlMode => {
             return MetaResult::SetInputMode(InputMode::Sql);


### PR DESCRIPTION
## Summary

- Bump version in `Cargo.toml` from `0.1.0-dev` to `0.1.0`
- Extend `build.rs` to embed `SAMO_BUILD_DATE` (UTC `YYYY-MM-DD`) alongside the existing `SAMO_GIT_HASH`; respects `SOURCE_DATE_EPOCH` for reproducible builds; gracefully falls back to `"unknown"` when git is absent
- Add `version_string()` at the crate root: `samo 0.1.0 (abc1234, built 2026-03-13)`
- Print a one-line version banner + hint on interactive startup only (not `-c` / `-f` / piped stdin), matching psql's connect-time style
- Add `\version` meta-command (`MetaCmd::Version`, `parse_v_family()`) that prints the same string on demand
- Prepend the version line to the `\?` help output header

## Test plan

- [ ] `cargo clippy` — zero warnings (verified)
- [ ] `cargo test --bin samo` — 1123 tests pass (verified)
- [ ] `samo --version` prints `samo 0.1.0 (<hash>, built <date>)`
- [ ] Interactive startup shows banner + hint before connection info
- [ ] `samo -c "select 1"` does NOT show banner
- [ ] `\version` inside REPL prints the version string
- [ ] `\?` help output starts with the version line

🤖 Generated with [Claude Code](https://claude.com/claude-code)