### PR TITLE
fix(output): consistent trailing newline after describe and query output

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -165,6 +165,11 @@ pub fn format_rowset_pset(out: &mut String, rs: &RowSet, cfg: &PsetConfig) {
         OutputFormat::Json => format_json(out, rs, cfg),
         OutputFormat::Html => format_html(out, rs, cfg),
     }
+
+    // psql always prints a blank line after each result set (the trailing
+    // newline after `(N rows)` plus one more).  Add it here so all formats
+    // get consistent behaviour regardless of whether a footer is shown.
+    out.push('\n');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1183,10 +1183,6 @@ fn print_result_set_pset(
     use crate::query::{ColumnMeta, RowSet};
 
     if is_select && !col_names.is_empty() {
-        if !is_first {
-            let _ = writeln!(writer);
-        }
-
         // simple_query returns NULL as empty string; we wrap every cell
         // in Some to distinguish "empty string" from "NULL" at the pset
         // formatting layer (which uses null_display).  The distinction
@@ -1231,6 +1227,9 @@ fn print_result_set_pset(
 
         let mut out = String::new();
         format_rowset_pset(&mut out, &rs, pset);
+        // format_rowset_pset appends a trailing blank line so that output
+        // matches psql's consistent blank line after every result set.
+        // No extra separator is needed before subsequent results.
         let _ = writer.write_all(out.as_bytes());
     } else if !is_select {
         // Non-SELECT statement: show rows affected if > 0.


### PR DESCRIPTION
## Summary

- `\d` commands and SELECT queries had inconsistent trailing newlines: describe commands (via `print_table_inner`) appended `\n\n` after the row-count footer, but SELECT queries routed through `format_rowset_pset` only appended `\n`.
- psql always emits a blank line after every result set (the row-count footer line plus one extra `\n`), regardless of format or footer setting.

## Changes

- `src/output.rs` — add `out.push('\n')` at the end of `format_rowset_pset` so all query output paths (aligned, expanded, unaligned, CSV, JSON, HTML) get the consistent trailing blank line.
- `src/repl.rs` — remove the pre-result blank line inserted before non-first result sets in `print_result_set_pset`; the trailing blank line from the previous result now provides the separation, matching psql's exact byte-for-byte output for multi-statement queries.

## Test plan

- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo test` — all 1121 tests pass
- [x] `printf "select 1;\n\\q\n" | samo ... | od -c` matches psql output (ends with `(1 row)\n\n`)
- [x] `printf "\\dt\n\\q\n" | samo ... | od -c` matches psql output (ends with `(N rows)\n\n`)
- [x] `printf "select 1;\nselect 2;\n\\q\n" | samo ... | od -c` matches psql multi-statement output
- [x] `select 1 where false` (0 rows) matches psql

🤖 Generated with [Claude Code](https://claude.com/claude-code)