### PR TITLE
fix(connection): silence TLS fallback warning for sslmode=prefer (matching psql)

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -788,10 +788,10 @@ pub async fn connect(
         SslMode::Disable => connect_plain(&pg_config, &params).await?,
         SslMode::Prefer => match connect_tls(&pg_config, &params).await {
             Ok(c) => c,
-            Err(e) => {
-                // Intentionally swallow TLS errors in prefer mode and fall
-                // back to a plain connection. Log for debugging.
-                eprintln!("samo: TLS unavailable ({e}), falling back to plain connection");
+            Err(_) => {
+                // sslmode=prefer: silently fall back to a plain connection
+                // when TLS is unavailable. This matches psql's default
+                // behavior — no warning is shown to the user.
                 connect_plain(&pg_config, &params).await?
             }
         },


### PR DESCRIPTION
## Summary

- When `sslmode=prefer` (the default), samo was printing `TLS unavailable (...), falling back to plain connection` to stderr on every local connection
- psql does NOT show this message — it silently falls back when TLS is unavailable under `sslmode=prefer`
- The fix removes the `eprintln!` in the `SslMode::Prefer` fallback arm; the error is now silently discarded (`_`)
- `sslmode=require` behavior is unchanged: TLS failure there still surfaces as a proper error
- Comment updated to explain the intentional silent behavior

## Test plan

- [x] `cargo clippy --all-targets --all-features` — clean, no warnings
- [x] `cargo test` — 1133 tests passed, 0 failed
- Manual check: connecting locally no longer shows the TLS warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)