### PR TITLE
fix(repl): add empty line after connection banner to match psql

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -670,6 +670,7 @@ async fn main() {
                 println!("{}", version_string());
                 println!("Type \\? for help, \\q to quit.");
                 println!("{}", connection::connection_info(&resolved));
+                println!();
             }
 
             let mut settings = build_settings(&cli, &cfg);


### PR DESCRIPTION
## Summary

- psql outputs an empty line between the help hint and the first prompt (e.g., after `Type "help" for help.`)
- Samo was missing this blank line, making the banner look cramped compared to psql
- Add `println!()` after the `connection_info` line in the interactive banner block

## Test plan

- [ ] Build and connect interactively: verify a blank line appears between the connection-info line and the `=>` prompt
- [ ] Run with `-c` flag: verify the blank line is NOT printed (non-interactive path unchanged)
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt` produces no changes
- [ ] `cargo test` passes (1221 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)