### PR TITLE
feat(dba): implement \dba locks tree visualization

### DIFF
--- a/src/dba.rs
+++ b/src/dba.rs
@@ -465,8 +465,7 @@ async fn collect_lock_edges(
 ) -> Vec<LockEdge> {
     // waitstart was added in PG 14. Since we target PG 14-18 it is always
     // available, but guard defensively in case the capabilities probe failed.
-    let has_waitstart = capabilities
-        .is_none_or(|c| c.pg_major_version().is_none_or(|v| v >= 14));
+    let has_waitstart = capabilities.is_none_or(|c| c.pg_major_version().is_none_or(|v| v >= 14));
 
     let sql = build_locks_sql(has_waitstart);
     crate::logging::trace("dba", &format!("locks diagnostic query: {}", sql.trim()));
@@ -561,9 +560,7 @@ fn build_locks_sql(has_waitstart: bool) -> String {
 }
 
 /// Parse `SimpleQueryMessage` rows into `LockEdge` values.
-fn parse_lock_edges(
-    messages: Vec<tokio_postgres::SimpleQueryMessage>,
-) -> Vec<LockEdge> {
+fn parse_lock_edges(messages: Vec<tokio_postgres::SimpleQueryMessage>) -> Vec<LockEdge> {
     let mut edges = Vec::new();
     for msg in messages {
         if let tokio_postgres::SimpleQueryMessage::Row(row) = msg {


### PR DESCRIPTION
## Summary

- Replaces the flat-table `\dba locks` implementation with a blocking-chain tree visualization using `├─`/`└─` connectors
- Collects lock edges via `pg_locks` joined with `pg_stat_activity`, builds a recursive `LockNode` forest, and renders root blockers (GRANTED) with indented waiting children (WAITING + duration)
- Uses `waitstart` (PG 14+) for accurate wait duration; falls back to `query_start` when capabilities indicate an older server
- Prints `No blocking locks detected.` when there are no blocking locks

## Implementation details

- `build_locks_sql(has_waitstart)` — builds the CTE query, kept separate to stay under clippy's 100-line function limit
- `parse_lock_edges(messages)` — converts `SimpleQueryMessage` rows into `LockEdge` structs
- `build_lock_forest(edges)` — constructs a `Vec<LockNode>` tree, deduplicating by `blocked_pid` and sorting children by wait duration
- `render_lock_forest(forest)` — renders with Unicode box-drawing connectors; multiple independent blocking trees are separated by blank lines

## Example output

```
PID 1234 (alice@mydb) GRANTED AccessExclusiveLock on users
  query: update users set active = false where id = 42
├─ PID 5678 (bob@mydb) WAITING 5.2s RowExclusiveLock on users
│  query: insert into users (name) values ('eve')
│  └─ PID 9012 (eve@mydb) WAITING 3.1s AccessShareLock on users
│     query: select * from users limit 10
└─ PID 3456 (carol@mydb) WAITING 4.8s RowShareLock on users
   query: select count(*) from users
```

## Test plan

- [ ] 13 new unit tests added covering `format_duration_secs`, `build_lock_forest` (empty, single edge, chain, fan-out), and `render_lock_forest` (no panic)
- [ ] `cargo clippy -- -D warnings` passes clean
- [ ] `cargo fmt` applied
- [ ] `cargo test` — 1242 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)