### PR TITLE
feat(repl): add auto-EXPLAIN mode via \set EXPLAIN

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1399,6 +1399,13 @@ pub async fn execute_query(
                         // statement in a multi-statement query.
                         // Capture rendered output so we can mirror to log.
                         let mut out_buf = Vec::<u8>::new();
+
+                        // Print "--- EXPLAIN ---" header before the plan
+                        // output so users can distinguish plan from results.
+                        if auto_explain_active && result_set_index == 0 {
+                            let _ = writeln!(out_buf, "--- EXPLAIN ---");
+                        }
+
                         print_result_set_pset(
                             &mut out_buf,
                             &col_names,
@@ -8290,6 +8297,35 @@ mod tests {
         assert_eq!(AutoExplain::On.label(), "on");
         assert_eq!(AutoExplain::Analyze.label(), "analyze");
         assert_eq!(AutoExplain::Verbose.label(), "verbose");
+    }
+
+    #[test]
+    fn set_explain_on_updates_auto_explain() {
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "EXPLAIN", "on");
+        assert_eq!(settings.auto_explain, AutoExplain::On);
+    }
+
+    #[test]
+    fn set_explain_analyze_updates_auto_explain() {
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "EXPLAIN", "analyze");
+        assert_eq!(settings.auto_explain, AutoExplain::Analyze);
+    }
+
+    #[test]
+    fn set_explain_verbose_updates_auto_explain() {
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "EXPLAIN", "verbose");
+        assert_eq!(settings.auto_explain, AutoExplain::Verbose);
+    }
+
+    #[test]
+    fn set_explain_off_updates_auto_explain() {
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "EXPLAIN", "on");
+        apply_set(&mut settings, "EXPLAIN", "off");
+        assert_eq!(settings.auto_explain, AutoExplain::Off);
     }
 
     // -- \gexec parser ---------------------------------------------------------


### PR DESCRIPTION
## Summary

- `AutoExplain` enum (`Off/On/Analyze/Verbose`) and `auto_explain` field in `ReplSettings` were already scaffolded in the codebase
- Added a `"--- EXPLAIN ---"` header printed before plan output when auto-explain is active, so users can visually distinguish the query plan from actual query results
- Added 4 unit tests covering `apply_set` mirroring `EXPLAIN on/analyze/verbose/off` into `settings.auto_explain`

## Behaviour

| Command | Effect |
|---|---|
| `\set EXPLAIN off` | default, no auto-explain |
| `\set EXPLAIN on` | prepend `EXPLAIN` to queries |
| `\set EXPLAIN analyze` | prepend `EXPLAIN ANALYZE` to queries |
| `\set EXPLAIN verbose` | prepend `EXPLAIN (ANALYZE, VERBOSE, BUFFERS, TIMING)` to queries |

Only applies to `SELECT`, `WITH`, `TABLE`, and `VALUES` queries. Skips queries that already start with `EXPLAIN`. Does not apply to backslash commands or internal system queries.

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` — all 1243 unit tests pass (plus 4 new `set_explain_*` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)