### PR TITLE
chore: bump version to v0.2.0 (Phase 1 milestone)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,7 +2166,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "samo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samo"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Self-driving Postgres agent and psql-compatible terminal"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -948,7 +948,7 @@ pub fn connection_info(params: &ConnParams) -> String {
 /// prepends a version banner — e.g.:
 ///
 /// ```text
-/// samo 0.1.0 (...) (server PostgreSQL 17.7)
+/// samo 0.2.0 (...) (server PostgreSQL 17.7)
 /// You are now connected to database "mydb" as user "alice" on host "other"
 /// at port "5432".
 /// ```
@@ -1466,7 +1466,7 @@ mod tests {
         };
         assert_eq!(
             reconnect_info(
-                "samo 0.1.0 (abc1234, built 2026-01-01)",
+                "samo 0.2.0 (abc1234, built 2026-01-01)",
                 Some("17.2"),
                 &old,
                 &new
@@ -1495,12 +1495,12 @@ mod tests {
         };
         assert_eq!(
             reconnect_info(
-                "samo 0.1.0 (abc1234, built 2026-01-01)",
+                "samo 0.2.0 (abc1234, built 2026-01-01)",
                 Some("16.3"),
                 &old,
                 &new
             ),
-            "samo 0.1.0 (abc1234, built 2026-01-01) (server PostgreSQL 16.3)\n\
+            "samo 0.2.0 (abc1234, built 2026-01-01) (server PostgreSQL 16.3)\n\
              You are now connected to database \"mydb\" as user \"alice\" \
              on host \"other.example.com\" at port \"5432\".",
         );
@@ -1525,12 +1525,12 @@ mod tests {
         };
         assert_eq!(
             reconnect_info(
-                "samo 0.1.0 (abc1234, built 2026-01-01)",
+                "samo 0.2.0 (abc1234, built 2026-01-01)",
                 Some("15.6"),
                 &old,
                 &new
             ),
-            "samo 0.1.0 (abc1234, built 2026-01-01) (server PostgreSQL 15.6)\n\
+            "samo 0.2.0 (abc1234, built 2026-01-01) (server PostgreSQL 15.6)\n\
              You are now connected to database \"mydb\" as user \"postgres\" \
              on host \"localhost\" at port \"5433\".",
         );
@@ -1555,7 +1555,7 @@ mod tests {
         };
         assert_eq!(
             reconnect_info(
-                "samo 0.1.0 (abc1234, built 2026-01-01)",
+                "samo 0.2.0 (abc1234, built 2026-01-01)",
                 Some("17.2"),
                 &old,
                 &new
@@ -1583,8 +1583,8 @@ mod tests {
             ..ConnParams::default()
         };
         assert_eq!(
-            reconnect_info("samo 0.1.0 (abc1234, built 2026-01-01)", None, &old, &new),
-            "samo 0.1.0 (abc1234, built 2026-01-01) (server PostgreSQL unknown)\n\
+            reconnect_info("samo 0.2.0 (abc1234, built 2026-01-01)", None, &old, &new),
+            "samo 0.2.0 (abc1234, built 2026-01-01) (server PostgreSQL unknown)\n\
              You are now connected to database \"postgres\" as user \"postgres\" \
              on host \"other.host\" at port \"5432\".",
         );
@@ -1648,7 +1648,7 @@ mod tests {
         };
         assert_eq!(
             reconnect_info(
-                "samo 0.1.0 (abc1234, built 2026-01-01)",
+                "samo 0.2.0 (abc1234, built 2026-01-01)",
                 Some("17.2"),
                 &old,
                 &new
@@ -1679,12 +1679,12 @@ mod tests {
         };
         assert_eq!(
             reconnect_info(
-                "samo 0.1.0 (abc1234, built 2026-01-01)",
+                "samo 0.2.0 (abc1234, built 2026-01-01)",
                 Some("16.3"),
                 &old,
                 &new
             ),
-            "samo 0.1.0 (abc1234, built 2026-01-01) (server PostgreSQL 16.3)\n\
+            "samo 0.2.0 (abc1234, built 2026-01-01) (server PostgreSQL 16.3)\n\
              You are now connected to database \"mydb\" as user \"alice\" \
              on host \"other.example.com\" at port \"5432\".\n\
              SSL connection (protocol: TLS, compression: off)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ const GIT_HASH: &str = env!("SAMO_GIT_HASH");
 /// Build-time date (UTC, `YYYY-MM-DD`) injected by `build.rs`.
 const BUILD_DATE: &str = env!("SAMO_BUILD_DATE");
 
-/// One-line version string: `samo 0.1.0 (abc1234, built 2026-03-13)`.
+/// One-line version string: `samo 0.2.0 (abc1234, built 2026-03-13)`.
 ///
 /// Exposed as `pub` so that meta-command handlers can print it without
 /// duplicating the formatting logic.


### PR DESCRIPTION
## Summary

Bumps the Samo package version from `0.1.0` to `0.2.0`, marking the
completion of Phase 1 (Beyond psql).

Per `SPEC.md` release boundaries:

- **v0.1** — psql-compatible terminal (complete)
- **v0.2** — Beyond psql: TUI pager, `\dba` diagnostics, connection
  profiles, named queries, session persistence (complete)

## Changes

- `Cargo.toml`: `version = "0.2.0"`
- `Cargo.lock`: regenerated with new version
- `src/main.rs`: doc comment example updated to `0.2.0`
- `src/connection.rs`: test fixture version strings updated to `0.2.0`

## Verification

- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test` — 1261 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)