### PR TITLE
feat(safety): add custom protected_patterns config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -115,12 +115,26 @@ impl Default for DisplayConfig {
 pub struct SafetyConfig {
     /// Warn before executing destructive statements. Default: `true`.
     pub destructive_warning: bool,
+    /// Additional SQL patterns that should trigger a destructive-operation
+    /// warning, in addition to the built-in set.
+    ///
+    /// Each entry is a substring that is matched case-insensitively against
+    /// the full SQL text.  If the SQL contains the pattern, the user is
+    /// prompted for confirmation just like a built-in destructive statement.
+    ///
+    /// ```toml
+    /// [safety]
+    /// protected_patterns = ["DELETE FROM audit_log", "TRUNCATE events"]
+    /// ```
+    #[serde(default)]
+    pub protected_patterns: Vec<String>,
 }
 
 impl Default for SafetyConfig {
     fn default() -> Self {
         Self {
             destructive_warning: true,
+            protected_patterns: Vec::new(),
         }
     }
 }
@@ -436,6 +450,15 @@ fn merge_config(base: Config, overlay: Config) -> Config {
         },
         safety: SafetyConfig {
             destructive_warning: overlay.safety.destructive_warning,
+            protected_patterns: {
+                let mut merged = base.safety.protected_patterns;
+                for p in overlay.safety.protected_patterns {
+                    if !merged.contains(&p) {
+                        merged.push(p);
+                    }
+                }
+                merged
+            },
         },
         ai: AiConfig {
             provider: overlay.ai.provider.or(base.ai.provider),
@@ -768,6 +791,7 @@ dbname = "testdb"
             },
             safety: SafetyConfig {
                 destructive_warning: true,
+                ..SafetyConfig::default()
             },
             ai: AiConfig::default(),
             governance: GovernanceConfig::default(),
@@ -784,6 +808,7 @@ dbname = "testdb"
             },
             safety: SafetyConfig {
                 destructive_warning: false,
+                ..SafetyConfig::default()
             },
             ai: AiConfig::default(),
             governance: GovernanceConfig::default(),

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1307,8 +1307,15 @@ pub async fn execute_query(
     // WHERE, etc.  In non-interactive mode the check is skipped automatically
     // inside `confirm_destructive`.
     if settings.safety_enabled {
-        if let Some(reason) = crate::safety::is_destructive(sql_to_send) {
-            if !crate::safety::confirm_destructive(reason) {
+        let built_in = crate::safety::is_destructive(sql_to_send).map(str::to_owned);
+        let custom = crate::safety::matches_custom_pattern(
+            sql_to_send,
+            &settings.config.safety.protected_patterns,
+        )
+        .map(|s| format!("matches protected pattern: {s}"));
+        let reason = built_in.or(custom);
+        if let Some(ref r) = reason {
+            if !crate::safety::confirm_destructive(r) {
                 eprintln!("Statement cancelled.");
                 return true; // skipped — not an error
             }
@@ -1521,8 +1528,15 @@ pub async fn execute_query_extended(
 
     // Destructive statement guard.
     if settings.safety_enabled {
-        if let Some(reason) = crate::safety::is_destructive(sql_to_send) {
-            if !crate::safety::confirm_destructive(reason) {
+        let built_in = crate::safety::is_destructive(sql_to_send).map(str::to_owned);
+        let custom = crate::safety::matches_custom_pattern(
+            sql_to_send,
+            &settings.config.safety.protected_patterns,
+        )
+        .map(|s| format!("matches protected pattern: {s}"));
+        let reason = built_in.or(custom);
+        if let Some(ref r) = reason {
+            if !crate::safety::confirm_destructive(r) {
                 eprintln!("Statement cancelled.");
                 return true; // skipped — not an error
             }

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -30,6 +30,26 @@ pub fn is_destructive(sql: &str) -> Option<&'static str> {
     None
 }
 
+/// Check whether `sql` matches any of the user-supplied `protected_patterns`.
+///
+/// Each pattern is compared case-insensitively as a substring of the full SQL
+/// text (after collapsing runs of whitespace to single spaces).  Returns
+/// `Some(pattern)` for the first matching pattern, or `None` when no pattern
+/// matches or the list is empty.
+pub fn matches_custom_pattern<'a>(sql: &str, patterns: &'a [String]) -> Option<&'a str> {
+    if patterns.is_empty() {
+        return None;
+    }
+    let normalised = sql.split_whitespace().collect::<Vec<_>>().join(" ");
+    let lower_sql = normalised.to_lowercase();
+    for pattern in patterns {
+        if lower_sql.contains(pattern.to_lowercase().as_str()) {
+            return Some(pattern.as_str());
+        }
+    }
+    None
+}
+
 /// Check a single SQL statement (no semicolons) for destructive patterns.
 fn check_segment(sql: &str) -> Option<&'static str> {
     let trimmed = sql.trim();
@@ -331,5 +351,46 @@ mod tests {
     #[test]
     fn multi_statement_all_safe() {
         assert_eq!(is_destructive("select 1; select 2;"), None);
+    }
+
+    // -- matches_custom_pattern ----------------------------------------------
+
+    #[test]
+    fn custom_pattern_matches_substring() {
+        let patterns = vec!["DELETE FROM audit_log".to_owned()];
+        assert_eq!(
+            matches_custom_pattern("delete from audit_log where id = 1", &patterns),
+            Some("DELETE FROM audit_log"),
+        );
+    }
+
+    #[test]
+    fn custom_pattern_no_match_on_unrelated_sql() {
+        let patterns = vec!["DELETE FROM audit_log".to_owned()];
+        assert_eq!(
+            matches_custom_pattern("delete from orders where id = 1", &patterns),
+            None,
+        );
+    }
+
+    #[test]
+    fn custom_pattern_empty_list_has_no_effect() {
+        assert_eq!(matches_custom_pattern("delete from audit_log", &[]), None,);
+    }
+
+    #[test]
+    fn custom_pattern_case_insensitive() {
+        let patterns = vec!["delete from audit_log".to_owned()];
+        // All-uppercase SQL should still match a lowercase pattern.
+        assert_eq!(
+            matches_custom_pattern("DELETE FROM AUDIT_LOG WHERE id = 1", &patterns),
+            Some("delete from audit_log"),
+        );
+        // Mixed-case pattern against mixed-case SQL.
+        let patterns2 = vec!["Delete From Audit_Log".to_owned()];
+        assert_eq!(
+            matches_custom_pattern("delete from audit_log where id = 1", &patterns2),
+            Some("Delete From Audit_Log"),
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `protected_patterns: Vec<String>` field to `SafetyConfig` in `src/config.rs`, deserialized with `#[serde(default)]` so existing configs are unaffected
- Adds `matches_custom_pattern(sql, patterns)` in `src/safety.rs` that does case-insensitive substring matching after normalising whitespace
- Both SQL execution paths in `src/repl.rs` (simple-query and bind-param) now check custom patterns when `safety_enabled` is true, with a message like `"matches protected pattern: <pattern>"`
- `merge_config` unions base + overlay `protected_patterns` lists (deduped)

## Test plan

- [x] `custom_pattern_matches_substring` — "DELETE FROM audit_log" pattern matches `delete from audit_log where id = 1`
- [x] `custom_pattern_no_match_on_unrelated_sql` — same pattern does not match a different table
- [x] `custom_pattern_empty_list_has_no_effect` — empty slice returns `None`
- [x] `custom_pattern_case_insensitive` — upper-case SQL matches lower-case pattern and vice-versa
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (1265 tests)

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)