### PR TITLE
feat(repl): add \refresh command to reload schema cache

### DIFF
--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -297,6 +297,10 @@ pub enum MetaCmd {
     /// `\profiles` — list all configured connection profiles.
     ListProfiles,
 
+    // -- Schema cache (#301) -----------------------------------------------
+    /// `\refresh` — reload the schema cache for tab completion.
+    RefreshSchema,
+
     // -- Session persistence (#247) ----------------------------------------
     /// `\session list` — show recent sessions.
     SessionList,
@@ -1127,6 +1131,12 @@ fn parse_o(input: &str) -> ParsedMeta {
 /// `\qecho` here as a special prefix-matched command reached from the `q`
 /// branch — wait, `\qecho` starts with `q`. This function is for `\r` only.
 fn parse_r_family(input: &str) -> ParsedMeta {
+    // `\refresh` — reload schema cache (check before bare `\r`).
+    if let Some(rest) = input.strip_prefix("refresh") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            return ParsedMeta::simple(MetaCmd::RefreshSchema);
+        }
+    }
     // `\r` — bare reset
     if let Some(rest) = input.strip_prefix('r') {
         if rest.is_empty() || rest.starts_with(char::is_whitespace) {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -999,6 +999,12 @@ pub struct ReplSettings {
     /// by querying `current_setting('is_superuser')`.  Controls whether the
     /// prompt shows `#` (superuser) or `>` (regular user).
     pub is_superuser: bool,
+    /// Shared schema cache for tab completion.
+    ///
+    /// `None` in non-interactive paths (e.g. `-c`, `-f`, piped stdin).
+    /// Set to `Some(...)` by the readline loop so that `\refresh` can
+    /// update the same `Arc` that the completion helper holds.
+    pub schema_cache: Option<Arc<RwLock<SchemaCache>>>,
 }
 
 impl std::fmt::Debug for ReplSettings {
@@ -1064,6 +1070,10 @@ impl std::fmt::Debug for ReplSettings {
             .field("session_id", &self.session_id)
             .field("query_count", &self.query_count)
             .field("is_superuser", &self.is_superuser)
+            .field(
+                "schema_cache",
+                &self.schema_cache.as_ref().map(|_| "<cache>"),
+            )
             .finish()
     }
 }
@@ -1111,6 +1121,7 @@ impl Default for ReplSettings {
             session_id: crate::session_store::new_session_id(),
             query_count: 0,
             is_superuser: false,
+            schema_cache: None,
         }
     }
 }
@@ -4193,6 +4204,20 @@ async fn dispatch_meta(
         MetaCmd::InteractiveMode => {
             return MetaResult::SetExecMode(ExecMode::Interactive);
         }
+        MetaCmd::RefreshSchema => match &settings.schema_cache {
+            None => {
+                eprintln!("\\refresh: no active connection or not in interactive mode");
+            }
+            Some(cache) => match load_schema_cache(client).await {
+                Ok(loaded) => {
+                    *cache.write().unwrap() = loaded;
+                    println!("Schema cache refreshed.");
+                }
+                Err(e) => {
+                    eprintln!("\\refresh: failed to reload schema cache: {e}");
+                }
+            },
+        },
         MetaCmd::Unknown(ref name) => {
             eprintln!("Invalid command \\{name}. Try \\? for help.");
         }
@@ -4703,6 +4728,9 @@ async fn run_readline_loop(
             }
         }
     }
+    // Store the Arc in settings so `\refresh` can update the same cache
+    // that the completion helper holds.
+    settings.schema_cache = Some(Arc::clone(&cache));
     // Enable syntax highlighting unless the user opted out or $TERM is dumb.
     let highlight = !settings.no_highlight && std::env::var("TERM").as_deref() != Ok("dumb");
     let helper = SamoHelper::new(Arc::clone(&cache), highlight);


### PR DESCRIPTION
## Summary

- Adds `MetaCmd::RefreshSchema` variant to `metacmd.rs`
- Parses `\refresh` in `parse_r_family` before bare `\r` (longest-match wins, no conflict)
- Adds `schema_cache: Option<Arc<RwLock<SchemaCache>>>` to `ReplSettings` so the same Arc shared with the rustyline completion helper is accessible from `dispatch_meta`
- Sets `settings.schema_cache` in `run_readline_loop` after the cache is initialised
- Handles `MetaCmd::RefreshSchema` in `dispatch_meta`: calls `load_schema_cache`, writes the fresh cache into the shared Arc, and prints "Schema cache refreshed." on success; prints an error on failure or when no interactive cache is available (non-interactive `-c`/`-f` paths)

## Test plan

- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo test` passes (1261 tests)
- [ ] Manual: connect to a Postgres instance, create a new table, run `\refresh`, verify the new table name appears in tab completion
- [ ] Manual: `\r` still resets the query buffer (no regression)
- [ ] Manual: `\refresh` in a non-interactive context (`-c '\refresh'`) prints the "not in interactive mode" message

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)