### PR TITLE
fix(ai): suppress LLM commentary in text2sql mode

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -9706,7 +9706,11 @@ mod tests {
 
         // Both surrounding text segments are present and would be suppressed
         // by the InputMode::Text2Sql guard in handle_ai_ask().
-        assert_eq!(text_segs.len(), 2, "expected two suppressible text segments");
+        assert_eq!(
+            text_segs.len(),
+            2,
+            "expected two suppressible text segments"
+        );
         assert_eq!(sql_segs.len(), 1, "expected one SQL segment");
         assert_eq!(sql_segs[0].1, "select count(*) from users;");
     }


### PR DESCRIPTION
## Summary

- In `text2sql` mode, LLM text segments (commentary, explanations) are now silently dropped; only SQL query results are shown.
- The system prompt sent to the LLM is augmented with a strict instruction to output SQL only when in `text2sql` mode, reducing the chance of commentary appearing in the first place.
- Adds a unit test (`text2sql_response_contains_suppressible_text_segments`) verifying that mixed responses parse into the expected text/SQL segments.

## Root cause

`handle_ai_ask()` unconditionally printed every `AiResponseSegment::Text` item regardless of input mode.

## Changes

`src/repl.rs` — `handle_ai_ask()`:
1. Text-segment guard: skip `println!` when `settings.input_mode == InputMode::Text2Sql`.
2. System-prompt injection: appends `IMPORTANT: You are in text2sql mode. Output ONLY the SQL...` when in text2sql mode.
3. New unit test for the segment-level suppression behaviour.

## Test plan

- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 1291 passed, 0 failed (new test included)
- [ ] Manual: `\text2sql`, type "how many users?" — confirm no LLM commentary appears around the result set

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)