### PR TITLE
feat(repl): add Vi/Emacs keybinding mode toggle

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,16 @@ pub struct DisplayConfig {
     pub pager_min_lines: usize,
     /// Table border style (`0`, `1`, or `2`). Mirrors `\pset border`. Default: `1`.
     pub border: u8,
+    /// Use Vi keybinding mode in the REPL. Default: `false` (Emacs mode).
+    ///
+    /// When `true`, rustyline uses `EditMode::Vi` instead of the default
+    /// Emacs mode.  Takes effect on the next session start.
+    ///
+    /// ```toml
+    /// [display]
+    /// vi_mode = true
+    /// ```
+    pub vi_mode: bool,
 }
 
 impl Default for DisplayConfig {
@@ -103,6 +113,7 @@ impl Default for DisplayConfig {
             expanded: false,
             pager_min_lines: 0,
             border: 1,
+            vi_mode: false,
         }
     }
 }
@@ -485,6 +496,7 @@ fn merge_config(base: Config, overlay: Config) -> Config {
             } else {
                 overlay.display.border
             },
+            vi_mode: overlay.display.vi_mode || base.display.vi_mode,
         },
         safety: SafetyConfig {
             destructive_warning: overlay.safety.destructive_warning,
@@ -596,6 +608,7 @@ mod tests {
         assert!(!cfg.display.expanded);
         assert_eq!(cfg.display.pager_min_lines, 0);
         assert_eq!(cfg.display.border, 1);
+        assert!(!cfg.display.vi_mode); // default is Emacs
         assert!(cfg.safety.destructive_warning);
         assert!(cfg.connection.host.is_none());
         assert!(cfg.connection.port.is_none());
@@ -618,6 +631,51 @@ expanded = true
         assert!(!cfg.display.highlight);
         assert!(cfg.display.timing);
         assert!(cfg.display.expanded);
+    }
+
+    #[test]
+    fn parse_display_vi_mode() {
+        let toml_str = r"
+[display]
+vi_mode = true
+";
+        let cfg: Config = toml::from_str(toml_str).expect("should parse");
+        assert!(cfg.display.vi_mode);
+    }
+
+    #[test]
+    fn merge_display_vi_mode_overlay_wins() {
+        let base = Config {
+            display: DisplayConfig {
+                vi_mode: false,
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        let overlay = Config {
+            display: DisplayConfig {
+                vi_mode: true,
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        let merged = merge_config(base, overlay);
+        assert!(merged.display.vi_mode);
+    }
+
+    #[test]
+    fn merge_display_vi_mode_base_preserved_when_overlay_false() {
+        let base = Config {
+            display: DisplayConfig {
+                vi_mode: true,
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        // overlay has vi_mode = false (default) → OR-merge keeps base true.
+        let overlay = Config::default();
+        let merged = merge_config(base, overlay);
+        assert!(merged.display.vi_mode);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,6 +502,7 @@ fn build_settings(cli: &Cli, cfg: &config::Config) -> repl::ReplSettings {
     let pager_enabled = cfg.display.pager;
     let timing = cfg.display.timing;
     let safety_enabled = cfg.safety.destructive_warning;
+    let vi_mode = cfg.display.vi_mode;
 
     // Apply config display.border default if it wasn't set via -P border=N.
     // The CLI -P args were already applied above via apply_cli_pset; if
@@ -545,6 +546,7 @@ fn build_settings(cli: &Cli, cfg: &config::Config) -> repl::ReplSettings {
         pager_min_lines,
         timing,
         safety_enabled,
+        vi_mode,
         config: cfg.clone(),
         exec_mode: if cli.yolo {
             repl::ExecMode::Yolo

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, RwLock};
 
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
-use rustyline::{Config, Editor};
+use rustyline::{Config, EditMode, Editor};
 use tokio_postgres::Client;
 
 use crate::complete::{load_schema_cache, SamoHelper, SchemaCache};
@@ -977,6 +977,13 @@ pub struct ReplSettings {
     /// When `true`, SQLSTATE codes are appended to error output.
     /// Defaults to `false` (psql default).
     pub verbose_errors: bool,
+    /// Use Vi keybinding mode in the REPL.
+    ///
+    /// Defaults to `false` (Emacs mode).  Set with `\set VI on`.
+    /// rustyline does not support changing `EditMode` on an existing editor
+    /// instance, so this preference is stored here and applied at the next
+    /// session start via [`run_readline_loop`].
+    pub vi_mode: bool,
     /// Path of the currently-executing script file, if any.
     ///
     /// Set whenever a file is being processed via `\i`, `\ir`, or `-f`.
@@ -1066,6 +1073,7 @@ impl std::fmt::Debug for ReplSettings {
             .field("db_capabilities", &self.db_capabilities)
             .field("i_know_what_im_doing", &self.i_know_what_im_doing)
             .field("verbose_errors", &self.verbose_errors)
+            .field("vi_mode", &self.vi_mode)
             .field("current_file", &self.current_file)
             .field("session_id", &self.session_id)
             .field("query_count", &self.query_count)
@@ -1117,6 +1125,7 @@ impl Default for ReplSettings {
             db_capabilities: crate::capabilities::DbCapabilities::default(),
             i_know_what_im_doing: false,
             verbose_errors: false,
+            vi_mode: false,
             current_file: None,
             session_id: crate::session_store::new_session_id(),
             query_count: 0,
@@ -3134,6 +3143,21 @@ fn apply_set(settings: &mut ReplSettings, name: &str, value: &str) {
         settings.config.ai.model = Some(value.to_owned());
         println!("AI model set to: {value}");
     }
+    // Mirror VI into vi_mode.
+    //
+    // rustyline does not support changing EditMode at runtime on an existing
+    // Editor instance, so we store the preference and apply it on the next
+    // session start.
+    if name == "VI" {
+        let on = matches!(value, "on" | "true" | "1");
+        settings.vi_mode = on;
+        settings.config.display.vi_mode = on;
+        if on {
+            println!("Vi mode enabled. Takes effect on next session.");
+        } else {
+            println!("Emacs mode (default). Takes effect on next session.");
+        }
+    }
 }
 
 /// Apply an `\unset` command.
@@ -4785,10 +4809,16 @@ async fn run_readline_loop(
     settings: &mut ReplSettings,
     tx: &mut TxState,
 ) -> i32 {
+    let edit_mode = if settings.vi_mode || settings.config.display.vi_mode {
+        EditMode::Vi
+    } else {
+        EditMode::Emacs
+    };
     let config = Config::builder()
         .max_history_size(HISTORY_SIZE)
         .expect("valid history size")
         .history_ignore_space(true)
+        .edit_mode(edit_mode)
         .build();
 
     // Build schema cache (best-effort — completion degrades gracefully on
@@ -8539,6 +8569,33 @@ mod tests {
         assert!(settings.config.ai.model.is_some());
         apply_unset(&mut settings, "AI_MODEL");
         assert!(settings.config.ai.model.is_none());
+    }
+
+    // -- \set VI ---------------------------------------------------------------
+
+    #[test]
+    fn set_vi_on_enables_vi_mode() {
+        let mut settings = ReplSettings::default();
+        assert!(!settings.vi_mode);
+        apply_set(&mut settings, "VI", "on");
+        assert!(settings.vi_mode);
+        assert!(settings.config.display.vi_mode);
+    }
+
+    #[test]
+    fn set_vi_off_disables_vi_mode() {
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "VI", "on");
+        assert!(settings.vi_mode);
+        apply_set(&mut settings, "VI", "off");
+        assert!(!settings.vi_mode);
+        assert!(!settings.config.display.vi_mode);
+    }
+
+    #[test]
+    fn set_vi_default_is_emacs() {
+        let settings = ReplSettings::default();
+        assert!(!settings.vi_mode);
     }
 
     // -- \gexec parser ---------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `\set VI on|off` REPL command to toggle between Vi and Emacs editing modes
- Add `vi_mode: bool` to `ReplSettings` (default `false` = Emacs)
- Add `vi_mode: bool` to `DisplayConfig` in `config.toml` for persistent config
- Apply `EditMode::Vi` / `EditMode::Emacs` at rustyline editor creation time
- Print a note that the change takes effect on the next session (rustyline limitation)

## Details

rustyline does not support changing `EditMode` at runtime on an existing `Editor`
instance. The preference is stored in `settings.vi_mode` and `settings.config.display.vi_mode`
and applied when `run_readline_loop` builds the rustyline `Config`.

`\set VI on` prints: `Vi mode enabled. Takes effect on next session.`
`\set VI off` prints: `Emacs mode (default). Takes effect on next session.`

The config file option (`[display] vi_mode = true`) is loaded at startup and
applied immediately (same session).

## Test plan

- [x] `set_vi_on_enables_vi_mode` — `\set VI on` sets both `settings.vi_mode` and `settings.config.display.vi_mode`
- [x] `set_vi_off_disables_vi_mode` — `\set VI off` clears both flags
- [x] `set_vi_default_is_emacs` — default is `false`
- [x] `parse_display_vi_mode` — TOML `[display] vi_mode = true` parses correctly
- [x] `merge_display_vi_mode_overlay_wins` — overlay `true` overrides base `false`
- [x] `merge_display_vi_mode_base_preserved_when_overlay_false` — base `true` preserved when overlay is default
- [x] All 1306 existing tests pass
- [x] `cargo clippy -- -D warnings` clean

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)