### PR TITLE
Add skill specification v0.2 (s2.md)

### DIFF
--- a/s2.md
+++ b/s2.md
@@ -1,0 +1,1251 @@
+# SAMO Skill Specification v0.2
+
+## Design Principles
+
+1. **Markdown is the interface.** Playbooks, actions, and docs are all markdown files.
+   The playbook IS the documentation. When it lands in a GitHub Issue, it reads naturally.
+   Contributing a skill means writing markdown and SQL — nothing else.
+2. **SQL-first analysis.** Analyzers are plain SQL files. Any DBA can read, audit, and
+   contribute without learning a framework.
+3. **Actions are enumerated.** Every possible mutation is declared upfront. The user sees
+   exactly what a skill can do before installing it.
+4. **The LLM reasons, the skill defines.** The AI layer selects skills, interprets findings,
+   and explains recommendations. But analysis queries and action templates are deterministic
+   SQL — not LLM-generated.
+5. **Progressive trust.** Start readonly. Earn trust through audit trail. Graduate to
+   human-in-loop, then auto. Never skip steps.
+
+## Runtime
+
+- **Language:** TypeScript
+- **Runtime:** Bun
+- **Postgres client:** postgres.js (porsager/postgres) or pg
+- **Why Bun:** Fast startup for CLI, native TypeScript, good for both daemon and interactive
+
+---
+
+## Skill Directory Structure
+
+```
+skills/
+  index-health/
+    SKILL.md                  # Manifest (required)
+    analyzers/
+      invalid-indexes.sql
+      unused-indexes.sql
+      redundant-indexes.sql
+      bloated-indexes.sql
+    actions/
+      reindex.md
+      create-index.md
+      drop-index.md
+    playbooks/
+      invalid-index-found.md
+      unused-index-cleanup.md
+    tests/
+      verify-index-valid.sql
+      verify-index-used.sql
+
+  rca-ash/
+    SKILL.md
+    analyzers/
+      detect-spike.sql
+      lock-contention.sql
+      io-bottleneck.sql
+      connection-saturation.sql
+    actions/
+      cancel-query.md
+      terminate-backend.md
+      set-timeout-guc.md
+    playbooks/
+      spike-response.md
+      lock-contention-response.md
+```
+
+---
+
+## SKILL.md — Manifest
+
+The manifest is a markdown file with YAML frontmatter. The body is human-readable
+description that doubles as the skill's README.
+
+```markdown
+---
+name: index-health
+version: 0.1.0
+author: postgres-ai
+license: MIT
+pg_version: ">=13"
+requires_extensions: []
+optional_extensions: [hypopg]
+requires_stats:
+  - pg_stat_user_indexes
+  - pg_stat_user_tables
+  - pg_stat_statements
+requires_roles:
+  analyzer: [pg_read_all_stats]
+  actor:
+    reindex: [INDEX on target table]
+    create_index: [CREATE on target schema]
+    drop_index: [INDEX on target table]
+tags: [indexes, performance, maintenance]
+---
+
+# Index Health
+
+Detects invalid, unused, redundant, and missing indexes.
+Recommends and optionally executes index maintenance operations.
+
+## What it checks
+
+- **Invalid indexes** — failed `CREATE INDEX CONCURRENTLY` that still occupy space
+  and slow down writes but are never used for queries. Critical if backing a unique
+  constraint (uniqueness is not enforced while index is invalid).
+- **Unused indexes** — zero scans since last stats reset. Waste disk space and
+  slow down every INSERT/UPDATE/DELETE.
+- **Redundant indexes** — left-prefix duplicates (e.g., `idx(a)` is redundant
+  if `idx(a, b)` exists).
+
+## Actions available
+
+| Action | Default level | Description |
+|--------|---------------|-------------|
+| reindex | human-in-loop | Rebuild invalid or bloated indexes |
+| create-index | human-in-loop | Create recommended missing indexes |
+| drop-index | readonly | Remove unused/redundant indexes |
+```
+
+---
+
+## Analyzer SQL Files
+
+Each analyzer is a standalone SQL file. SAMO expects specific column conventions
+in the result set. Metadata lives in SQL comments with `samo:` prefix.
+
+```sql
+-- analyzers/invalid-indexes.sql
+--
+-- samo:schedule: every 1h
+-- samo:severity: critical
+-- samo:description: Detects indexes marked as invalid (failed CREATE INDEX CONCURRENTLY)
+
+SELECT
+  n.nspname                             AS schema_name,
+  c.relname                             AS table_name,
+  i.relname                             AS index_name,
+  pg_size_pretty(pg_relation_size(i.oid)) AS index_size,
+  pg_relation_size(i.oid)               AS index_size_bytes,
+  ix.indisvalid                         AS is_valid,
+  ix.indisready                         AS is_ready,
+  ix.indisunique                        AS is_unique,
+  ix.indisprimary                       AS is_primary,
+  pg_get_indexdef(ix.indexrelid)         AS index_def,
+  -- samo conventions: finding_type, confidence, explanation
+  'invalid_index'                       AS finding_type,
+  1.0                                   AS confidence,
+  format(
+    E'Index `%I.%I` on `%I.%I` is **invalid** (size: %s). '
+    'This typically means `CREATE INDEX CONCURRENTLY` failed mid-way. '
+    'The index occupies disk space and slows down writes but is never used for queries.',
+    n.nspname, i.relname, n.nspname, c.relname,
+    pg_size_pretty(pg_relation_size(i.oid))
+  )                                     AS explanation
+FROM pg_index ix
+  JOIN pg_class c ON c.oid = ix.indrelid
+  JOIN pg_class i ON i.oid = ix.indexrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE
+  NOT ix.indisvalid
+  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast');
+```
+
+```sql
+-- analyzers/unused-indexes.sql
+--
+-- samo:schedule: daily 06:00
+-- samo:severity: warning
+-- samo:description: Indexes with zero scans since last stats reset
+-- samo:min_stats_age: 7d
+
+SELECT
+  n.nspname                             AS schema_name,
+  c.relname                             AS table_name,
+  i.relname                             AS index_name,
+  pg_size_pretty(pg_relation_size(i.oid)) AS index_size,
+  pg_relation_size(i.oid)               AS index_size_bytes,
+  s.idx_scan                            AS scan_count,
+  ix.indisunique                        AS is_unique,
+  ix.indisprimary                       AS is_primary,
+  pg_get_indexdef(ix.indexrelid)         AS index_def,
+  CASE
+    WHEN ix.indisprimary THEN 'skip'
+    WHEN ix.indisunique THEN 'investigate'
+    ELSE 'candidate_for_drop'
+  END                                   AS recommendation,
+  'unused_index'                        AS finding_type,
+  CASE
+    WHEN ix.indisprimary THEN 0.0
+    WHEN ix.indisunique THEN 0.3
+    ELSE 0.9
+  END                                   AS confidence,
+  format(
+    E'Index `%I.%I` on `%I.%I` has **%s scans** since stats reset. Size: %s.',
+    n.nspname, i.relname, n.nspname, c.relname,
+    s.idx_scan,
+    pg_size_pretty(pg_relation_size(i.oid))
+  )                                     AS explanation
+FROM pg_stat_user_indexes s
+  JOIN pg_index ix ON ix.indexrelid = s.indexrelid
+  JOIN pg_class c ON c.oid = ix.indrelid
+  JOIN pg_class i ON i.oid = ix.indexrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE
+  s.idx_scan = 0
+  AND NOT ix.indisprimary
+ORDER BY pg_relation_size(i.oid) DESC;
+```
+
+```sql
+-- analyzers/redundant-indexes.sql
+--
+-- samo:schedule: weekly
+-- samo:severity: info
+-- samo:description: Indexes that are left-prefixed duplicates of other indexes
+
+WITH index_cols AS (
+  SELECT
+    ix.indexrelid,
+    ix.indrelid,
+    n.nspname                           AS schema_name,
+    ci.relname                          AS index_name,
+    ct.relname                          AS table_name,
+    pg_get_indexdef(ix.indexrelid)       AS index_def,
+    pg_relation_size(ci.oid)            AS index_size,
+    array_agg(a.attname ORDER BY k.n)   AS columns,
+    ix.indisunique,
+    ix.indisprimary,
+    ix.indpred IS NOT NULL              AS is_partial,
+    pg_get_expr(ix.indpred, ix.indrelid) AS predicate
+  FROM pg_index ix
+    JOIN pg_class ci ON ci.oid = ix.indexrelid
+    JOIN pg_class ct ON ct.oid = ix.indrelid
+    JOIN pg_namespace n ON n.oid = ct.relnamespace
+    CROSS JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, n)
+    JOIN pg_attribute a ON a.attrelid = ix.indrelid AND a.attnum = k.attnum
+  WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+  GROUP BY ix.indexrelid, ix.indrelid, n.nspname, ci.relname, ct.relname,
+           ix.indisunique, ix.indisprimary, ix.indpred
+)
+SELECT
+  a.schema_name,
+  a.table_name,
+  a.index_name                          AS redundant_index,
+  a.index_def                           AS redundant_index_def,
+  pg_size_pretty(a.index_size)          AS redundant_index_size,
+  a.index_size                          AS redundant_index_size_bytes,
+  b.index_name                          AS covering_index,
+  b.index_def                           AS covering_index_def,
+  'redundant_index'                     AS finding_type,
+  CASE
+    WHEN a.is_partial != b.is_partial THEN 0.3
+    WHEN a.indisunique AND NOT b.indisunique THEN 0.2
+    ELSE 0.85
+  END                                   AS confidence,
+  format(
+    E'Index `%I` is a **left-prefix duplicate** of `%I` on `%I.%I`. '
+    'The smaller index wastes %s of disk space plus write overhead.',
+    a.index_name, b.index_name,
+    a.schema_name, a.table_name,
+    pg_size_pretty(a.index_size)
+  )                                     AS explanation
+FROM index_cols a
+  JOIN index_cols b
+    ON a.indrelid = b.indrelid
+    AND a.indexrelid != b.indexrelid
+    AND a.columns = b.columns[1:array_length(a.columns, 1)]
+    AND array_length(a.columns, 1) < array_length(b.columns, 1)
+WHERE NOT a.indisprimary
+ORDER BY a.index_size DESC;
+```
+
+---
+
+## Action Markdown Files
+
+Actions are markdown files with YAML frontmatter for machine-readable config
+and a markdown body that becomes the human-readable explanation in GitHub Issues.
+
+```markdown
+<!-- actions/reindex.md -->
+---
+name: reindex
+default_level: human-in-loop
+severity: medium
+requires_privileges:
+  - INDEX on {schema_name}.{table_name}
+---
+
+# Reindex: `{schema_name}.{index_name}`
+
+Rebuild index to fix invalid state or reduce bloat.
+
+## Pre-flight checks
+
+- [ ] Index exists and is on a user table
+- [ ] Not during peak hours (active connections < 70% of max)
+- [ ] Using CONCURRENTLY (PG >= 12)
+- [ ] Index size < 10 GB (otherwise escalate to human-in-loop)
+
+## SQL
+
+```sql
+REINDEX INDEX CONCURRENTLY {schema_name}.{index_name};
+```
+
+## Verify
+
+```sql
+SELECT indisvalid, indisready
+FROM pg_index
+WHERE indexrelid = '{schema_name}.{index_name}'::regclass;
+```
+
+Expected: `indisvalid = true AND indisready = true`
+
+## If verification fails
+
+REINDEX completed but index is still invalid.
+Recommendation: DROP INDEX CONCURRENTLY and recreate from definition.
+Escalating to human review.
+
+## Constraints
+
+| Constraint | Condition | On violation |
+|------------|-----------|--------------|
+| use_concurrently | pg_version >= 12 | force human-in-loop |
+| table_size_limit | index_size_bytes > 10 GB | force human-in-loop |
+| no_peak_hours | active_pct > 70% | defer (retry later) |
+```
+
+```markdown
+<!-- actions/create-index.md -->
+---
+name: create-index
+default_level: human-in-loop
+severity: medium
+requires_privileges:
+  - CREATE on {schema_name}
+---
+
+# Create Index: `{index_name}`
+
+Create a new index to improve query performance.
+
+## Pre-flight checks
+
+- [ ] Using CONCURRENTLY (mandatory — reject without it)
+- [ ] No equivalent index already exists on the same columns
+- [ ] Index name follows convention (`idx_*`)
+- [ ] Not during peak hours
+
+## SQL
+
+```sql
+{index_definition};
+```
+
+## Verify
+
+```sql
+SELECT indisvalid, indisready
+FROM pg_index
+WHERE indexrelid = '{schema_name}.{index_name}'::regclass;
+```
+
+Expected: `indisvalid = true AND indisready = true`
+
+## If verification fails
+
+CREATE INDEX CONCURRENTLY failed — index is left in invalid state.
+Run `DROP INDEX CONCURRENTLY {schema_name}.{index_name};` to clean up,
+then investigate why the creation failed (disk space? duplicate values
+for unique index?).
+
+## Constraints
+
+| Constraint | Condition | On violation |
+|------------|-----------|--------------|
+| force_concurrently | definition includes CONCURRENTLY | reject |
+| no_duplicate | no equivalent index exists | reject |
+| no_peak_hours | active_pct > 70% | defer |
+```
+
+```markdown
+<!-- actions/drop-index.md -->
+---
+name: drop-index
+default_level: readonly
+severity: high
+requires_privileges:
+  - INDEX on {schema_name}.{table_name}
+---
+
+# Drop Index: `{schema_name}.{index_name}`
+
+Remove an unused or redundant index to reclaim disk space and reduce write overhead.
+
+⚠️ **Default level: readonly** — SAMO will only recommend dropping, never execute
+without explicit policy upgrade. This is intentionally conservative.
+
+## Pre-flight checks
+
+- [ ] Not a primary key index (reject — never drop PK)
+- [ ] Not backing a unique constraint (reject unless explicit override)
+- [ ] Confirm still zero scans at execution time (re-check live)
+- [ ] Using CONCURRENTLY
+
+## SQL
+
+```sql
+DROP INDEX CONCURRENTLY {schema_name}.{index_name};
+```
+
+## Constraints
+
+| Constraint | Condition | On violation |
+|------------|-----------|--------------|
+| not_primary_key | indisprimary = false | reject |
+| not_unique | indisunique = false | reject |
+| verify_unused | idx_scan = 0 at execution time | reject |
+| use_concurrently | always | reject without it |
+```
+
+```markdown
+<!-- actions/cancel-query.md -->
+---
+name: cancel-query
+default_level: human-in-loop
+severity: high
+requires_privileges:
+  - pg_signal_backend
+---
+
+# Cancel Query: PID `{pid}`
+
+Send a cancel signal to a running query. The query will terminate with an error,
+but the connection stays open. This is the **safe** option — the application
+receives a query error and can retry.
+
+## Pre-flight checks
+
+- [ ] PID is a client backend (not replication, not SAMO)
+- [ ] Query has been running for at least {min_duration}
+
+## SQL
+
+```sql
+SELECT pg_cancel_backend({pid});
+```
+
+## Verify
+
+```sql
+SELECT state != 'active' OR pid IS NULL
+FROM pg_stat_activity WHERE pid = {pid};
+```
+
+## If verification fails
+
+`pg_cancel_backend()` did not stop the query. The query may be in a
+non-cancellable state (e.g., waiting on external IO).
+
+Next option: `pg_terminate_backend({pid})` — this will **drop the connection
+entirely**. The application will see a disconnection.
+
+Escalating to human review.
+
+## Constraints
+
+| Constraint | Condition | On violation |
+|------------|-----------|--------------|
+| not_replication | backend_type = 'client backend' | reject |
+| not_samo | usename not in (samo_analyzer, samo_actor) | reject |
+| min_duration | query running > 30s | reject |
+| max_per_hour | cancels this hour < 20 | reject |
+```
+
+```markdown
+<!-- actions/terminate-backend.md -->
+---
+name: terminate-backend
+default_level: human-in-loop
+severity: critical
+requires_privileges:
+  - pg_signal_backend
+---
+
+# Terminate Backend: PID `{pid}`
+
+**⚠️ Destructive action** — this drops the connection entirely. The application
+will see a disconnection error. Use only when `cancel-query` fails or the
+session is idle-in-transaction and unresponsive.
+
+## Pre-flight checks
+
+- [ ] PID is a client backend (not replication, not SAMO)
+- [ ] Session has been problematic for at least {min_duration}
+- [ ] Cancel was already attempted (preferred escalation path)
+
+## SQL
+
+```sql
+SELECT pg_terminate_backend({pid});
+```
+
+## Verify
+
+```sql
+SELECT count(*) = 0
+FROM pg_stat_activity WHERE pid = {pid};
+```
+
+## Constraints
+
+| Constraint | Condition | On violation |
+|------------|-----------|--------------|
+| not_replication | backend_type = 'client backend' | reject |
+| not_samo | usename not in (samo_analyzer, samo_actor) | reject |
+| min_duration | session problematic > 60s | reject |
+| max_per_hour | terminates this hour < 5 | reject |
+| prefer_cancel_first | cancel attempted for this PID | warn |
+```
+
+---
+
+## Playbook Markdown Files
+
+Playbooks are the core of SAMO's response logic. They are markdown files that
+the runtime parses for structured directives while remaining fully readable
+as documentation.
+
+### Parsing conventions
+
+The SAMO runtime scans playbook markdown for these patterns:
+
+- **YAML frontmatter** (`---` block): trigger conditions, metadata
+- **`> [!samo-run]` callouts**: execute an analyzer SQL file
+- **`> [!samo-action]` callouts**: propose/execute an action
+- **`> [!samo-condition]` callouts**: branch based on finding data
+- **`> [!samo-log]` callouts**: record to audit log
+- **Everything else**: human-readable content that flows into GitHub Issues
+
+This means a playbook is simultaneously:
+1. Executable logic for the SAMO runtime
+2. Documentation for the skill
+3. The actual content of the GitHub Issue when findings are reported
+
+### Example: Invalid Index Response
+
+```markdown
+<!-- playbooks/invalid-index-found.md -->
+---
+name: Handle Invalid Index
+trigger:
+  finding_type: invalid_index
+---
+
+# 🔴 Invalid Index Found: `{schema_name}.{index_name}`
+
+Index `{index_name}` on `{schema_name}.{table_name}` is **invalid** ({index_size}).
+
+This typically means `CREATE INDEX CONCURRENTLY` failed partway through.
+The index occupies disk space and slows down every write, but is never
+used for queries.
+
+## Assessment
+
+> [!samo-condition]
+> if: is_unique = true
+> then: goto unique-constraint-at-risk
+
+> [!samo-condition]
+> if: is_unique = false
+> then: goto standard-invalid-index
+
+## Unique constraint at risk {#unique-constraint-at-risk}
+
+🚨 **This index backs a UNIQUE constraint. Uniqueness is NOT being enforced.**
+
+Duplicate values may have been inserted while the index was invalid.
+This requires immediate attention.
+
+### Recommended action
+
+> [!samo-action]
+> action: reindex
+> params:
+>   schema_name: {schema_name}
+>   index_name: {index_name}
+> level: human-in-loop
+> urgency: immediate
+
+After reindex completes, check for duplicates:
+
+```sql
+SELECT {key_columns}, count(*)
+FROM {schema_name}.{table_name}
+GROUP BY {key_columns}
+HAVING count(*) > 1;
+```
+
+> [!samo-log]
+> type: incident
+> severity: critical
+> category: invalid_unique_index
+
+## Standard invalid index {#standard-invalid-index}
+
+This index does not back a constraint. It is safe to either rebuild
+or drop and recreate.
+
+### Recommended action
+
+> [!samo-action]
+> action: reindex
+> params:
+>   schema_name: {schema_name}
+>   index_name: {index_name}
+
+If REINDEX fails, the alternative is:
+
+```sql
+DROP INDEX CONCURRENTLY {schema_name}.{index_name};
+{index_def};
+```
+
+> [!samo-log]
+> type: finding
+> severity: high
+> category: invalid_index
+```
+
+### Example: Spike Response (RCA)
+
+```markdown
+<!-- playbooks/spike-response.md -->
+---
+name: Activity Spike Response
+trigger:
+  finding_type: activity_spike
+  condition: severity IN ('warning', 'critical', 'emergency')
+---
+
+# ⚡ Activity Spike Detected
+
+**{active_sessions} active sessions** — {spike_ratio}x above baseline of {baseline_active}.
+
+| Metric | Value |
+|--------|-------|
+| Active sessions | {active_sessions} |
+| Lock waiters | {lock_waiters} |
+| IO waiters | {io_waiters} |
+| LWLock waiters | {lwlock_waiters} |
+| Connections | {total_connections}/{max_connections} |
+| Severity | {severity} |
+| Classification | {spike_type} |
+
+## Root Cause Analysis
+
+> [!samo-condition]
+> if: spike_type = 'lock_contention'
+> then: goto lock-contention-rca
+
+> [!samo-condition]
+> if: spike_type = 'io_bottleneck'
+> then: goto io-rca
+
+> [!samo-condition]
+> if: spike_type = 'connection_saturation'
+> then: goto connection-rca
+
+> [!samo-condition]
+> if: spike_type = 'cpu_or_query_spike'
+> then: goto query-rca
+
+> [!samo-condition]
+> default: true
+> then: goto general-rca
+
+---
+
+## Lock Contention {#lock-contention-rca}
+
+> [!samo-run]
+> analyzer: lock-contention.sql
+
+### Root Blocker
+
+**PID {blocking_pid}** is blocking **{blocked_count} sessions** for **{blocking_duration_sec}s**.
+
+**State:** `{blocking_state}` | **Wait event:** `{blocking_wait_event}`
+
+```sql
+-- Blocking query:
+{blocking_query}
+```
+
+### 🚨 Immediate Mitigation
+
+> [!samo-condition]
+> if: blocking_duration_sec > 30 AND severity IN ('critical', 'emergency')
+> then: goto cancel-blocker
+
+> [!samo-condition]
+> if: blocking_duration_sec <= 30
+> then: goto monitor-blocker
+
+#### Cancel the blocking query {#cancel-blocker}
+
+> [!samo-action]
+> action: cancel-query
+> params:
+>   pid: {blocking_pid}
+> level: human-in-loop
+> urgency: immediate
+
+This will cancel PID {blocking_pid}'s query. The connection stays open,
+the application receives a query error and can retry.
+
+If cancel doesn't work within 30s, consider terminating:
+
+> [!samo-action]
+> action: terminate-backend
+> params:
+>   pid: {blocking_pid}
+> level: human-in-loop
+> urgency: escalation
+> condition: cancel_failed = true
+
+#### Monitoring (not yet critical) {#monitor-blocker}
+
+Blocker has been active for {blocking_duration_sec}s — monitoring.
+Will escalate to cancel if duration exceeds 60s or blocked count exceeds 20.
+
+### 📋 Short-term Mitigation
+
+After resolving the immediate spike, consider these GUC changes to prevent
+future pile-ups:
+
+**`lock_timeout`** — Limits how long a query waits to acquire a lock.
+Prevents cascading pile-ups when one transaction holds a lock too long.
+
+```sql
+-- Recommended: set per-session in application code
+SET LOCAL lock_timeout = '3s';
+-- Or system-wide (affects all sessions):
+ALTER SYSTEM SET lock_timeout = '5s';
+SELECT pg_reload_conf();
+```
+
+**`idle_in_transaction_session_timeout`** — Kills sessions that sit idle
+inside an open transaction. These hold locks indefinitely.
+
+```sql
+ALTER SYSTEM SET idle_in_transaction_session_timeout = '30s';
+SELECT pg_reload_conf();
+```
+
+**`statement_timeout`** — Safety net to prevent any single query from
+running forever.
+
+```sql
+ALTER SYSTEM SET statement_timeout = '60s';
+SELECT pg_reload_conf();
+```
+
+### 🔧 Long-term Fixes
+
+These require application changes but permanently resolve lock contention patterns:
+
+1. **Use `SKIP LOCKED`** for queue-like access patterns where multiple workers
+   process rows from the same table:
+   ```sql
+   SELECT * FROM jobs
+   WHERE status = 'pending'
+   ORDER BY created_at
+   LIMIT 1
+   FOR UPDATE SKIP LOCKED;
+   ```
+
+2. **Use `SET LOCAL lock_timeout` with retry logic** in your application.
+   Instead of waiting indefinitely for a lock, fail fast and retry:
+   ```python
+   for attempt in range(3):
+       try:
+           with db.transaction():
+               db.execute("SET LOCAL lock_timeout = '3s'")
+               db.execute("UPDATE accounts SET ...")
+               break
+       except LockTimeout:
+           if attempt == 2: raise
+           await sleep(0.1 * (2 ** attempt))  # exponential backoff
+   ```
+
+3. **Break long transactions into smaller units.** The most common cause of
+   lock contention is a single transaction that does too much work while
+   holding row-level locks.
+
+4. **Consider advisory locks** for application-level coordination instead
+   of relying on row-level locks for mutual exclusion.
+
+> [!samo-log]
+> type: incident
+> severity: {severity}
+> category: lock_contention
+> details:
+>   blocking_pid: {blocking_pid}
+>   blocked_count: {blocked_count}
+>   duration_sec: {blocking_duration_sec}
+
+---
+
+## IO Bottleneck {#io-rca}
+
+> [!samo-run]
+> analyzer: io-bottleneck.sql
+
+IO waits are dominating active sessions ({io_waiters}/{active_sessions}).
+
+### Immediate
+
+- Check `pg_stat_bgwriter` for checkpoint frequency spikes
+- Check OS-level IO: `iostat -x 1`, `iotop`
+- Look for sequential scans on large tables (check `pg_stat_user_tables.seq_scan`)
+
+### Short-term
+
+- **`shared_buffers`** — If buffer cache hit ratio < 99%, increase.
+  Check: `SELECT round(100 * blks_hit / (blks_hit + blks_read), 2) FROM pg_stat_database WHERE datname = current_database();`
+- **`effective_io_concurrency`** — Set to 200 for SSDs (default 1 is for spinning disks)
+- **`checkpoint_completion_target`** — Set to 0.9 to spread checkpoint IO
+
+### Long-term
+
+- Add missing indexes (sequential scans on large tables = IO storms)
+- Partition large, frequently-scanned tables
+- Move analytical queries to a read replica
+- Consider `pg_prewarm` for critical tables after restart
+
+> [!samo-log]
+> type: incident
+> severity: {severity}
+> category: io_bottleneck
+
+---
+
+## Connection Saturation {#connection-rca}
+
+> [!samo-run]
+> analyzer: connection-saturation.sql
+
+**{total_connections}/{max_connections}** connections in use ({pct_used}%).
+
+| State | Count |
+|-------|-------|
+| Active | {active_count} |
+| Idle | {idle_count} |
+| Idle in transaction | {idle_in_txn_count} |
+
+### Immediate
+
+- Terminate idle-in-transaction sessions older than 5 min:
+  ```sql
+  SELECT pg_terminate_backend(pid)
+  FROM pg_stat_activity
+  WHERE state = 'idle in transaction'
+    AND state_change < now() - interval '5 minutes';
+  ```
+
+### Short-term
+
+- Deploy **PgBouncer** if not already present
+- Set `idle_in_transaction_session_timeout = '30s'`
+- Reduce application pool sizes (most apps over-provision connections)
+
+### Long-term
+
+- Audit connection pool configuration across all services
+- Set per-role connection limits in `pg_hba.conf`
+- Consider per-service Postgres roles with `CONNECTION LIMIT`
+
+> [!samo-log]
+> type: incident
+> severity: {severity}
+> category: connection_saturation
+
+---
+
+## Query-Driven Spike {#query-rca}
+
+**{active_sessions} active sessions** — mostly CPU-bound (not waiting on locks or IO).
+
+### Immediate
+
+- If one runaway query dominates: consider cancelling it
+- If many copies of the same query: check application for retry storms
+
+### Short-term
+
+- Identify top queries by active count from `pg_stat_activity`
+- Add missing indexes for the offending queries
+- Set `statement_timeout` as a safety net
+
+### Long-term
+
+- Optimize query plans for top offenders
+- Add application-level caching for hot queries
+- Consider read replicas for read-heavy workloads
+
+> [!samo-log]
+> type: incident
+> severity: {severity}
+> category: query_spike
+
+---
+
+## General Elevated Activity {#general-rca}
+
+No single dominant cause identified.
+
+**{active_sessions} active sessions** ({spike_ratio}x baseline).
+Wait event breakdown: Locks={lock_waiters}, IO={io_waiters}, LWLock={lwlock_waiters}.
+
+Collecting full snapshot for offline analysis.
+
+> [!samo-log]
+> type: snapshot
+> severity: {severity}
+> collect: [pg_stat_activity, pg_locks, pg_stat_statements_top50]
+```
+
+---
+
+## RCA Analyzers
+
+```sql
+-- analyzers/detect-spike.sql
+--
+-- samo:schedule: every 10s
+-- samo:severity: dynamic
+-- samo:description: Detects activity spikes by comparing current sessions to baseline
+
+WITH current_activity AS (
+  SELECT
+    count(*) FILTER (WHERE state = 'active')           AS active_sessions,
+    count(*) FILTER (WHERE wait_event_type = 'Lock')   AS lock_waiters,
+    count(*) FILTER (WHERE wait_event_type = 'IO')     AS io_waiters,
+    count(*) FILTER (WHERE wait_event_type = 'LWLock') AS lwlock_waiters,
+    count(*) FILTER (WHERE wait_event IS NOT NULL
+                       AND state = 'active')           AS total_waiters,
+    count(*)                                            AS total_connections,
+    current_setting('max_connections')::int             AS max_connections
+  FROM pg_stat_activity
+  WHERE pid != pg_backend_pid()
+    AND backend_type = 'client backend'
+),
+baseline AS (
+  SELECT coalesce(
+    (SELECT avg(active_count) FROM (
+      SELECT count(*) AS active_count
+      FROM samo_internal.ash_samples  -- pg_ash data if available
+      WHERE sample_time > now() - interval '1 hour'
+        AND sample_time < now() - interval '5 minutes'
+      GROUP BY date_trunc('minute', sample_time)
+    ) t),
+    5.0  -- default baseline if no history
+  ) AS avg_active
+)
+SELECT
+  ca.*,
+  b.avg_active                          AS baseline_active,
+  ca.active_sessions::float / greatest(b.avg_active, 1) AS spike_ratio,
+  CASE
+    WHEN ca.active_sessions <= b.avg_active * 1.5 THEN 'normal'
+    WHEN ca.lock_waiters::float / greatest(ca.active_sessions, 1) > 0.5 THEN 'lock_contention'
+    WHEN ca.io_waiters::float / greatest(ca.active_sessions, 1) > 0.5 THEN 'io_bottleneck'
+    WHEN ca.lwlock_waiters::float / greatest(ca.active_sessions, 1) > 0.3 THEN 'lwlock_contention'
+    WHEN ca.total_connections::float / ca.max_connections > 0.8 THEN 'connection_saturation'
+    WHEN ca.active_sessions > b.avg_active * 3 THEN 'cpu_or_query_spike'
+    ELSE 'elevated_unclassified'
+  END                                   AS spike_type,
+  CASE
+    WHEN ca.active_sessions <= b.avg_active * 1.5 THEN 'normal'
+    WHEN ca.active_sessions <= b.avg_active * 3 THEN 'warning'
+    WHEN ca.active_sessions <= b.avg_active * 5 THEN 'critical'
+    ELSE 'emergency'
+  END                                   AS severity,
+  'activity_spike'                      AS finding_type,
+  CASE
+    WHEN ca.active_sessions <= b.avg_active * 1.5 THEN 0.0
+    ELSE 0.95
+  END                                   AS confidence
+FROM current_activity ca
+CROSS JOIN baseline b;
+```
+
+```sql
+-- analyzers/lock-contention.sql
+--
+-- samo:schedule: on_demand
+-- samo:severity: critical
+-- samo:description: Identifies lock chains and root blockers
+
+WITH RECURSIVE lock_chain AS (
+  SELECT
+    blocked.pid                          AS blocked_pid,
+    blocked.query                        AS blocked_query,
+    blocked.query_start                  AS blocked_since,
+    blocking.pid                         AS blocking_pid,
+    blocking.query                       AS blocking_query,
+    blocking.query_start                 AS blocking_since,
+    blocking.state                       AS blocking_state,
+    blocking.wait_event                  AS blocking_wait_event,
+    1                                    AS depth,
+    ARRAY[blocking.pid]                  AS chain
+  FROM pg_stat_activity blocked
+    JOIN pg_locks bl ON bl.pid = blocked.pid
+    JOIN pg_locks bk ON bk.locktype = bl.locktype
+      AND bk.database IS NOT DISTINCT FROM bl.database
+      AND bk.relation IS NOT DISTINCT FROM bl.relation
+      AND bk.page IS NOT DISTINCT FROM bl.page
+      AND bk.tuple IS NOT DISTINCT FROM bl.tuple
+      AND bk.virtualxid IS NOT DISTINCT FROM bl.virtualxid
+      AND bk.transactionid IS NOT DISTINCT FROM bl.transactionid
+      AND bk.pid != bl.pid
+      AND bk.granted
+    JOIN pg_stat_activity blocking ON blocking.pid = bk.pid
+  WHERE NOT bl.granted
+
+  UNION ALL
+
+  SELECT
+    lc.blocked_pid, lc.blocked_query, lc.blocked_since,
+    bk2.pid, sa2.query, sa2.query_start, sa2.state, sa2.wait_event,
+    lc.depth + 1,
+    lc.chain || bk2.pid
+  FROM lock_chain lc
+    JOIN pg_locks bl2 ON bl2.pid = lc.blocking_pid AND NOT bl2.granted
+    JOIN pg_locks bk2 ON bk2.locktype = bl2.locktype
+      AND bk2.database IS NOT DISTINCT FROM bl2.database
+      AND bk2.relation IS NOT DISTINCT FROM bl2.relation
+      AND bk2.pid != bl2.pid AND bk2.granted
+    JOIN pg_stat_activity sa2 ON sa2.pid = bk2.pid
+  WHERE lc.depth < 10 AND NOT bk2.pid = ANY(lc.chain)
+)
+SELECT
+  blocking_pid,
+  blocking_query,
+  blocking_since,
+  blocking_state,
+  blocking_wait_event,
+  extract(epoch FROM now() - blocking_since)::int AS blocking_duration_sec,
+  count(DISTINCT blocked_pid)           AS blocked_count,
+  max(depth)                            AS max_chain_depth,
+  array_agg(DISTINCT blocked_pid)       AS blocked_pids,
+  'lock_contention_root'                AS finding_type,
+  0.95                                  AS confidence,
+  format(
+    E'**PID %s** is blocking %s sessions for %ss. State: `%s` | Wait: `%s`',
+    blocking_pid, count(DISTINCT blocked_pid),
+    extract(epoch FROM now() - blocking_since)::int,
+    blocking_state, blocking_wait_event
+  )                                     AS explanation
+FROM lock_chain
+GROUP BY blocking_pid, blocking_query, blocking_since, blocking_state, blocking_wait_event
+ORDER BY count(DISTINCT blocked_pid) DESC, blocking_since ASC;
+```
+
+---
+
+## Runtime Parsing Rules
+
+The TypeScript/Bun runtime processes playbook markdown as follows:
+
+### 1. Frontmatter extraction
+
+Standard YAML between `---` fences at the top of the file.
+
+### 2. Directive callouts
+
+SAMO uses GitHub-flavored markdown callout syntax (`> [!type]`) extended
+with `samo-` prefixed types:
+
+```typescript
+// Directive types the runtime recognizes:
+type SamoDirective =
+  | { type: 'samo-run'; analyzer: string }
+  | { type: 'samo-action'; action: string; params: Record<string, string>;
+      level?: AAALevel; urgency?: string; condition?: string }
+  | { type: 'samo-condition'; if?: string; default?: boolean; then: string }
+  | { type: 'samo-log'; logType: string; severity?: string;
+      category?: string; details?: Record<string, string> };
+
+type AAALevel = 'readonly' | 'human-in-loop' | 'auto';
+```
+
+### 3. Template variables
+
+Variables in `{curly_braces}` are substituted from the current finding context.
+The runtime maintains a context object that accumulates data as analyzers run:
+
+```typescript
+interface PlaybookContext {
+  // From the triggering finding
+  finding: Record<string, any>;
+  // Accumulated from samo-run analyzers
+  analyses: Record<string, Record<string, any>[]>;
+  // Action results
+  actions: { name: string; result: 'approved' | 'rejected' | 'pending' | 'executed' | 'failed' }[];
+}
+```
+
+### 4. Section navigation
+
+`goto` targets in `samo-condition` reference heading anchors:
+
+```markdown
+> [!samo-condition]
+> if: spike_type = 'lock_contention'
+> then: goto lock-contention-rca
+
+## Lock Contention {#lock-contention-rca}
+```
+
+The runtime skips to the target section and continues execution from there.
+Sections without a `goto` pointing to them still render in the output
+but their directives don't execute.
+
+### 5. Output generation
+
+When creating a GitHub Issue from a playbook execution:
+
+1. The full markdown renders as the issue body
+2. `samo-condition` blocks that evaluated to false are stripped
+3. `samo-action` blocks render as formatted action proposals with approve/reject controls
+4. `samo-run` blocks are replaced with the analyzer results formatted as markdown tables
+5. Template variables are substituted with actual values
+
+---
+
+## CLI Commands (MVP)
+
+```bash
+# Setup
+samo init                    # Interactive setup: roles, policy, GitHub connection
+samo init --connection "postgres://..." --github myorg/myapp
+
+# Analysis
+samo analyze                 # Run all analyzers once, print findings
+samo analyze --skill index-health  # Run specific skill
+samo analyze --json          # Machine-readable output
+
+# Daemon
+samo daemon                  # Run scheduled analyzers + event detection
+samo daemon --foreground     # Don't daemonize (for Docker/systemd)
+
+# Status
+samo status                  # Current database health snapshot
+samo audit                   # Recent audit log entries
+samo audit --incidents       # Just incidents
+
+# Skills
+samo skills list             # Installed skills
+samo skills install <path|url>  # Install a skill
+samo skills check <name>     # Show what permissions a skill needs
+```
+
+---
+
+## Project Structure (TypeScript/Bun)
+
+```
+samo/
+  package.json
+  bunfig.toml
+  tsconfig.json
+
+  src/
+    cli/
+      index.ts              # Entry point, command routing
+      init.ts               # samo init
+      analyze.ts            # samo analyze
+      daemon.ts             # samo daemon
+      status.ts             # samo status
+      audit.ts              # samo audit
+
+    core/
+      skill-loader.ts       # Parse SKILL.md, load SQL files, parse action/playbook markdown
+      analyzer-runner.ts    # Execute SQL analyzers, collect findings
+      playbook-engine.ts    # Parse and execute playbook markdown
+      action-executor.ts    # Execute action templates with constraint checking
+      policy-engine.ts      # Load policy.yaml, resolve AAA levels per action
+      auditor.ts            # Audit logging, circuit breakers
+
+    integrations/
+      postgres.ts           # Connection management (analyzer pool, actor pool)
+      github.ts             # GitHub Issues: create, poll for approval, update
+      notifications.ts      # Slack, stdout, etc.
+
+    markdown/
+      parser.ts             # Parse SAMO callout directives from markdown
+      renderer.ts           # Render playbook to GitHub Issue markdown
+      template.ts           # Variable substitution in {curly_braces}
+
+    types/
+      index.ts              # All shared types
+
+  skills/                   # Bundled skills (shipped with samo)
+    index-health/
+      SKILL.md
+      analyzers/
+      actions/
+      playbooks/
+    rca-ash/
+      SKILL.md
+      analyzers/
+      actions/
+      playbooks/
+
+  tests/
+    fixtures/               # Test databases, sample findings
+    skills/                 # Skill parsing tests
+    playbooks/              # Playbook execution tests
+    integration/            # End-to-end tests against real PG
+```
+
+---
+
+## MVP Scope
+
+### Ship
+
+- **Runtime:** skill loader, analyzer runner, playbook engine, action executor, policy engine, auditor
+- **CLI:** `samo init`, `samo analyze`, `samo daemon`, `samo status`, `samo audit`
+- **Integrations:** Postgres (two-role model), GitHub Issues (human-in-loop)
+- **Skill: index-health** — analyzers (invalid, unused, redundant), actions (reindex, drop), playbook (invalid index found)
+- **Skill: rca-ash** — analyzers (detect spike, lock contention), actions (cancel query), playbook (spike response, lock branch)
+
+### Skip for MVP
+
+| Feature | Ship in |
+|---------|---------|
+| LLM/AI natural language interface | v0.2 |
+| Interactive CLI / psql replacement | v0.3 |
+| Skill hub / marketplace | v0.4 |
+| Auto mode for destructive actions | v0.2 |
+| CloudWatch / RDS / Supabase specific analyzers | v0.3 |
+| Missing index detection (needs HypoPG/plan analysis) | v0.2 |
+| Slack notifications | v0.2 |
+| Web UI | v0.4+ |
+| Multi-database support | v0.3 |
+| IO/CPU/connection RCA branches (beyond lock contention) | v0.2 |


### PR DESCRIPTION
Adds the SAMO Skill Specification v0.2 — defines the skill/connector architecture:

- **Design principles**: markdown-as-interface, SQL-first analyzers, enumerated actions, progressive trust
- **Skill structure**: SKILL.md manifests, analyzer SQL files, action markdown, playbook markdown
- **Playbook engine**: `samo-run`, `samo-action`, `samo-condition`, `samo-log` callout directives
- **RCA analyzers**: spike detection, lock chain analysis
- **Runtime**: TypeScript/Bun (separate from the Rust CLI binary)
- **MVP scope**: index-health + rca-ash skills, GitHub Issues integration

Note: this spec describes a TypeScript/Bun skill runtime that complements the existing Rust CLI. The Rust binary handles psql-compatible terminal; the skill runtime handles autonomous analysis/action.