### PR TITLE
feat(repl): add persistent status bar (FR-25)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -109,6 +109,18 @@ pub struct DisplayConfig {
     /// vi_mode = true
     /// ```
     pub vi_mode: bool,
+    /// Show the persistent status bar at the bottom of the terminal.
+    ///
+    /// When `true` (the default in interactive sessions), a one-line bar is
+    /// rendered at the bottom of the terminal showing connection info, mode,
+    /// transaction state, query timing, and AI token usage.
+    ///
+    /// Disable with `\set STATUSLINE off` at runtime or:
+    /// ```toml
+    /// [display]
+    /// statusline_enabled = false
+    /// ```
+    pub statusline_enabled: bool,
 }
 
 impl Default for DisplayConfig {
@@ -121,6 +133,8 @@ impl Default for DisplayConfig {
             pager_min_lines: 0,
             border: 1,
             vi_mode: false,
+            // Default ON — overridden to OFF in non-interactive sessions.
+            statusline_enabled: true,
         }
     }
 }
@@ -807,6 +821,9 @@ fn merge_config(base: Config, overlay: Config) -> Config {
                 overlay.display.border
             },
             vi_mode: overlay.display.vi_mode || base.display.vi_mode,
+            // Prefer explicit false from overlay over base default.
+            statusline_enabled: overlay.display.statusline_enabled
+                && base.display.statusline_enabled,
         },
         safety: SafetyConfig {
             destructive_warning: overlay.safety.destructive_warning,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod session;
 mod session_store;
 mod setup;
 mod ssh_tunnel;
+mod statusline;
 mod vars;
 
 // Phase 2/3 infrastructure — compiled but not yet wired into the main

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1057,6 +1057,16 @@ pub struct ReplSettings {
     /// These files are read at AI-call time and appended to the system
     /// prompt so the LLM has project-specific schema and query context.
     pub ai_context_files: Vec<String>,
+
+    // -- Status bar (FR-25) ------------------------------------------------
+    /// Persistent status bar rendered at the bottom of the terminal.
+    ///
+    /// Present only in interactive sessions; `None` in non-interactive paths.
+    pub statusline: Option<crate::statusline::StatusLine>,
+    /// Last query duration in milliseconds (for the status bar).
+    ///
+    /// Updated after each query execution.
+    pub last_query_duration_ms: Option<u64>,
 }
 
 impl std::fmt::Debug for ReplSettings {
@@ -1147,6 +1157,8 @@ impl std::fmt::Debug for ReplSettings {
                 &self.project_context.as_deref().map(|_| "<text>"),
             )
             .field("ai_context_files", &self.ai_context_files.len())
+            .field("statusline", &self.statusline.as_ref().map(|s| s.enabled))
+            .field("last_query_duration_ms", &self.last_query_duration_ms)
             .finish()
     }
 }
@@ -1204,6 +1216,8 @@ impl Default for ReplSettings {
             last_row_count: None,
             project_context: None,
             ai_context_files: Vec::new(),
+            statusline: None,
+            last_query_duration_ms: None,
         }
     }
 }
@@ -1427,7 +1441,9 @@ pub async fn execute_query(
 
     crate::logging::debug("repl", &format!("execute query: {}", sql_to_send.trim()));
 
-    let start = if settings.timing {
+    // Always capture start time when timing display or status bar is active.
+    let needs_timing = settings.timing || settings.statusline.is_some();
+    let start = if needs_timing {
         Some(Instant::now())
     } else {
         None
@@ -1572,8 +1588,15 @@ pub async fn execute_query(
 
     if let Some(t) = start {
         let elapsed = t.elapsed();
-        // Timing always goes to stdout regardless of output redirection.
-        println!("Time: {:.3} ms", elapsed.as_secs_f64() * 1000.0);
+        // as_millis() returns u128; truncate to u64 (safe for any realistic duration).
+        #[allow(clippy::cast_possible_truncation)]
+        let elapsed_ms = elapsed.as_millis() as u64;
+        // Timing output always goes to stdout regardless of output redirection.
+        if settings.timing {
+            println!("Time: {:.3} ms", elapsed.as_secs_f64() * 1000.0);
+        }
+        // Store duration for the status bar.
+        settings.last_query_duration_ms = Some(elapsed_ms);
     }
 
     // Auto-EXPLAIN AI interpretation: when AI is configured and auto-EXPLAIN
@@ -1651,7 +1674,9 @@ pub async fn execute_query_extended(
         let _ = writeln!(lf, "{sql_to_send}");
     }
 
-    let start = if settings.timing {
+    // Always capture start time when timing display or status bar is active.
+    let needs_timing_ext = settings.timing || settings.statusline.is_some();
+    let start = if needs_timing_ext {
         Some(Instant::now())
     } else {
         None
@@ -1775,7 +1800,12 @@ pub async fn execute_query_extended(
 
     if let Some(t) = start {
         let elapsed = t.elapsed();
-        println!("Time: {:.3} ms", elapsed.as_secs_f64() * 1000.0);
+        #[allow(clippy::cast_possible_truncation)]
+        let elapsed_ms = elapsed.as_millis() as u64;
+        if settings.timing {
+            println!("Time: {:.3} ms", elapsed.as_secs_f64() * 1000.0);
+        }
+        settings.last_query_duration_ms = Some(elapsed_ms);
     }
 
     if success {
@@ -2066,7 +2096,17 @@ async fn execute_query_interactive(
         term_rows.saturating_sub(2),
         settings.pager_min_lines,
     ) {
+        // Clear status bar before handing off to pager (pager takes full screen).
+        if let Some(ref sl) = settings.statusline {
+            sl.clear();
+            sl.teardown_scroll_region();
+        }
         run_pager_for_text(settings, &text, &captured);
+        // Re-establish scroll region and re-render status bar after pager exits.
+        if let Some(ref sl) = settings.statusline {
+            sl.setup_scroll_region();
+            sl.render();
+        }
     } else {
         let _ = io::stdout().write_all(&captured);
     }
@@ -2088,6 +2128,24 @@ async fn execute_query_interactive(
             });
             flush_audit_entry(settings, &entry);
         }
+    }
+
+    // Update status bar with latest state after query completes.
+    let duration_ms = settings.last_query_duration_ms.unwrap_or(0);
+    let tokens_used = settings.tokens_used;
+    let token_budget = settings.config.ai.max_tokens;
+    let input_mode = settings.input_mode;
+    let exec_mode = settings.exec_mode;
+    let tx_state = *tx;
+    if let Some(ref mut sl) = settings.statusline {
+        sl.update(
+            tx_state,
+            duration_ms,
+            tokens_used,
+            token_budget,
+            input_mode,
+            exec_mode,
+        );
     }
 
     ok
@@ -2155,7 +2213,17 @@ async fn execute_query_extended_interactive(
         term_rows.saturating_sub(2),
         settings.pager_min_lines,
     ) {
+        // Clear status bar before handing off to pager.
+        if let Some(ref sl) = settings.statusline {
+            sl.clear();
+            sl.teardown_scroll_region();
+        }
         run_pager_for_text(settings, &text, &captured);
+        // Re-establish scroll region and re-render after pager exits.
+        if let Some(ref sl) = settings.statusline {
+            sl.setup_scroll_region();
+            sl.render();
+        }
     } else {
         let _ = io::stdout().write_all(&captured);
     }
@@ -2177,6 +2245,24 @@ async fn execute_query_extended_interactive(
             });
             flush_audit_entry(settings, &entry);
         }
+    }
+
+    // Update status bar with latest state after query completes.
+    let duration_ms = settings.last_query_duration_ms.unwrap_or(0);
+    let tokens_used = settings.tokens_used;
+    let token_budget = settings.config.ai.max_tokens;
+    let input_mode = settings.input_mode;
+    let exec_mode = settings.exec_mode;
+    let tx_state = *tx;
+    if let Some(ref mut sl) = settings.statusline {
+        sl.update(
+            tx_state,
+            duration_ms,
+            tokens_used,
+            token_budget,
+            input_mode,
+            exec_mode,
+        );
     }
 
     ok
@@ -3336,6 +3422,7 @@ fn apply_expanded(settings: &mut ReplSettings, mode: ExpandedMode) {
 /// - `\set name value` — assign.
 ///
 /// Special case: when `ECHO_HIDDEN` is set to `on`, update `settings.echo_hidden`.
+#[allow(clippy::too_many_lines)]
 fn apply_set(settings: &mut ReplSettings, name: &str, value: &str) {
     if name.is_empty() {
         // List all variables.
@@ -3449,6 +3536,25 @@ fn apply_set(settings: &mut ReplSettings, name: &str, value: &str) {
             println!("Vi mode enabled. Takes effect on next session.");
         } else {
             println!("Emacs mode (default). Takes effect on next session.");
+        }
+    }
+    // Mirror STATUSLINE into the status bar enabled flag.
+    if name == "STATUSLINE" {
+        let on = matches!(value, "on" | "true" | "1");
+        settings.config.display.statusline_enabled = on;
+        if let Some(ref mut sl) = settings.statusline {
+            sl.enabled = on;
+            if on {
+                sl.setup_scroll_region();
+                sl.render();
+            } else {
+                sl.teardown_scroll_region();
+            }
+        }
+        if on {
+            println!("Status bar enabled.");
+        } else {
+            println!("Status bar disabled.");
         }
     }
 }
@@ -5232,11 +5338,31 @@ pub async fn run_repl(
     // Build rustyline editor (skip if --no-readline).
     let use_readline = !no_readline && io::stdin().is_terminal();
 
-    if use_readline {
+    // Initialise the status bar for interactive sessions.
+    // Enabled when: readline mode AND stderr is a terminal AND config allows it.
+    if use_readline
+        && crate::statusline::StatusLine::is_interactive()
+        && settings.config.display.statusline_enabled
+    {
+        let mut sl = crate::statusline::StatusLine::new(true);
+        sl.set_connection(&params.host, params.port, &params.dbname);
+        sl.setup_scroll_region();
+        sl.render();
+        settings.statusline = Some(sl);
+    }
+
+    let exit_code = if use_readline {
         run_readline_loop(&mut client, &mut params, &mut settings, &mut tx).await
     } else {
         run_dumb_loop(&mut client, &mut params, &mut settings, &mut tx).await
+    };
+
+    // Tear down the status bar on exit.
+    if let Some(ref sl) = settings.statusline {
+        sl.teardown_scroll_region();
     }
+
+    exit_code
 }
 
 // ---------------------------------------------------------------------------
@@ -5381,6 +5507,12 @@ async fn run_readline_loop(
     let mut stmt_buf = String::new();
 
     loop {
+        // Re-render the status bar before each prompt so it stays fresh
+        // (handles resize events and mode changes from previous commands).
+        if let Some(ref mut sl) = settings.statusline {
+            sl.on_resize();
+        }
+
         let prompt = build_prompt_from_settings(settings, params, *tx, !buf.is_empty());
 
         match rl.readline(&prompt) {
@@ -5452,6 +5584,11 @@ async fn run_readline_loop(
                         // Update audit connection context for the new connection.
                         settings.audit_dbname.clone_from(&params.dbname);
                         settings.audit_user.clone_from(&params.user);
+                        // Update status bar with new connection label.
+                        if let Some(ref mut sl) = settings.statusline {
+                            sl.set_connection(&params.host, params.port, &params.dbname);
+                            sl.render();
+                        }
                     }
                     HandleLineResult::BufferUpdated | HandleLineResult::Continue => {}
                 }

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -1,0 +1,230 @@
+//! Persistent one-line status bar for the interactive REPL (FR-25).
+//!
+//! Renders a status line at the bottom of the terminal using direct ANSI
+//! escape sequences.  Uses the terminal scroll region (CSR) to reserve the
+//! last row so that normal output does not overwrite it.
+//!
+//! Format:
+//! ```text
+//!  db-host:5432/mydb │ SQL │ tx:idle │ last: 12ms │ ai: 847/4096 tok
+//! ```
+//!
+//! The status bar writes to **stderr** so that it does not mix with query
+//! output on stdout.
+
+use std::io::{self, IsTerminal, Write};
+
+use crate::repl::{ExecMode, InputMode, TxState};
+
+// ---------------------------------------------------------------------------
+// Status bar state
+// ---------------------------------------------------------------------------
+
+/// Persistent status bar displayed at the bottom of the terminal.
+pub struct StatusLine {
+    /// Whether the status bar is enabled.
+    pub enabled: bool,
+    /// Cached terminal width (columns).
+    term_cols: u16,
+    /// Cached terminal height (rows).  The status bar occupies this row.
+    term_rows: u16,
+    /// Connection label: `host:port/dbname`.
+    conn_label: String,
+    /// Current input mode.
+    input_mode: InputMode,
+    /// Current execution mode.
+    exec_mode: ExecMode,
+    /// Current transaction state.
+    tx_state: TxState,
+    /// Duration of the last query (milliseconds), or `None` if no query yet.
+    last_duration_ms: Option<u64>,
+    /// Cumulative AI tokens used this session.
+    ai_tokens_used: u64,
+    /// Configured AI token budget (0 = unlimited / no AI configured).
+    ai_token_budget: u32,
+}
+
+impl StatusLine {
+    /// Create a new `StatusLine`.
+    ///
+    /// The bar is enabled by default only when stderr is a terminal.
+    /// Pass `enabled = false` for non-interactive / piped sessions.
+    pub fn new(enabled: bool) -> Self {
+        let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+        Self {
+            enabled,
+            term_cols: cols,
+            term_rows: rows,
+            conn_label: String::new(),
+            input_mode: InputMode::default(),
+            exec_mode: ExecMode::default(),
+            tx_state: TxState::default(),
+            last_duration_ms: None,
+            ai_tokens_used: 0,
+            ai_token_budget: 0,
+        }
+    }
+
+    /// Return `true` when stderr is a terminal (interactive session).
+    pub fn is_interactive() -> bool {
+        io::stderr().is_terminal()
+    }
+
+    /// Set the connection label (`host:port/dbname`).
+    pub fn set_connection(&mut self, host: &str, port: u16, dbname: &str) {
+        self.conn_label = format!("{host}:{port}/{dbname}");
+    }
+
+    /// Update state after a query completes and re-render.
+    pub fn update(
+        &mut self,
+        tx_state: TxState,
+        duration_ms: u64,
+        tokens_used: u64,
+        token_budget: u32,
+        input_mode: InputMode,
+        exec_mode: ExecMode,
+    ) {
+        self.tx_state = tx_state;
+        self.last_duration_ms = Some(duration_ms);
+        self.ai_tokens_used = tokens_used;
+        self.ai_token_budget = token_budget;
+        self.input_mode = input_mode;
+        self.exec_mode = exec_mode;
+        self.render();
+    }
+
+    /// Refresh the cached terminal size (call on SIGWINCH / resize events).
+    pub fn on_resize(&mut self) {
+        if let Ok((cols, rows)) = crossterm::terminal::size() {
+            self.term_cols = cols;
+            self.term_rows = rows;
+        }
+        self.render();
+    }
+
+    /// Install the terminal scroll region, reserving the last row for the
+    /// status bar.  Call once at REPL startup.
+    pub fn setup_scroll_region(&self) {
+        if !self.enabled {
+            return;
+        }
+        let last = self.term_rows;
+        // Set scroll region to rows 1 .. (last-1), leaving the final row free.
+        // ANSI: ESC [ top ; bottom r   (1-based)
+        let _ = write!(io::stderr(), "\x1b[1;{}r", last.saturating_sub(1));
+        let _ = io::stderr().flush();
+    }
+
+    /// Restore the full scroll region.  Call at REPL exit.
+    pub fn teardown_scroll_region(&self) {
+        if !self.enabled {
+            return;
+        }
+        // Reset scroll region to the full terminal.
+        let _ = write!(io::stderr(), "\x1b[r");
+        // Clear the status bar row.
+        self.clear_row();
+        let _ = io::stderr().flush();
+    }
+
+    /// Clear the status bar row (used before pager handoff and at exit).
+    pub fn clear(&self) {
+        if !self.enabled {
+            return;
+        }
+        self.clear_row();
+        let _ = io::stderr().flush();
+    }
+
+    /// Render the status bar to stderr.
+    pub fn render(&self) {
+        if !self.enabled {
+            return;
+        }
+        let content = self.format_status();
+        self.write_status_row(&content);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /// Format the status string (without ANSI codes, padded to terminal width).
+    fn format_status(&self) -> String {
+        // Mode label.
+        let mode = match self.exec_mode {
+            ExecMode::Interactive => match self.input_mode {
+                InputMode::Sql => "SQL",
+                InputMode::Text2Sql => "text2sql",
+            },
+            ExecMode::Plan => "plan",
+            ExecMode::Yolo => "yolo",
+            ExecMode::Observe => "observe",
+        };
+
+        // Transaction state label.
+        let tx = match self.tx_state {
+            TxState::Idle => "idle",
+            TxState::InTransaction => "in-tx",
+            TxState::Failed => "failed",
+        };
+
+        // Last query duration.
+        let duration = match self.last_duration_ms {
+            None => String::new(),
+            Some(ms) if ms < 1000 => format!(" │ last: {ms}ms"),
+            #[allow(clippy::cast_precision_loss)]
+            Some(ms) => format!(" │ last: {:.1}s", ms as f64 / 1000.0),
+        };
+
+        // AI token usage (only when a budget is configured or tokens were used).
+        let ai = if self.ai_token_budget > 0 || self.ai_tokens_used > 0 {
+            format!(" │ ai: {}/{}tok", self.ai_tokens_used, self.ai_token_budget)
+        } else {
+            String::new()
+        };
+
+        // Assemble the status string.
+        let conn = if self.conn_label.is_empty() {
+            String::new()
+        } else {
+            format!(" {} │", self.conn_label)
+        };
+        let inner = format!("{conn} {mode} │ tx:{tx}{duration}{ai} ");
+
+        // Pad or truncate to terminal width.
+        let width = self.term_cols as usize;
+        let char_count = inner.chars().count();
+        if char_count < width {
+            let pad = " ".repeat(width - char_count);
+            format!("{inner}{pad}")
+        } else {
+            inner.chars().take(width).collect()
+        }
+    }
+
+    /// Write `content` to the last terminal row using save/restore cursor.
+    fn write_status_row(&self, content: &str) {
+        let row = self.term_rows;
+        let mut stderr = io::stderr();
+        // \x1b[s       — save cursor position
+        // \x1b[{row};0H — move to last row, column 1
+        // \x1b[7m      — reverse video
+        // {content}    — status string padded to width
+        // \x1b[0m      — reset attributes
+        // \x1b[u       — restore cursor position
+        let _ = write!(stderr, "\x1b[s\x1b[{row};0H\x1b[7m{content}\x1b[0m\x1b[u");
+        let _ = stderr.flush();
+    }
+
+    /// Erase the status bar row without disturbing the cursor.
+    fn clear_row(&self) {
+        let row = self.term_rows;
+        let width = self.term_cols as usize;
+        let blank = " ".repeat(width);
+        let mut stderr = io::stderr();
+        let _ = write!(stderr, "\x1b[s\x1b[{row};0H{blank}\x1b[u");
+        let _ = stderr.flush();
+    }
+}


### PR DESCRIPTION
Closes #330

## Summary
- Add `src/statusline.rs` with a `StatusLine` struct that renders a persistent one-line bar at the bottom of the terminal using ANSI escape sequences and the terminal scroll region (CSR)
- Shows: `host:port/dbname │ SQL │ tx:idle │ last: 12ms │ ai: 847/4096tok`
- Toggle with `\set STATUSLINE on|off`; configure with `[display] statusline_enabled = true` in config file
- Default: ON in interactive sessions, OFF in non-interactive/piped mode
- Pager handoff: clears status bar before pager, re-renders after pager exits
- Terminal resize: handled via `on_resize()` called before each prompt
- Connection label updates on `\c` reconnect
- Always captures query timing when status bar is active (not just when `\timing` is on)

## Test plan
- [ ] `cargo test` passes (1353 tests)
- [ ] `cargo clippy` passes with no warnings
- [ ] Status bar renders correctly in interactive mode
- [ ] Status bar is disabled in non-interactive mode (piped stdin, `-c`, `-f`)
- [ ] `\set STATUSLINE off` hides the bar; `\set STATUSLINE on` restores it
- [ ] Pager works correctly with status bar (clears before, restores after)
- [ ] Terminal resize handled (bar re-renders at new bottom row before next prompt)
- [ ] `\c` reconnect updates the connection label in the bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)