### PR TITLE
perf: optimize startup and query execution path

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -136,7 +136,9 @@ pub fn open_output(path: Option<&str>) -> Result<Option<Box<dyn Write>>, String>
                 .truncate(true)
                 .open(p)
                 .map_err(|e| format!("\\o: could not open \"{p}\": {e}"))?;
-            Ok(Some(Box::new(file)))
+            // Wrap in BufWriter so that large result sets are written in
+            // batches rather than one syscall per write_all call.
+            Ok(Some(Box::new(std::io::BufWriter::new(file))))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,13 +609,14 @@ async fn main() {
             .unwrap_or(logging::Level::Warn)
     };
 
-    // Load config early so we can read [logging] rotation settings.
-    // We load it again below after profile/flag resolution, but the
-    // logging config is stable (not affected by connection flags).
-    let (early_cfg, _) = config::load_config();
+    // Load config once up front: needed for logging rotation settings and
+    // then reused below for the full startup path.  Previously this was
+    // called twice (once for logging, once after early-exit guards), which
+    // doubled the TOML parsing overhead on every invocation.
+    let (base_cfg, config_warnings) = config::load_config();
     let rotation = logging::RotationConfig::from_mb(
-        early_cfg.logging.max_file_size_mb,
-        early_cfg.logging.max_files,
+        base_cfg.logging.max_file_size_mb,
+        base_cfg.logging.max_files,
     );
 
     if let Some(path) = cli.log_file.as_deref() {
@@ -637,9 +638,8 @@ async fn main() {
         return;
     }
 
-    // Load config hierarchy (system then user); non-fatal warnings are
-    // printed to stderr unless --quiet suppresses them.
-    let (base_cfg, config_warnings) = config::load_config();
+    // Print config warnings now that logging is initialised.  Suppressed
+    // by --quiet as before.
     for w in &config_warnings {
         if !cli.quiet {
             eprintln!("samo: warning: {w}");
@@ -790,9 +790,23 @@ async fn main() {
 
             let mut settings = build_settings(&cli, &cfg, &project_result);
 
-            // Detect database capabilities (pg_ash, server version, etc.).
-            // Run before the banner so we can include the server version.
-            settings.db_capabilities = capabilities::detect(&client).await;
+            // Capability detection: in non-interactive mode (-c, -f, piped
+            // input) we skip the pg_ash / pooler / managed-provider probes
+            // since those results are only used for the interactive banner,
+            // the statusline, and governance decisions.  We still fetch the
+            // server version so that logging and daemon mode have it.
+            //
+            // In interactive mode we run the full detect() so the banner,
+            // pg_ash statusline, and governance framework all work.
+            settings.db_capabilities = if is_interactive || cli.daemon {
+                capabilities::detect(&client).await
+            } else {
+                // Lightweight path: only the server version query.
+                capabilities::DbCapabilities {
+                    server_version: capabilities::detect_server_version_pub(&client).await,
+                    ..Default::default()
+                }
+            };
 
             if !cli.quiet && is_interactive {
                 // Version banner — matches psql's style of showing version on
@@ -817,8 +831,13 @@ async fn main() {
             }
 
             // Detect whether the connected role is a superuser so the prompt
-            // can show `#` instead of `>`.
-            settings.is_superuser = capabilities::detect_superuser(&client).await;
+            // can show `#` instead of `>`.  Only needed for the interactive
+            // prompt; skip in scripting / piped / daemon mode.
+            settings.is_superuser = if is_interactive {
+                capabilities::detect_superuser(&client).await
+            } else {
+                false
+            };
 
             let exit_code = if cli.daemon {
                 // Daemon mode: headless continuous monitoring.


### PR DESCRIPTION
Closes #342

## Summary

Three targeted startup/scripting-path optimizations:

- **Eliminate duplicate `config::load_config()`** — `main()` previously called `load_config()` twice: once for logging rotation settings, once after the early-exit guards. Each call parses TOML from disk. Consolidated into a single call with the result reused.

- **Skip heavy capability probes in non-interactive mode** — `capabilities::detect()` runs 5 round-trip DB queries (pg_ash schema check, server_version, `SHOW pool_mode`, `pg_settings` for RDS/CloudSQL/Neon, `pg_roles` for Supabase). In `-c`/`-f`/pipe mode these results are unused (they serve the interactive banner, pg_ash status line, and governance framework). The non-interactive path now calls only `detect_server_version_pub()` (1 query instead of 5+). `detect_superuser()` is also skipped since the prompt character is not rendered in scripting mode.

- **`BufWriter` for `-o` output file** — `open_output()` previously returned `Box<File>` directly, meaning each `write_all()` call in `execute_query()` was a separate syscall. Wrapped with `BufWriter` to batch writes for large result sets.

## Benchmark results

PostgreSQL not available locally for live benchmarks (CI will cover this).

**Binary size:**
- `samo` (release, strip+LTO+codegen-units=1): **8.6 MiB**
- `psql` (libpq 17, homebrew): **731 KiB**

**Expected improvements for `-c` queries** (per optimization):
1. Saves one full TOML parse + file read per invocation
2. Saves 4–5 round-trip DB queries per `-c` invocation (equivalent to ~5× reduction in startup overhead after connect)
3. Reduces syscall count for large result set writes to `-o` files

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test --bin samo` — 1354 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)