### PR TITLE
feat(repl): switch Tab completion to List mode (pgcli-like)

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -5460,6 +5460,7 @@ async fn run_readline_loop(
         .max_history_size(HISTORY_SIZE)
         .expect("valid history size")
         .history_ignore_space(true)
+        .completion_type(rustyline::CompletionType::List)
         .edit_mode(edit_mode)
         .build();
 


### PR DESCRIPTION
Closes #348

## Summary
- Switch rustyline CompletionType from Circular (default) to List
- Tab now shows all matching candidates at once instead of cycling one-by-one

## Test plan
- [x] cargo test passes
- [x] cargo clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)