### PR TITLE
fix: SSH host key warning, URL credential masking, libc pid check (H3+M2+M4)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -42,14 +42,14 @@ pub fn check_existing_pid(path: &Path) -> Option<u32> {
     // Check if process exists (Unix only).
     #[cfg(unix)]
     {
-        use std::os::unix::process::ExitStatusExt;
         // kill(pid, 0) checks existence without sending a signal.
-        let status = std::process::Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .status()
-            .ok()?;
-        if status.success() || status.signal() == Some(0) {
-            return Some(pid);
+        // Returns 0 on success (process exists and we can signal it)
+        // or -1 with ESRCH if the process does not exist.
+        if let Ok(pid_i32) = i32::try_from(pid) {
+            let alive = unsafe { libc::kill(pid_i32, 0) } == 0;
+            if alive {
+                return Some(pid);
+            }
         }
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -354,18 +354,45 @@ pub fn trace(component: &str, msg: &str) {
 
 /// Mask sensitive values in connection strings.
 ///
-/// Replaces `password=<value>` patterns with `password=***`.
-/// The search is case-insensitive.
+/// Handles two formats:
+/// - Key-value: `password=<value>` → `password=***` (case-insensitive)
+/// - URI: `scheme://user:password@host` → `scheme://user:***@host`
 #[allow(dead_code)]
 pub fn mask_credentials(s: &str) -> String {
-    let lower = s.to_lowercase();
+    // First, handle URI-style credentials: scheme://user:password@host
+    // Find "://" and then look for ":password@" after it.
+    let result = if let Some(scheme_end) = s.find("://") {
+        // Everything after "://"
+        let after_scheme = &s[scheme_end + 3..];
+        // The userinfo is the part before the first '@'
+        if let Some(at_pos) = after_scheme.find('@') {
+            let userinfo = &after_scheme[..at_pos];
+            // Only mask if there's a colon in the userinfo (user:password form)
+            if let Some(colon_pos) = userinfo.find(':') {
+                // Reconstruct: prefix + scheme + "://" + user + ":***@" + rest
+                let prefix = &s[..scheme_end + 3];
+                let user = &userinfo[..colon_pos];
+                let rest = &after_scheme[at_pos..]; // includes '@'
+                format!("{prefix}{user}:***{rest}")
+            } else {
+                s.to_owned()
+            }
+        } else {
+            s.to_owned()
+        }
+    } else {
+        s.to_owned()
+    };
+
+    // Then, handle key=value style: password=<value>
+    let lower = result.to_lowercase();
     if let Some(idx) = lower.find("password=") {
-        let prefix = &s[..idx + 9]; // "password=" is 9 bytes
-        let rest = &s[idx + 9..];
+        let prefix = &result[..idx + 9]; // "password=" is 9 bytes
+        let rest = &result[idx + 9..];
         let end = rest.find([' ', '&', ';']).unwrap_or(rest.len());
         format!("{prefix}***{}", &rest[end..])
     } else {
-        s.to_owned()
+        result
     }
 }
 
@@ -486,6 +513,27 @@ mod tests {
         let input = "user=foo&password=bar&host=db";
         let output = mask_credentials(input);
         assert_eq!(output, "user=foo&password=***&host=db");
+    }
+
+    #[test]
+    fn mask_credentials_uri_with_password() {
+        let input = "postgresql://alice:s3cr3t@db.example.com:5432/mydb";
+        let output = mask_credentials(input);
+        assert_eq!(output, "postgresql://alice:***@db.example.com:5432/mydb");
+    }
+
+    #[test]
+    fn mask_credentials_uri_no_password() {
+        let input = "postgresql://alice@db.example.com/mydb";
+        let output = mask_credentials(input);
+        assert_eq!(output, "postgresql://alice@db.example.com/mydb");
+    }
+
+    #[test]
+    fn mask_credentials_uri_postgres_scheme() {
+        let input = "postgres://user:hunter2@localhost/testdb";
+        let output = mask_credentials(input);
+        assert_eq!(output, "postgres://user:***@localhost/testdb");
     }
 
     // -- current_time_hms -----------------------------------------------------

--- a/src/ssh_tunnel.rs
+++ b/src/ssh_tunnel.rs
@@ -242,6 +242,12 @@ pub async fn open_tunnel(
         });
     }
 
+    // Warn once per tunnel that host key verification is disabled.
+    eprintln!(
+        "WARNING: SSH host key verification is disabled. \
+         This connection may be vulnerable to MITM attacks."
+    );
+
     // 3. Bind local listener on an OS-assigned port.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await


### PR DESCRIPTION
Partial fix for #339

## Summary
- H3: Print warning to stderr when SSH host key verification is disabled (once per tunnel, after successful auth)
- M2: `mask_credentials` now handles `postgresql://user:pass@host` URI-style credentials in addition to `password=` key-value format; 3 new tests added
- M4: `check_existing_pid` uses `libc::kill(pid, 0)` instead of shelling out to `kill -0`; uses `i32::try_from` to satisfy clippy's `cast_possible_wrap` lint

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt` passes (no changes)
- [x] `cargo test` passes (1364 tests, 3 new URI masking tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)