### PR TITLE
fix(config): use Option instead of sentinel values for border/pager_min_lines (M3)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -95,10 +95,16 @@ pub struct DisplayConfig {
     pub timing: bool,
     /// Expanded display mode (like `\x`). Default: `false`.
     pub expanded: bool,
-    /// Minimum output lines before the pager activates. Default: `0` (always).
-    pub pager_min_lines: usize,
-    /// Table border style (`0`, `1`, or `2`). Mirrors `\pset border`. Default: `1`.
-    pub border: u8,
+    /// Minimum output lines before the pager activates.
+    ///
+    /// When `None` (or absent from config), the default `0` applies (always
+    /// page).  When `Some(n)`, the pager only activates if output exceeds `n`
+    /// lines.
+    pub pager_min_lines: Option<usize>,
+    /// Table border style (`0`, `1`, or `2`). Mirrors `\pset border`.
+    ///
+    /// When `None` (or absent from config), the default `1` applies.
+    pub border: Option<u8>,
     /// Use Vi keybinding mode in the REPL. Default: `false` (Emacs mode).
     ///
     /// When `true`, rustyline uses `EditMode::Vi` instead of the default
@@ -130,8 +136,8 @@ impl Default for DisplayConfig {
             highlight: true,
             timing: false,
             expanded: false,
-            pager_min_lines: 0,
-            border: 1,
+            pager_min_lines: None,
+            border: None,
             vi_mode: false,
             // Default ON — overridden to OFF in non-interactive sessions.
             statusline_enabled: true,
@@ -850,16 +856,11 @@ fn merge_config(base: Config, overlay: Config) -> Config {
             highlight: overlay.display.highlight,
             timing: overlay.display.timing,
             expanded: overlay.display.expanded,
-            pager_min_lines: if overlay.display.pager_min_lines == 0 {
-                base.display.pager_min_lines
-            } else {
-                overlay.display.pager_min_lines
-            },
-            border: if overlay.display.border == 1 {
-                base.display.border
-            } else {
-                overlay.display.border
-            },
+            pager_min_lines: overlay
+                .display
+                .pager_min_lines
+                .or(base.display.pager_min_lines),
+            border: overlay.display.border.or(base.display.border),
             vi_mode: overlay.display.vi_mode || base.display.vi_mode,
             // Prefer explicit false from overlay over base default.
             statusline_enabled: overlay.display.statusline_enabled
@@ -981,8 +982,8 @@ mod tests {
         assert!(cfg.display.highlight); // default
         assert!(!cfg.display.timing);
         assert!(!cfg.display.expanded);
-        assert_eq!(cfg.display.pager_min_lines, 0);
-        assert_eq!(cfg.display.border, 1);
+        assert_eq!(cfg.display.pager_min_lines, None);
+        assert_eq!(cfg.display.border, None);
         assert!(!cfg.display.vi_mode); // default is Emacs
         assert!(cfg.safety.destructive_warning);
         assert!(cfg.connection.host.is_none());
@@ -1061,8 +1062,8 @@ pager_min_lines = 40
 border = 2
 ";
         let cfg: Config = toml::from_str(toml_str).expect("should parse");
-        assert_eq!(cfg.display.pager_min_lines, 40);
-        assert_eq!(cfg.display.border, 2);
+        assert_eq!(cfg.display.pager_min_lines, Some(40));
+        assert_eq!(cfg.display.border, Some(2));
     }
 
     #[test]
@@ -1133,38 +1134,76 @@ host = "localhost"
     fn merge_display_pager_min_lines_overlay_wins() {
         let base = Config {
             display: DisplayConfig {
-                pager_min_lines: 20,
-                border: 0,
+                pager_min_lines: Some(20),
+                border: Some(0),
                 ..DisplayConfig::default()
             },
             ..Default::default()
         };
         let overlay = Config {
             display: DisplayConfig {
-                pager_min_lines: 50,
-                border: 2,
+                pager_min_lines: Some(50),
+                border: Some(2),
                 ..DisplayConfig::default()
             },
             ..Default::default()
         };
         let merged = merge_config(base, overlay);
-        assert_eq!(merged.display.pager_min_lines, 50);
-        assert_eq!(merged.display.border, 2);
+        assert_eq!(merged.display.pager_min_lines, Some(50));
+        assert_eq!(merged.display.border, Some(2));
     }
 
     #[test]
-    fn merge_display_pager_min_lines_base_preserved_when_overlay_zero() {
+    fn merge_display_pager_min_lines_base_preserved_when_overlay_none() {
         let base = Config {
             display: DisplayConfig {
-                pager_min_lines: 30,
+                pager_min_lines: Some(30),
                 ..DisplayConfig::default()
             },
             ..Default::default()
         };
-        // Overlay has pager_min_lines = 0 (default), so base value is kept.
+        // Overlay has pager_min_lines = None (not set), so base value is kept.
         let overlay = Config::default();
         let merged = merge_config(base, overlay);
-        assert_eq!(merged.display.pager_min_lines, 30);
+        assert_eq!(merged.display.pager_min_lines, Some(30));
+    }
+
+    #[test]
+    fn merge_display_border_base_preserved_when_overlay_none() {
+        let base = Config {
+            display: DisplayConfig {
+                border: Some(1),
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        // Overlay has border = None (not set), so base value is kept.
+        let overlay = Config::default();
+        let merged = merge_config(base, overlay);
+        assert_eq!(merged.display.border, Some(1));
+    }
+
+    #[test]
+    fn merge_display_border_explicit_one_overlay_wins() {
+        // Previously, border=1 was a sentinel meaning "not set", so it was
+        // impossible for an overlay to explicitly set border=1. With Option,
+        // Some(1) from the overlay wins over any base value.
+        let base = Config {
+            display: DisplayConfig {
+                border: Some(2),
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        let overlay = Config {
+            display: DisplayConfig {
+                border: Some(1),
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        let merged = merge_config(base, overlay);
+        assert_eq!(merged.display.border, Some(1));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -456,8 +456,17 @@ fn build_settings(
     cfg: &config::Config,
     project: &config::ProjectConfigResult,
 ) -> repl::ReplSettings {
-    // Build PsetConfig from CLI flags.
+    // Build PsetConfig: start with struct default, apply config-file values,
+    // then let CLI flags override.  This ordering means explicit CLI flags
+    // always win without needing sentinel-value comparisons.
     let mut pset = output::PsetConfig::default();
+
+    // Apply config-file display.border before CLI args so that CLI takes
+    // precedence.
+    if let Some(b) = cfg.display.border {
+        pset.border = b.min(2);
+    }
+
     if cli.csv {
         pset.format = output::OutputFormat::Csv;
     } else if cli.json {
@@ -522,14 +531,6 @@ fn build_settings(
     let safety_enabled = cfg.safety.destructive_warning;
     let vi_mode = cfg.display.vi_mode;
 
-    // Apply config display.border default if it wasn't set via -P border=N.
-    // The CLI -P args were already applied above via apply_cli_pset; if
-    // border is still at the struct default (1) and the config overrides
-    // it, apply the config value here.
-    if pset.border == 1 && cfg.display.border != 1 {
-        pset.border = cfg.display.border.min(2);
-    }
-
     // Initialise pager_command from the PAGER environment variable.
     // A non-empty PAGER that is not "on"/"off" sets an external pager.
     // An empty or absent PAGER leaves the built-in pager as default.
@@ -542,7 +543,7 @@ fn build_settings(
     let expanded = pset.expanded;
 
     // Pager min-lines threshold from config; 0 means always page (default).
-    let pager_min_lines = cfg.display.pager_min_lines;
+    let pager_min_lines = cfg.display.pager_min_lines.unwrap_or(0);
 
     repl::ReplSettings {
         echo_hidden: cli.echo_hidden,


### PR DESCRIPTION
## Summary

Addresses M3 from code review issue #339.

- Replace `DisplayConfig.border: u8` with `Option<u8>` — the old sentinel `1` made it impossible for a user to explicitly set `border = 1` in an overlay config (it was treated as "not set")
- Replace `DisplayConfig.pager_min_lines: usize` with `Option<usize>` — the old sentinel `0` meant setting `pager_min_lines = 0` in a project config was silently ignored
- Merge logic now uses `Option::or()` — clean and correct, no sentinel comparisons
- In `main.rs`: apply config-file `border` _before_ CLI `-P` args so CLI always wins without needing sentinel comparisons; remove the old heuristic `if pset.border == 1 && cfg.display.border != 1` block
- `pager_min_lines` resolved via `.unwrap_or(0)` at the point of use (default behaviour preserved)
- Two new regression tests: `merge_display_border_base_preserved_when_overlay_none` and `merge_display_border_explicit_one_overlay_wins` (the latter explicitly documents the bug that was impossible to test before)

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 1366 passed, 0 failed

Closes #339 (M3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)