### PR TITLE
fix(config): use Option instead of sentinel values for border/pager_min_lines (M3)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -95,10 +95,12 @@ pub struct DisplayConfig {
     pub timing: bool,
     /// Expanded display mode (like `\x`). Default: `false`.
     pub expanded: bool,
-    /// Minimum output lines before the pager activates. Default: `0` (always).
-    pub pager_min_lines: usize,
-    /// Table border style (`0`, `1`, or `2`). Mirrors `\pset border`. Default: `1`.
-    pub border: u8,
+    /// Minimum output lines before the pager activates.
+    /// `None` means "not set in this config layer" (effective default: `0`).
+    pub pager_min_lines: Option<usize>,
+    /// Table border style (`0`, `1`, or `2`). Mirrors `\pset border`.
+    /// `None` means "not set in this config layer" (effective default: `1`).
+    pub border: Option<u8>,
     /// Use Vi keybinding mode in the REPL. Default: `false` (Emacs mode).
     ///
     /// When `true`, rustyline uses `EditMode::Vi` instead of the default
@@ -130,8 +132,8 @@ impl Default for DisplayConfig {
             highlight: true,
             timing: false,
             expanded: false,
-            pager_min_lines: 0,
-            border: 1,
+            pager_min_lines: None,
+            border: None,
             vi_mode: false,
             // Default ON — overridden to OFF in non-interactive sessions.
             statusline_enabled: true,
@@ -850,16 +852,11 @@ fn merge_config(base: Config, overlay: Config) -> Config {
             highlight: overlay.display.highlight,
             timing: overlay.display.timing,
             expanded: overlay.display.expanded,
-            pager_min_lines: if overlay.display.pager_min_lines == 0 {
-                base.display.pager_min_lines
-            } else {
-                overlay.display.pager_min_lines
-            },
-            border: if overlay.display.border == 1 {
-                base.display.border
-            } else {
-                overlay.display.border
-            },
+            pager_min_lines: overlay
+                .display
+                .pager_min_lines
+                .or(base.display.pager_min_lines),
+            border: overlay.display.border.or(base.display.border),
             vi_mode: overlay.display.vi_mode || base.display.vi_mode,
             // Prefer explicit false from overlay over base default.
             statusline_enabled: overlay.display.statusline_enabled
@@ -981,8 +978,8 @@ mod tests {
         assert!(cfg.display.highlight); // default
         assert!(!cfg.display.timing);
         assert!(!cfg.display.expanded);
-        assert_eq!(cfg.display.pager_min_lines, 0);
-        assert_eq!(cfg.display.border, 1);
+        assert_eq!(cfg.display.pager_min_lines, None);
+        assert_eq!(cfg.display.border, None);
         assert!(!cfg.display.vi_mode); // default is Emacs
         assert!(cfg.safety.destructive_warning);
         assert!(cfg.connection.host.is_none());
@@ -1061,8 +1058,8 @@ pager_min_lines = 40
 border = 2
 ";
         let cfg: Config = toml::from_str(toml_str).expect("should parse");
-        assert_eq!(cfg.display.pager_min_lines, 40);
-        assert_eq!(cfg.display.border, 2);
+        assert_eq!(cfg.display.pager_min_lines, Some(40));
+        assert_eq!(cfg.display.border, Some(2));
     }
 
     #[test]
@@ -1133,38 +1130,38 @@ host = "localhost"
     fn merge_display_pager_min_lines_overlay_wins() {
         let base = Config {
             display: DisplayConfig {
-                pager_min_lines: 20,
-                border: 0,
+                pager_min_lines: Some(20),
+                border: Some(0),
                 ..DisplayConfig::default()
             },
             ..Default::default()
         };
         let overlay = Config {
             display: DisplayConfig {
-                pager_min_lines: 50,
-                border: 2,
+                pager_min_lines: Some(50),
+                border: Some(2),
                 ..DisplayConfig::default()
             },
             ..Default::default()
         };
         let merged = merge_config(base, overlay);
-        assert_eq!(merged.display.pager_min_lines, 50);
-        assert_eq!(merged.display.border, 2);
+        assert_eq!(merged.display.pager_min_lines, Some(50));
+        assert_eq!(merged.display.border, Some(2));
     }
 
     #[test]
-    fn merge_display_pager_min_lines_base_preserved_when_overlay_zero() {
+    fn merge_display_pager_min_lines_base_preserved_when_overlay_none() {
         let base = Config {
             display: DisplayConfig {
-                pager_min_lines: 30,
+                pager_min_lines: Some(30),
                 ..DisplayConfig::default()
             },
             ..Default::default()
         };
-        // Overlay has pager_min_lines = 0 (default), so base value is kept.
+        // Overlay has pager_min_lines = None (default), so base value is kept.
         let overlay = Config::default();
         let merged = merge_config(base, overlay);
-        assert_eq!(merged.display.pager_min_lines, 30);
+        assert_eq!(merged.display.pager_min_lines, Some(30));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -524,10 +524,12 @@ fn build_settings(
 
     // Apply config display.border default if it wasn't set via -P border=N.
     // The CLI -P args were already applied above via apply_cli_pset; if
-    // border is still at the struct default (1) and the config overrides
-    // it, apply the config value here.
-    if pset.border == 1 && cfg.display.border != 1 {
-        pset.border = cfg.display.border.min(2);
+    // border is still at the struct default (1) and the config sets a value,
+    // apply the config value here.
+    if pset.border == 1 {
+        if let Some(v) = cfg.display.border {
+            pset.border = v.min(2);
+        }
     }
 
     // Initialise pager_command from the PAGER environment variable.
@@ -542,7 +544,7 @@ fn build_settings(
     let expanded = pset.expanded;
 
     // Pager min-lines threshold from config; 0 means always page (default).
-    let pager_min_lines = cfg.display.pager_min_lines;
+    let pager_min_lines = cfg.display.pager_min_lines.unwrap_or(0);
 
     repl::ReplSettings {
         echo_hidden: cli.echo_hidden,


### PR DESCRIPTION
## Summary

- Fixes M3 from code review issue #339
- `DisplayConfig.border` changed from `u8` to `Option<u8>` (was using `1` as "not set" sentinel)
- `DisplayConfig.pager_min_lines` changed from `usize` to `Option<usize>` (was using `0` as "not set" sentinel)
- `Default` impl sets both fields to `None`
- Merge logic now uses `Option::or()` instead of sentinel comparisons
- All usage sites updated: `main.rs` uses `unwrap_or(0)` for `pager_min_lines` and `if let Some(v)` for `border`
- Tests updated to use `Some(...)` values and assert `Option` results

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all 1364 tests pass
- [x] `cargo fmt` — no formatting changes needed

Closes #339 (M3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)