### PR TITLE
fix(repl): preserve \watch and \gx in history

### DIFF
--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -5595,11 +5595,11 @@ mod tests {
 
     // -- history stmt_buf construction for inline terminators (#360) ----------
 
-    /// Helper: simulate the stmt_buf construction for an inline backslash line.
+    /// Helper: simulate the `stmt_buf` construction for an inline backslash line.
     ///
     /// Mirrors the logic in `handle_line` (lines beginning
     /// "Check for inline backslash command"): find the split point, push
-    /// sql_part then " " + meta_part into stmt_buf.
+    /// `sql_part` then " " + `meta_part` into `stmt_buf`.
     fn build_stmt_buf_for_inline(line: &str) -> Option<String> {
         let pos = find_inline_backslash(line)?;
         let sql_part = &line[..pos];


### PR DESCRIPTION
## Summary

- Fixes #360: inline terminators (`\gx`, `\g`, `\watch`, `\gset`) were
  not recorded in readline history; the history entry was silently dropped.
- Root cause: the inline-backslash dispatch arms in `handle_line` called
  `stmt_buf.clear()` before the readline loop's `add_history_entry` check
  could fire, wiping the fully-assembled original input string.
- Fix: remove `stmt_buf.clear()` from all `ExecuteBuffer*` arms in the
  inline dispatch block; also change the `_ =>` fallthrough arm (used by
  `\watch`) to clear `buf` and return `BufferUpdated` so the loop's
  `buf.is_empty()` guard triggers history recording.
- Adds four unit tests verifying `stmt_buf` is built correctly for each
  affected terminator (`\gx`, `\watch`, `\g`, `\gset`).

## Test plan

- [ ] `cargo test history` — 4 new tests pass
- [ ] `cargo test` — all 1368 tests pass, no regressions
- [ ] Manual: type `select now() \gx` in the REPL, press Up — should
  recall `select now() \gx`, not an empty entry or `select now();`
- [ ] Manual: type `select now() \watch 1`, let it run, Ctrl-C, press
  Up — should recall `select now() \watch 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)