### PR TITLE
feat(ai): enforce token budget with usage tracking

### DIFF
--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -58,15 +58,17 @@ impl Default for CompletionOptions {
 pub struct CompletionResult {
     /// The generated text content.
     pub content: String,
-    /// Number of tokens in the prompt.
+    /// Number of tokens in the prompt (input side).
     ///
-    /// Reserved for future token-usage tracking (issue #75).
-    #[allow(dead_code)]
+    /// Populated by all providers that return usage metadata.
+    /// Used by [`crate::repl::ai_commands::record_token_usage`] to track
+    /// cumulative session token consumption against the configured budget.
     pub input_tokens: u32,
-    /// Number of tokens in the completion.
+    /// Number of tokens in the completion (output side).
     ///
-    /// Reserved for future token-usage tracking (issue #75).
-    #[allow(dead_code)]
+    /// Populated by all providers that return usage metadata.
+    /// Used by [`crate::repl::ai_commands::record_token_usage`] to track
+    /// cumulative session token consumption against the configured budget.
     pub output_tokens: u32,
 }
 

--- a/src/repl/ai_commands.rs
+++ b/src/repl/ai_commands.rs
@@ -847,7 +847,7 @@ pub(super) fn parse_ai_response_segments(response: &str) -> Vec<AiResponseSegmen
 pub(super) async fn handle_ai_plan(
     client: &Client,
     prompt: &str,
-    settings: &ReplSettings,
+    settings: &mut ReplSettings,
     params: &ConnParams,
 ) {
     if settings
@@ -941,6 +941,7 @@ pub(super) async fn handle_ai_plan(
             return;
         }
     };
+    record_token_usage(settings, &result);
 
     // Offer to save the plan.
     if ask_yn_prompt("Save this plan? [y/N] ", false) {

--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -897,7 +897,7 @@ pub(super) async fn execute_query_interactive(
     // Update status bar with latest state after query completes.
     let duration_ms = settings.last_query_duration_ms.unwrap_or(0);
     let tokens_used = settings.tokens_used;
-    let token_budget = settings.config.ai.max_tokens;
+    let token_budget = u32::try_from(settings.config.ai.token_budget).unwrap_or(u32::MAX);
     let input_mode = settings.input_mode;
     let exec_mode = settings.exec_mode;
     let tx_state = *tx;
@@ -1014,7 +1014,7 @@ pub(super) async fn execute_query_extended_interactive(
     // Update status bar with latest state after query completes.
     let duration_ms = settings.last_query_duration_ms.unwrap_or(0);
     let tokens_used = settings.tokens_used;
-    let token_budget = settings.config.ai.max_tokens;
+    let token_budget = u32::try_from(settings.config.ai.token_budget).unwrap_or(u32::MAX);
     let input_mode = settings.input_mode;
     let exec_mode = settings.exec_mode;
     let tx_state = *tx;

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1957,6 +1957,27 @@ fn apply_set(settings: &mut ReplSettings, name: &str, value: &str) {
         settings.config.ai.model = Some(value.to_owned());
         println!("AI model set to: {value}");
     }
+    // Mirror TOKEN_BUDGET into config.ai.token_budget.
+    //
+    // Accepts a non-negative integer; 0 means unlimited.
+    if name == "TOKEN_BUDGET" {
+        match value.parse::<u64>() {
+            Ok(n) => {
+                settings.config.ai.token_budget = n;
+                if n == 0 {
+                    println!("AI token budget: unlimited");
+                } else {
+                    println!("AI token budget set to: {n} tokens");
+                }
+            }
+            Err(_) => {
+                eprintln!(
+                    "\\set TOKEN_BUDGET: invalid value \"{value}\"\n\
+                     Expected a non-negative integer (0 = unlimited)."
+                );
+            }
+        }
+    }
     // Mirror VI into vi_mode.
     //
     // rustyline does not support changing EditMode at runtime on an existing
@@ -5476,6 +5497,42 @@ mod tests {
         assert!(settings.config.ai.model.is_some());
         apply_unset(&mut settings, "AI_MODEL");
         assert!(settings.config.ai.model.is_none());
+    }
+
+    // -- \set TOKEN_BUDGET -----------------------------------------------------
+
+    #[test]
+    fn set_token_budget_numeric_updates_config() {
+        let mut settings = ReplSettings::default();
+        assert_eq!(settings.config.ai.token_budget, 0);
+        apply_set(&mut settings, "TOKEN_BUDGET", "50000");
+        assert_eq!(settings.config.ai.token_budget, 50_000);
+        assert_eq!(settings.vars.get("TOKEN_BUDGET"), Some("50000"));
+    }
+
+    #[test]
+    fn set_token_budget_zero_means_unlimited() {
+        let mut settings = ReplSettings::default();
+        settings.config.ai.token_budget = 10_000;
+        apply_set(&mut settings, "TOKEN_BUDGET", "0");
+        assert_eq!(settings.config.ai.token_budget, 0);
+    }
+
+    #[test]
+    fn set_token_budget_invalid_value_leaves_config_unchanged() {
+        let mut settings = ReplSettings::default();
+        settings.config.ai.token_budget = 5_000;
+        apply_set(&mut settings, "TOKEN_BUDGET", "not_a_number");
+        // Budget is unchanged because the value was rejected.
+        assert_eq!(settings.config.ai.token_budget, 5_000);
+    }
+
+    #[test]
+    fn set_token_budget_overwrites_previous() {
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "TOKEN_BUDGET", "10000");
+        apply_set(&mut settings, "TOKEN_BUDGET", "20000");
+        assert_eq!(settings.config.ai.token_budget, 20_000);
     }
 
     // -- \set VI ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #367. The token budget framework was partially implemented; this PR completes it with four targeted fixes:

- **Status bar bug**: `execute_query_interactive` and `execute_query_extended_interactive` were passing `config.ai.max_tokens` (per-request generation limit) to the status bar as the session budget. Changed to use `config.ai.token_budget` (session limit), with a saturating `u32` cast for the `u64 → u32` mismatch.
- **`handle_ai_plan` missing tracking**: The function took `&ReplSettings` (immutable) and never called `record_token_usage`, so plan-mode AI calls silently escaped the budget counter. Changed signature to `&mut ReplSettings` and added `record_token_usage` after `stream_completion`.
- **`CompletionResult` dead_code annotations**: `input_tokens` / `output_tokens` were annotated `#[allow(dead_code)]` with a "reserved for future use" comment, even though `record_token_usage` already reads them. Removed the annotations and updated the doc-comments.
- **`\set TOKEN_BUDGET <N>`**: Added runtime configuration in `apply_set()` so users can adjust the session budget without restarting (e.g. `\set TOKEN_BUDGET 100000`). `0` means unlimited. Invalid values print a clear error and leave the budget unchanged.

## Test plan

- [ ] `cargo test` — 1381 tests, all pass (includes 4 new `TOKEN_BUDGET` unit tests and existing budget/record-usage tests)
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] Manual: `\set TOKEN_BUDGET 500` then `/ask` a question; after ~500 tokens the next AI command should print the "budget exhausted" message
- [ ] Manual: status bar `ai: X/Ytok` now reflects the session budget rather than `max_tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)