### PR TITLE
feat(ai): inline error suggestions — auto-suggest /fix after SQL errors

### DIFF
--- a/src/repl/ai_commands.rs
+++ b/src/repl/ai_commands.rs
@@ -1139,6 +1139,9 @@ pub(super) async fn handle_ai_fix(
         let choice = ask_yne_prompt("Execute? [Y/n/e] ", true);
         match choice {
             AskChoice::Yes => {
+                // Mark that this execution originates from /fix so the
+                // auto-suggest hint is suppressed for any resulting error.
+                settings.last_was_fix = true;
                 execute_query(client, fix_sql, settings, tx).await;
             }
             AskChoice::Edit => match crate::io::edit(fix_sql, None, None) {
@@ -1147,6 +1150,7 @@ pub(super) async fn handle_ai_fix(
                     if edited.is_empty() {
                         eprintln!("(empty — skipped)");
                     } else {
+                        settings.last_was_fix = true;
                         execute_query(client, edited, settings, tx).await;
                     }
                 }

--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -309,6 +309,7 @@ pub async fn execute_query(
 
             // Capture context for /fix.
             let sqlstate = e.as_db_error().map(|db| db.code().code().to_owned());
+            let is_sql_error = e.as_db_error().is_some();
             let error_message = e
                 .as_db_error()
                 .map_or_else(|| e.to_string(), |db| db.message().to_owned());
@@ -319,9 +320,26 @@ pub async fn execute_query(
             });
 
             // Inline error suggestion: if AI is configured and
-            // auto_explain_errors is on, show a brief hint.
+            // auto_explain_errors is on, show a brief LLM hint.
             if settings.config.ai.auto_explain_errors {
                 suggest_error_fix_inline(sql_to_send, &error_message, settings).await;
+            }
+
+            // Auto-suggest /fix: show a dim hint pointing the user to /fix.
+            // Only shown for SQL errors (not connection errors), when AI is
+            // configured, auto_suggest_fix is enabled, and the user did not
+            // just invoke /fix (to avoid hint loops).
+            if is_sql_error
+                && settings.auto_suggest_fix
+                && !settings.last_was_fix
+                && settings
+                    .config
+                    .ai
+                    .provider
+                    .as_deref()
+                    .is_some_and(|p| !p.is_empty())
+            {
+                eprintln!("\x1b[2mHint: type /fix to auto-correct this query\x1b[0m");
             }
 
             false
@@ -363,6 +381,11 @@ pub async fn execute_query(
         // Increment session query counter.
         settings.query_count = settings.query_count.saturating_add(1);
     }
+
+    // Always clear the /fix-loop guard after each execution so the next
+    // query (regardless of whether this one succeeded or failed) can show
+    // the hint again if appropriate.
+    settings.last_was_fix = false;
 
     success
 }
@@ -442,6 +465,7 @@ pub async fn execute_query_extended(
             crate::output::eprint_db_error(&e, Some(sql_to_send), settings.verbose_errors);
             tx.on_error();
             let sqlstate = e.as_db_error().map(|db| db.code().code().to_owned());
+            let is_sql_error = e.as_db_error().is_some();
             settings.last_error = Some(LastError {
                 query: sql_to_send.to_owned(),
                 error_message: e
@@ -449,6 +473,20 @@ pub async fn execute_query_extended(
                     .map_or_else(|| e.to_string(), |db| db.message().to_owned()),
                 sqlstate,
             });
+            // Auto-suggest /fix hint for SQL errors when AI is configured.
+            if is_sql_error
+                && settings.auto_suggest_fix
+                && !settings.last_was_fix
+                && settings
+                    .config
+                    .ai
+                    .provider
+                    .as_deref()
+                    .is_some_and(|p| !p.is_empty())
+            {
+                eprintln!("\x1b[2mHint: type /fix to auto-correct this query\x1b[0m");
+            }
+            settings.last_was_fix = false;
             return false;
         }
     };
@@ -536,13 +574,29 @@ pub async fn execute_query_extended(
 
             // Capture context for /fix.
             let sqlstate = e.as_db_error().map(|db| db.code().code().to_owned());
+            let is_sql_error = e.as_db_error().is_some();
+            let error_message = e
+                .as_db_error()
+                .map_or_else(|| e.to_string(), |db| db.message().to_owned());
             settings.last_error = Some(LastError {
                 query: sql_to_send.to_owned(),
-                error_message: e
-                    .as_db_error()
-                    .map_or_else(|| e.to_string(), |db| db.message().to_owned()),
+                error_message,
                 sqlstate,
             });
+
+            // Auto-suggest /fix hint for SQL errors when AI is configured.
+            if is_sql_error
+                && settings.auto_suggest_fix
+                && !settings.last_was_fix
+                && settings
+                    .config
+                    .ai
+                    .provider
+                    .as_deref()
+                    .is_some_and(|p| !p.is_empty())
+            {
+                eprintln!("\x1b[2mHint: type /fix to auto-correct this query\x1b[0m");
+            }
 
             false
         }
@@ -572,6 +626,9 @@ pub async fn execute_query_extended(
         // Increment session query counter.
         settings.query_count = settings.query_count.saturating_add(1);
     }
+
+    // Always clear the /fix-loop guard after each execution.
+    settings.last_was_fix = false;
 
     success
 }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1031,6 +1031,15 @@ pub struct ReplSettings {
     ///
     /// Updated after each query execution.
     pub last_query_duration_ms: Option<u64>,
+    /// Show an inline hint ("type /fix …") after a SQL error.
+    ///
+    /// Defaults to `true`. Disable with `\set AUTO_SUGGEST off`.
+    /// Only shown when AI is configured and the error is a SQL error.
+    pub auto_suggest_fix: bool,
+    /// Set to `true` immediately before `/fix` runs so that the inline
+    /// hint is suppressed for any error produced by the fixed query,
+    /// avoiding suggestion loops.  Cleared after each query execution.
+    pub last_was_fix: bool,
 }
 
 impl std::fmt::Debug for ReplSettings {
@@ -1123,6 +1132,8 @@ impl std::fmt::Debug for ReplSettings {
             .field("ai_context_files", &self.ai_context_files.len())
             .field("statusline", &self.statusline.as_ref().map(|s| s.enabled))
             .field("last_query_duration_ms", &self.last_query_duration_ms)
+            .field("auto_suggest_fix", &self.auto_suggest_fix)
+            .field("last_was_fix", &self.last_was_fix)
             .finish()
     }
 }
@@ -1182,6 +1193,8 @@ impl Default for ReplSettings {
             ai_context_files: Vec::new(),
             statusline: None,
             last_query_duration_ms: None,
+            auto_suggest_fix: true,
+            last_was_fix: false,
         }
     }
 }
@@ -1991,6 +2004,16 @@ fn apply_set(settings: &mut ReplSettings, name: &str, value: &str) {
             println!("Vi mode enabled. Takes effect on next session.");
         } else {
             println!("Emacs mode (default). Takes effect on next session.");
+        }
+    }
+    // Mirror AUTO_SUGGEST into auto_suggest_fix.
+    if name == "AUTO_SUGGEST" {
+        let on = value != "off" && value != "false" && value != "0";
+        settings.auto_suggest_fix = on;
+        if on {
+            println!("Auto-suggest /fix hint enabled.");
+        } else {
+            println!("Auto-suggest /fix hint disabled.");
         }
     }
     // Mirror STATUSLINE into the status bar enabled flag.
@@ -5533,6 +5556,50 @@ mod tests {
         apply_set(&mut settings, "TOKEN_BUDGET", "10000");
         apply_set(&mut settings, "TOKEN_BUDGET", "20000");
         assert_eq!(settings.config.ai.token_budget, 20_000);
+    }
+
+    // -- \set AUTO_SUGGEST (#368) ----------------------------------------------
+
+    #[test]
+    fn auto_suggest_fix_default_is_true() {
+        let s = ReplSettings::default();
+        assert!(s.auto_suggest_fix);
+    }
+
+    #[test]
+    fn last_was_fix_default_is_false() {
+        let s = ReplSettings::default();
+        assert!(!s.last_was_fix);
+    }
+
+    #[test]
+    fn set_auto_suggest_off_disables_flag() {
+        let mut settings = ReplSettings::default();
+        assert!(settings.auto_suggest_fix);
+        apply_set(&mut settings, "AUTO_SUGGEST", "off");
+        assert!(!settings.auto_suggest_fix);
+    }
+
+    #[test]
+    fn set_auto_suggest_on_enables_flag() {
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "AUTO_SUGGEST", "off");
+        apply_set(&mut settings, "AUTO_SUGGEST", "on");
+        assert!(settings.auto_suggest_fix);
+    }
+
+    #[test]
+    fn set_auto_suggest_false_disables_flag() {
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "AUTO_SUGGEST", "false");
+        assert!(!settings.auto_suggest_fix);
+    }
+
+    #[test]
+    fn set_auto_suggest_zero_disables_flag() {
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "AUTO_SUGGEST", "0");
+        assert!(!settings.auto_suggest_fix);
     }
 
     // -- \set VI ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- After a SQL error, print a dim hint (`Hint: type /fix to auto-correct this query`) when AI is configured and `auto_suggest_fix` is enabled (default: `true`)
- Add `auto_suggest_fix` field to `ReplSettings` (default `true`) and `last_was_fix` guard to prevent hint loops when `/fix` itself re-runs a query that errors
- Wire `\set AUTO_SUGGEST on|off` in `apply_set()` so users can disable the hint

## Implementation detail

- `execute_query` and `execute_query_extended` both show the hint on SQL errors (`db_error` present) when: AI provider is set, `auto_suggest_fix` is `true`, and `last_was_fix` is `false`
- `handle_ai_fix` sets `last_was_fix = true` before executing the corrected query; both execute functions always reset it to `false` on exit
- Six new unit tests cover default values and `\set AUTO_SUGGEST` toggling

## Test plan

- [ ] Run `cargo test` — all 1383 tests pass
- [ ] Run `cargo clippy -- -D warnings` — no warnings
- [ ] Manual: connect to Postgres, run a query with a typo (e.g. `select signup_dat from users`) — confirm dim hint appears after the error
- [ ] Run `/fix` — confirm hint is suppressed for the re-executed query
- [ ] Run `\set AUTO_SUGGEST off` — confirm hint no longer appears

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)