### PR TITLE
fix(daemon): gate Unix-only imports with #[cfg(unix)]

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -90,11 +90,10 @@ pub fn generate_health_token() -> String {
 
 /// Write the bearer token to the token file (mode 0600 on Unix).
 pub fn write_token_file(path: &Path, token: &str) -> std::io::Result<()> {
-    use std::fs::OpenOptions;
-    use std::io::Write as _;
-
     #[cfg(unix)]
     {
+        use std::fs::OpenOptions;
+        use std::io::Write as _;
         use std::os::unix::fs::OpenOptionsExt;
         let mut opts = OpenOptions::new();
         opts.write(true).create(true).truncate(true).mode(0o600);


### PR DESCRIPTION
## Summary
- Move `OpenOptions` and `Write` imports inside the `#[cfg(unix)]` block in `write_token_file()`
- Fixes Windows build failures caused by unused import warnings with `-D warnings`

## Test plan
- [ ] Windows x86_64 build passes
- [ ] Windows aarch64 build passes
- [ ] Unix builds unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)