### PR TITLE
feat(repl): auto-EXPLAIN mode with \set EXPLAIN and F5 cycling

### DIFF
--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -129,6 +129,7 @@ pub async fn execute_query(
     // non-query statements (SET, BEGIN, COMMIT, etc.).
     let auto_explained;
     let mut auto_explain_active = false;
+    let auto_explain_label = settings.auto_explain.label();
     let sql_to_send = if settings.auto_explain == AutoExplain::Off {
         interpolated.as_str()
     } else {
@@ -252,10 +253,10 @@ pub async fn execute_query(
                         // Capture rendered output so we can mirror to log.
                         let mut out_buf = Vec::<u8>::new();
 
-                        // Print "--- EXPLAIN ---" header before the plan
-                        // output so users can distinguish plan from results.
+                        // Print "[auto-explain: <mode>]" header before the
+                        // plan output so users know EXPLAIN was prepended.
                         if auto_explain_active && result_set_index == 0 {
-                            let _ = writeln!(out_buf, "--- EXPLAIN ---");
+                            let _ = writeln!(out_buf, "[auto-explain: {auto_explain_label}]");
                         }
 
                         print_result_set_pset(
@@ -957,6 +958,7 @@ pub(super) async fn execute_query_interactive(
     let token_budget = u32::try_from(settings.config.ai.token_budget).unwrap_or(u32::MAX);
     let input_mode = settings.input_mode;
     let exec_mode = settings.exec_mode;
+    let auto_explain = settings.auto_explain;
     let tx_state = *tx;
     if let Some(ref mut sl) = settings.statusline {
         sl.update(
@@ -967,6 +969,7 @@ pub(super) async fn execute_query_interactive(
             input_mode,
             exec_mode,
         );
+        sl.set_auto_explain(auto_explain);
     }
 
     ok
@@ -1074,6 +1077,7 @@ pub(super) async fn execute_query_extended_interactive(
     let token_budget = u32::try_from(settings.config.ai.token_budget).unwrap_or(u32::MAX);
     let input_mode = settings.input_mode;
     let exec_mode = settings.exec_mode;
+    let auto_explain = settings.auto_explain;
     let tx_state = *tx;
     if let Some(ref mut sl) = settings.statusline {
         sl.update(
@@ -1084,6 +1088,7 @@ pub(super) async fn execute_query_extended_interactive(
             input_mode,
             exec_mode,
         );
+        sl.set_auto_explain(auto_explain);
     }
 
     ok

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -576,8 +576,7 @@ pub enum AutoExplain {
 
 impl AutoExplain {
     /// Cycle to the next mode: Off → On → Analyze → Verbose → Off.
-    #[allow(dead_code)]
-    fn cycle(self) -> Self {
+    pub(crate) fn cycle(self) -> Self {
         match self {
             Self::Off => Self::On,
             Self::On => Self::Analyze,
@@ -597,7 +596,7 @@ impl AutoExplain {
     }
 
     /// Human-readable label.
-    fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Off => "off",
             Self::On => "on",
@@ -1881,6 +1880,11 @@ fn apply_set(settings: &mut ReplSettings, name: &str, value: &str) {
         return;
     }
     if value.is_empty() {
+        // Synthetic settings: show current state rather than the vars store.
+        if name == "EXPLAIN" {
+            println!("Auto-EXPLAIN is {}.", settings.auto_explain.label());
+            return;
+        }
         // Display one variable.
         match settings.vars.get(name) {
             Some(v) => println!("{name} = '{v}'"),
@@ -1938,7 +1942,7 @@ fn apply_set(settings: &mut ReplSettings, name: &str, value: &str) {
             "on" | "true" | "1" => AutoExplain::On,
             "analyze" => AutoExplain::Analyze,
             "verbose" => AutoExplain::Verbose,
-            "off" | "false" | "0" | "" => AutoExplain::Off,
+            "off" | "false" | "0" => AutoExplain::Off,
             other => {
                 eprintln!(
                     "\\set EXPLAIN: unknown value \"{other}\"\n\
@@ -2087,11 +2091,7 @@ fn apply_fkey_toggle(action: FKeyAction, settings: &mut ReplSettings) {
             }
         }
         FKeyAction::AutoExplain => {
-            settings.auto_explain = if settings.auto_explain == AutoExplain::Off {
-                AutoExplain::On
-            } else {
-                AutoExplain::Off
-            };
+            settings.auto_explain = settings.auto_explain.cycle();
             println!("Auto-EXPLAIN is {}.", settings.auto_explain.label());
         }
         FKeyAction::Text2Sql => {
@@ -3542,6 +3542,7 @@ async fn run_readline_loop(
         // Re-render the status bar before each prompt so it stays fresh
         // (handles resize events and mode changes from previous commands).
         if let Some(ref mut sl) = settings.statusline {
+            sl.set_auto_explain(settings.auto_explain);
             sl.on_resize();
         }
 
@@ -5431,6 +5432,30 @@ mod tests {
         let mut settings = ReplSettings::default();
         apply_set(&mut settings, "EXPLAIN", "on");
         apply_set(&mut settings, "EXPLAIN", "off");
+        assert_eq!(settings.auto_explain, AutoExplain::Off);
+    }
+
+    #[test]
+    fn set_explain_no_value_does_not_change_mode() {
+        // \set EXPLAIN (no value) should show current mode, not reset it.
+        let mut settings = ReplSettings::default();
+        apply_set(&mut settings, "EXPLAIN", "analyze");
+        // Calling with empty value must not change the mode.
+        apply_set(&mut settings, "EXPLAIN", "");
+        assert_eq!(settings.auto_explain, AutoExplain::Analyze);
+    }
+
+    #[test]
+    fn fkey_auto_explain_cycles_all_modes() {
+        let mut settings = ReplSettings::default();
+        assert_eq!(settings.auto_explain, AutoExplain::Off);
+        apply_fkey_toggle(FKeyAction::AutoExplain, &mut settings);
+        assert_eq!(settings.auto_explain, AutoExplain::On);
+        apply_fkey_toggle(FKeyAction::AutoExplain, &mut settings);
+        assert_eq!(settings.auto_explain, AutoExplain::Analyze);
+        apply_fkey_toggle(FKeyAction::AutoExplain, &mut settings);
+        assert_eq!(settings.auto_explain, AutoExplain::Verbose);
+        apply_fkey_toggle(FKeyAction::AutoExplain, &mut settings);
         assert_eq!(settings.auto_explain, AutoExplain::Off);
     }
 

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -14,7 +14,7 @@
 
 use std::io::{self, IsTerminal, Write};
 
-use crate::repl::{ExecMode, InputMode, TxState};
+use crate::repl::{AutoExplain, ExecMode, InputMode, TxState};
 
 // ---------------------------------------------------------------------------
 // Status bar state
@@ -42,6 +42,8 @@ pub struct StatusLine {
     ai_tokens_used: u64,
     /// Configured AI token budget (0 = unlimited / no AI configured).
     ai_token_budget: u32,
+    /// Current auto-EXPLAIN level (shown when not Off).
+    auto_explain: AutoExplain,
 }
 
 impl StatusLine {
@@ -62,6 +64,7 @@ impl StatusLine {
             last_duration_ms: None,
             ai_tokens_used: 0,
             ai_token_budget: 0,
+            auto_explain: AutoExplain::Off,
         }
     }
 
@@ -91,6 +94,12 @@ impl StatusLine {
         self.ai_token_budget = token_budget;
         self.input_mode = input_mode;
         self.exec_mode = exec_mode;
+        self.render();
+    }
+
+    /// Set the current auto-EXPLAIN level and re-render.
+    pub fn set_auto_explain(&mut self, mode: AutoExplain) {
+        self.auto_explain = mode;
         self.render();
     }
 
@@ -185,13 +194,20 @@ impl StatusLine {
             String::new()
         };
 
+        // Auto-EXPLAIN indicator (only when active).
+        let explain = if self.auto_explain == AutoExplain::Off {
+            String::new()
+        } else {
+            format!(" │ explain:{}", self.auto_explain.label())
+        };
+
         // Assemble the status string.
         let conn = if self.conn_label.is_empty() {
             String::new()
         } else {
             format!(" {} │", self.conn_label)
         };
-        let inner = format!("{conn} {mode} │ tx:{tx}{duration}{ai} ");
+        let inner = format!("{conn} {mode} │ tx:{tx}{duration}{explain}{ai} ");
 
         // Pad or truncate to terminal width.
         let width = self.term_cols as usize;


### PR DESCRIPTION
## Summary

- **F5 key now cycles through all four modes**: Off → On → Analyze → Verbose → Off (previously only toggled Off ↔ On)
- **`\set EXPLAIN` without a value** now shows the current mode instead of silently resetting it to `Off`
- **Output header changed** from `--- EXPLAIN ---` to `[auto-explain: <mode>]` so users immediately know which EXPLAIN variant was prepended
- **Status bar** displays `│ explain:<mode>` when auto-EXPLAIN is active

## Changes

- `src/repl/mod.rs`: intercept `\set EXPLAIN` with empty value before the generic vars lookup; use `.cycle()` in F5 handler; make `AutoExplain::label()` and `cycle()` `pub(crate)`; sync statusline auto_explain state before each prompt
- `src/repl/execute.rs`: replace `--- EXPLAIN ---` header with `[auto-explain: <mode>]`; call `sl.set_auto_explain()` after each query
- `src/statusline.rs`: add `auto_explain` field; add `set_auto_explain()` method; render `│ explain:<mode>` when not Off

## Test plan

- [ ] `cargo test` — 1389 tests pass (2 new: `set_explain_no_value_does_not_change_mode`, `fkey_auto_explain_cycles_all_modes`)
- [ ] `RUSTFLAGS="" cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt` — clean
- [ ] Manual: `\set EXPLAIN on`, then `select 1` → output begins with `[auto-explain: on]`
- [ ] Manual: `\set EXPLAIN analyze`, then `select 1` → output begins with `[auto-explain: analyze]`
- [ ] Manual: `\set EXPLAIN` (no value) while in analyze mode → prints `Auto-EXPLAIN is analyze.`
- [ ] Manual: press F5 repeatedly → cycles Off → on → analyze → verbose → off
- [ ] Manual: status bar shows `│ explain:analyze` when in analyze mode

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)