### PR TITLE
feat(repl): \autonomy command for per-feature control

### DIFF
--- a/src/governance.rs
+++ b/src/governance.rs
@@ -59,6 +59,39 @@ impl FeatureArea {
             Self::Security => "security",
         }
     }
+
+    /// Parse a feature area from its label string (case-insensitive).
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "vacuum" => Some(Self::Vacuum),
+            "bloat" => Some(Self::Bloat),
+            "index_health" => Some(Self::IndexHealth),
+            "config_tuning" => Some(Self::ConfigTuning),
+            "query_optimization" => Some(Self::QueryOptimization),
+            "connection_management" => Some(Self::ConnectionManagement),
+            "replication" => Some(Self::Replication),
+            "rca" => Some(Self::Rca),
+            "backup_monitoring" => Some(Self::BackupMonitoring),
+            "security" => Some(Self::Security),
+            _ => None,
+        }
+    }
+
+    /// All feature areas in display order.
+    pub fn all() -> &'static [Self] {
+        &[
+            Self::Vacuum,
+            Self::Bloat,
+            Self::IndexHealth,
+            Self::ConfigTuning,
+            Self::QueryOptimization,
+            Self::ConnectionManagement,
+            Self::Replication,
+            Self::Rca,
+            Self::BackupMonitoring,
+            Self::Security,
+        ]
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -85,6 +118,27 @@ impl AutonomyLevel {
             Self::Observe => "O",
             Self::Supervised => "S",
             Self::Auto => "A",
+        }
+    }
+
+    /// Human-readable label for display.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Observe => "observe",
+            Self::Supervised => "supervised",
+            Self::Auto => "auto",
+        }
+    }
+
+    /// Parse from a string (case-insensitive).
+    ///
+    /// Accepts `"observe"` / `"o"`, `"supervised"` / `"s"`, `"auto"` / `"a"`.
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "observe" | "o" => Some(Self::Observe),
+            "supervised" | "s" => Some(Self::Supervised),
+            "auto" | "a" => Some(Self::Auto),
+            _ => None,
         }
     }
 }

--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -336,6 +336,20 @@ pub enum MetaCmd {
     /// ```
     LogFile(Option<String>),
 
+    // -- Autonomy control (#386) -------------------------------------------
+    /// `\autonomy [<area> <level> | all <level>]` — view or set per-feature
+    /// autonomy levels.
+    ///
+    /// - `\autonomy` — display a table of all feature areas and their levels.
+    /// - `\autonomy <area> <level>` — set one feature area's autonomy level.
+    /// - `\autonomy all <level>` — set all feature areas to the given level.
+    ///
+    /// Valid levels: `observe` (O), `supervised` (S), `auto` (A).
+    ///
+    /// Payload: `(area, level)` when both args are given; `("", "")` when bare
+    /// (display mode).  `area` is `"all"` for the bulk-set variant.
+    Autonomy(String, String),
+
     // -- Fallback ----------------------------------------------------------
     /// Unrecognised command; carries the original command token.
     Unknown(String),
@@ -477,7 +491,7 @@ pub fn parse(input: &str) -> ParsedMeta {
             parse_simple_or_unknown(input, "q", MetaCmd::Quit)
         }
         Some('?') => parse_simple_or_unknown(input, "?", MetaCmd::Help),
-        Some('a') => parse_simple_or_unknown(input, "a", MetaCmd::ToggleAlign),
+        Some('a') => parse_a_family(input),
         Some('c') => parse_c_family(input),
         Some('C') => parse_set_title(input),
         Some('e') => parse_e_family(input),
@@ -509,6 +523,27 @@ pub fn parse(input: &str) -> ParsedMeta {
 // ---------------------------------------------------------------------------
 // Command-specific parsers
 // ---------------------------------------------------------------------------
+
+/// Parse `\a` (toggle align) or `\autonomy [area level]`.
+fn parse_a_family(input: &str) -> ParsedMeta {
+    // `\autonomy` — must be checked before bare `\a` (longer prefix).
+    if let Some(rest) = input.strip_prefix("autonomy") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            let rest = rest.trim();
+            if rest.is_empty() {
+                // Bare `\autonomy` — display table.
+                return ParsedMeta::simple(MetaCmd::Autonomy(String::new(), String::new()));
+            }
+            // Parse `area level` or `all level`.
+            let mut parts = rest.splitn(2, char::is_whitespace);
+            let area = parts.next().unwrap_or("").to_owned();
+            let level = parts.next().map_or("", str::trim).to_owned();
+            return ParsedMeta::simple(MetaCmd::Autonomy(area, level));
+        }
+    }
+    // Bare `\a` — toggle aligned/unaligned output.
+    parse_simple_or_unknown(input, "a", MetaCmd::ToggleAlign)
+}
 
 /// Parse commands that must match a fixed token exactly (e.g. `\q`, `\?`).
 fn parse_simple_or_unknown(input: &str, token: &str, cmd: MetaCmd) -> ParsedMeta {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -3138,12 +3138,68 @@ async fn dispatch_meta(
                 return result;
             }
         }
+        // Autonomy control (#386).
+        MetaCmd::Autonomy(ref area, ref level) => {
+            dispatch_autonomy(area, level, settings);
+        }
         ref stub => {
             eprintln!("{}: not yet implemented (see #27)", stub.label());
         }
     }
 
     MetaResult::Continue
+}
+
+// ---------------------------------------------------------------------------
+// Autonomy control (#386)
+// ---------------------------------------------------------------------------
+
+/// Handle `\autonomy [area level | all level]`.
+///
+/// - No args: print a table of all feature areas and their current levels.
+/// - `area level`: set one feature area's autonomy level.
+/// - `all level`: set all feature areas to the given level.
+fn dispatch_autonomy(area: &str, level: &str, settings: &mut ReplSettings) {
+    use crate::governance::{AutonomyLevel, FeatureArea};
+
+    if area.is_empty() {
+        // Display table.
+        println!("{:<22}  Autonomy", "Feature area");
+        println!("{}  {}", "-".repeat(22), "-".repeat(10));
+        for &feature in FeatureArea::all() {
+            let current = settings.config.governance.autonomy_for(feature);
+            println!("{:<22}  {}", feature.label(), current.label());
+        }
+        return;
+    }
+
+    // Parse the level.
+    let Some(new_level) = AutonomyLevel::from_str(level) else {
+        eprintln!(
+            "\\autonomy: unknown level \"{level}\". \
+             Valid levels: observe, supervised, auto"
+        );
+        return;
+    };
+
+    if area == "all" {
+        for &feature in FeatureArea::all() {
+            settings.config.governance.set_autonomy(feature, new_level);
+        }
+        println!("all autonomy set to {}.", new_level.label());
+        return;
+    }
+
+    let Some(feature) = FeatureArea::from_str(area) else {
+        eprintln!(
+            "\\autonomy: unknown feature area \"{area}\". \
+             Use \\autonomy (no args) to list valid areas."
+        );
+        return;
+    };
+
+    settings.config.governance.set_autonomy(feature, new_level);
+    println!("{} autonomy set to {}.", feature.label(), new_level.label());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `\autonomy` metacommand to view and control per-feature autonomy levels
- `\autonomy` (no args) prints a table of all 10 feature areas and their current level
- `\autonomy <area> <level>` sets one feature area's level (e.g. `\autonomy vacuum auto`)
- `\autonomy all <level>` sets all feature areas at once

## Implementation

- **`src/governance.rs`**: Added `FeatureArea::from_str`, `FeatureArea::all`, `AutonomyLevel::label`, and `AutonomyLevel::from_str` helper methods
- **`src/metacmd.rs`**: Added `MetaCmd::Autonomy(String, String)` variant; split `'a'` dispatch into `parse_a_family` that handles both `\a` (toggle-align) and the longer `\autonomy` prefix (greedy longest-match)
- **`src/repl/mod.rs`**: Added `dispatch_autonomy` function and wired `MetaCmd::Autonomy` into the handler match; reads/writes `settings.config.governance`

## Test plan

- [ ] `\autonomy` — displays 10-row table with all areas defaulting to `observe`
- [ ] `\autonomy vacuum auto` — prints `vacuum autonomy set to auto.`
- [ ] `\autonomy all supervised` — prints `all autonomy set to supervised.`; subsequent `\autonomy` shows all as `supervised`
- [ ] `\autonomy badarea auto` — prints error: unknown feature area
- [ ] `\autonomy vacuum badlevel` — prints error: unknown level
- [ ] `\a` — still toggles aligned/unaligned output (no regression)
- [ ] All 1400 existing unit tests pass (`cargo test`)
- [ ] `cargo clippy -- -D warnings` clean

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)