### PR TITLE
feat(governance): persist post-action verification in audit log

### DIFF
--- a/src/governance.rs
+++ b/src/governance.rs
@@ -266,6 +266,11 @@ pub struct AuditLogEntry {
     pub outcome: ActionOutcome,
     /// Auditor's assessment (if any).
     pub auditor_note: Option<String>,
+    /// Post-action verification result.
+    ///
+    /// `Some(true)` = verified resolved, `Some(false)` = problem persists,
+    /// `None` = verification not performed or not applicable.
+    pub verified: Option<bool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -310,6 +315,7 @@ impl AuditLog {
             justification,
             outcome,
             auditor_note,
+            verified: None,
         });
         seq
     }
@@ -335,6 +341,16 @@ impl AuditLog {
             .iter()
             .filter(|e| e.feature == feature)
             .collect()
+    }
+
+    /// Set the verification result for an entry identified by sequence number.
+    ///
+    /// Used by the post-action verification step to update an entry after
+    /// the action has been executed and checked.
+    pub fn set_verification(&mut self, seq: u64, verified: bool) {
+        if let Some(entry) = self.entries.iter_mut().find(|e| e.seq == seq) {
+            entry.verified = Some(verified);
+        }
     }
 
     /// Serialize the log to JSON (for export/persistence).

--- a/src/rca_actions.rs
+++ b/src/rca_actions.rs
@@ -395,7 +395,8 @@ pub async fn run_auto_flow(
         let outcome = actor.execute(client, &action_request).await;
         let success = matches!(outcome, ActionOutcome::Success { .. });
 
-        if success {
+        // Capture verification result before consuming outcome.
+        let verified_result: Option<bool> = if success {
             if let ActionOutcome::Success { ref detail } = outcome {
                 crate::logging::info("auto", &format!("Executed: {detail}"));
             }
@@ -415,14 +416,19 @@ pub async fn run_auto_flow(
                     ),
                 );
             }
+            Some(verified)
         } else {
             if let ActionOutcome::Failure { ref error } = outcome {
                 crate::logging::warn("auto", &format!("Failed: {error}"));
             }
             circuit_breaker.record(proposal.feature, false);
-        }
+            None
+        };
 
-        log_action(audit_log, proposal, AutonomyLevel::Auto, outcome, None);
+        let seq = log_action(audit_log, proposal, AutonomyLevel::Auto, outcome, None);
+        if let Some(verified) = verified_result {
+            audit_log.set_verification(seq, verified);
+        }
         if success {
             executed += 1;
         }
@@ -436,13 +442,16 @@ pub async fn run_auto_flow(
 }
 
 /// Log an action to the audit log.
+///
+/// Returns the sequence number of the new entry, so callers can
+/// update it later (e.g., with a verification result).
 fn log_action(
     audit_log: &mut AuditLog,
     proposal: &ActionProposal,
     autonomy: AutonomyLevel,
     outcome: ActionOutcome,
     note: Option<String>,
-) {
+) -> u64 {
     audit_log.record(
         proposal.feature,
         autonomy,
@@ -450,7 +459,7 @@ fn log_action(
         proposal.finding.clone(),
         outcome,
         note,
-    );
+    )
 }
 
 /// Present a single proposal, prompt the user, and execute if approved.
@@ -557,33 +566,38 @@ async fn present_and_execute(
     let success = matches!(outcome, ActionOutcome::Success { .. });
 
     // Post-action verification (on success only).
-    let verified_note = if success {
+    let (verified_note, verified_result) = if success {
         if let ActionOutcome::Success { detail } = &outcome {
             eprintln!("      Done: {detail}");
         }
         let vr = crate::verification::verify_action(client, &action_request.action_type).await;
         eprintln!("      Verify: {vr}\n");
 
+        let confirmed = vr.is_confirmed();
         // Append verification result to auditor note.
         let vr_str = format!(" | Verification: {vr}");
-        Some(match note {
+        let combined_note = Some(match note {
             Some(n) => format!("{n}{vr_str}"),
             None => vr_str,
-        })
+        });
+        (combined_note, Some(confirmed))
     } else {
         match &outcome {
             ActionOutcome::Failure { error } => eprintln!("      Failed: {error}\n"),
             other => eprintln!("      {other:?}\n"),
         }
-        note
+        (note, None)
     };
-    log_action(
+    let seq = log_action(
         audit_log,
         proposal,
         AutonomyLevel::Supervised,
         outcome,
         verified_note,
     );
+    if let Some(verified) = verified_result {
+        audit_log.set_verification(seq, verified);
+    }
     success
 }
 


### PR DESCRIPTION
## Summary

- Adds `verified: Option<bool>` field to `AuditLogEntry` in governance.rs
- Adds `set_verification()` method to `AuditLog` for post-execution updates
- Changes `log_action()` in rca_actions.rs to return seq number for later update
- Wires verification results into both `run_supervised_flow()` and `run_auto_flow()`
- In Auto mode, failed verifications feed into circuit breaker
- Closes #448

## Test plan

- [x] `cargo check` clean
- [x] All 1686 existing tests pass
- [ ] Manual: execute supervised action, verify audit log entry has `verified` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)