### PR TITLE
chore(deploy): rename samo → rpg in all deploy files

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,18 +1,18 @@
-# Samo container image — Alpine-based, minimal footprint.
+# Rpg container image — Alpine-based, minimal footprint.
 #
 # Build:
-#   docker build -t samo:latest -f deploy/Dockerfile .
+#   docker build -t rpg:latest -f deploy/Dockerfile .
 #
 # Run:
 #   docker run --rm \
 #     -e PGHOST=host.docker.internal \
 #     -e PGPORT=5432 \
-#     -e PGUSER=samo \
+#     -e PGUSER=rpg \
 #     -e PGDATABASE=postgres \
-#     samo:latest daemon
+#     rpg:latest --daemon
 
 # --- Build stage ---
-FROM rust:1.82-alpine AS builder
+FROM rust:1.85-alpine AS builder
 
 RUN apk add --no-cache musl-dev git
 
@@ -25,11 +25,11 @@ RUN cargo build --release --target x86_64-unknown-linux-musl
 FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates && \
-    adduser -D -H -s /sbin/nologin samo
+    adduser -D -H -s /sbin/nologin rpg
 
-COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/samo /usr/local/bin/samo
+COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/rpg /usr/local/bin/rpg
 
-USER samo
+USER rpg
 
-ENTRYPOINT ["samo"]
+ENTRYPOINT ["rpg"]
 CMD ["--help"]

--- a/deploy/com.rpg.agent.plist
+++ b/deploy/com.rpg.agent.plist
@@ -1,11 +1,11 @@
-<!-- Launchd plist for Samo daemon mode (macOS).
+<!-- Launchd plist for Rpg daemon mode (macOS).
 
 Installation:
-  1. Copy binary to /usr/local/bin/samo
-  2. Copy config to /usr/local/etc/samo/config.toml
+  1. Copy binary to /usr/local/bin/rpg
+  2. Copy config to /usr/local/etc/rpg/config.toml
   3. Copy this file to ~/Library/LaunchAgents/ (user) or
      /Library/LaunchDaemons/ (system-wide)
-  4. Load: launchctl load ~/Library/LaunchAgents/com.samo.agent.plist
+  4. Load: launchctl load ~/Library/LaunchAgents/com.rpg.agent.plist
 
 Environment variables:
   Set PGHOST, PGPORT, etc. in the EnvironmentVariables dict below,
@@ -16,14 +16,14 @@ Environment variables:
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.samo.agent</string>
+    <string>com.rpg.agent</string>
 
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/bin/samo</string>
-        <string>daemon</string>
+        <string>/usr/local/bin/rpg</string>
+        <string>--daemon</string>
         <string>--config</string>
-        <string>/usr/local/etc/samo/config.toml</string>
+        <string>/usr/local/etc/rpg/config.toml</string>
     </array>
 
     <key>RunAtLoad</key>
@@ -39,10 +39,10 @@ Environment variables:
     <integer>5</integer>
 
     <key>StandardOutPath</key>
-    <string>/usr/local/var/log/samo/stdout.log</string>
+    <string>/usr/local/var/log/rpg/stdout.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/usr/local/var/log/samo/stderr.log</string>
+    <string>/usr/local/var/log/rpg/stderr.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
@@ -52,7 +52,7 @@ Environment variables:
         <key>PGPORT</key>
         <string>5432</string>
         <key>PGUSER</key>
-        <string>samo</string>
+        <string>rpg</string>
         <key>PGDATABASE</key>
         <string>postgres</string>
         -->

--- a/deploy/helm/rpg/templates/_helpers.tpl
+++ b/deploy/helm/rpg/templates/_helpers.tpl
@@ -1,14 +1,14 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "samo.name" -}}
+{{- define "rpg.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create a default fully qualified app name.
 */}}
-{{- define "samo.fullname" -}}
+{{- define "rpg.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -24,9 +24,9 @@ Create a default fully qualified app name.
 {{/*
 Common labels.
 */}}
-{{- define "samo.labels" -}}
-helm.sh/chart: {{ include "samo.chart" . }}
-{{ include "samo.selectorLabels" . }}
+{{- define "rpg.labels" -}}
+helm.sh/chart: {{ include "rpg.chart" . }}
+{{ include "rpg.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -36,24 +36,24 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels.
 */}}
-{{- define "samo.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "samo.name" . }}
+{{- define "rpg.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rpg.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Chart label.
 */}}
-{{- define "samo.chart" -}}
+{{- define "rpg.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Service account name.
 */}}
-{{- define "samo.serviceAccountName" -}}
+{{- define "rpg.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "samo.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "rpg.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -62,7 +62,7 @@ Service account name.
 {{/*
 Image reference.
 */}}
-{{- define "samo.image" -}}
+{{- define "rpg.image" -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}

--- a/deploy/install-windows-service.ps1
+++ b/deploy/install-windows-service.ps1
@@ -1,27 +1,27 @@
-# Install Samo as a Windows service using NSSM (Non-Sucking Service Manager).
+# Install Rpg as a Windows service using NSSM (Non-Sucking Service Manager).
 #
 # Prerequisites:
 #   1. Download NSSM from https://nssm.cc/download
 #   2. Place nssm.exe in PATH or current directory
-#   3. Place samo.exe in C:\Program Files\Samo\
-#   4. Create config at C:\ProgramData\Samo\config.toml
+#   3. Place rpg.exe in C:\Program Files\Rpg\
+#   4. Create config at C:\ProgramData\Rpg\config.toml
 #
 # Usage (run as Administrator):
 #   .\install-windows-service.ps1
 #
 # To remove:
-#   nssm remove Samo confirm
+#   nssm remove rpg confirm
 
 $ErrorActionPreference = "Stop"
 
-$ServiceName = "Samo"
-$SamoBin = "C:\Program Files\Samo\samo.exe"
-$ConfigPath = "C:\ProgramData\Samo\config.toml"
-$LogDir = "C:\ProgramData\Samo\logs"
+$ServiceName = "rpg"
+$RpgBin = "C:\Program Files\Rpg\rpg.exe"
+$ConfigPath = "C:\ProgramData\Rpg\config.toml"
+$LogDir = "C:\ProgramData\Rpg\logs"
 
 # Verify prerequisites
-if (-not (Test-Path $SamoBin)) {
-    Write-Error "Samo binary not found at $SamoBin"
+if (-not (Test-Path $RpgBin)) {
+    Write-Error "Rpg binary not found at $RpgBin"
     exit 1
 }
 
@@ -38,9 +38,9 @@ if (-not $nssm) {
 }
 
 # Install service
-nssm install $ServiceName $SamoBin "daemon --config `"$ConfigPath`""
-nssm set $ServiceName AppDirectory "C:\ProgramData\Samo"
-nssm set $ServiceName DisplayName "Samo - Self-Driving Postgres Agent"
+nssm install $ServiceName $RpgBin "--daemon --config `"$ConfigPath`""
+nssm set $ServiceName AppDirectory "C:\ProgramData\Rpg"
+nssm set $ServiceName DisplayName "Rpg - Self-Driving Postgres Agent"
 nssm set $ServiceName Description "Autonomous Postgres monitoring and management daemon"
 nssm set $ServiceName Start SERVICE_AUTO_START
 nssm set $ServiceName AppStdout "$LogDir\stdout.log"

--- a/deploy/rpg.service
+++ b/deploy/rpg.service
@@ -1,32 +1,32 @@
-# Systemd unit file for Samo daemon mode.
+# Systemd unit file for Rpg daemon mode.
 #
 # Installation:
-#   1. Copy this file to /etc/systemd/system/samo.service
-#   2. Copy samo binary to /usr/local/bin/samo
-#   3. Create config: /etc/samo/config.toml
-#   4. Create user:   useradd --system --no-create-home samo
-#   5. Enable:        systemctl enable --now samo
+#   1. Copy this file to /etc/systemd/system/rpg.service
+#   2. Copy rpg binary to /usr/local/bin/rpg
+#   3. Create config: /etc/rpg/config.toml
+#   4. Create user:   useradd --system --no-create-home rpg
+#   5. Enable:        systemctl enable --now rpg
 #
-# Environment variables (set in /etc/samo/env or override file):
+# Environment variables (set in /etc/rpg/env or override file):
 #   PGHOST, PGPORT, PGUSER, PGDATABASE, PGPASSWORD (or .pgpass)
 #   ANTHROPIC_API_KEY (optional, for AI features)
 
 [Unit]
-Description=Samo — self-driving Postgres agent
+Description=Rpg — self-driving Postgres agent
 Documentation=https://github.com/NikolayS/project-alpha
 After=network-online.target postgresql.service
 Wants=network-online.target
 
 [Service]
 Type=simple
-User=samo
-Group=samo
+User=rpg
+Group=rpg
 
-ExecStart=/usr/local/bin/samo daemon --config /etc/samo/config.toml
+ExecStart=/usr/local/bin/rpg --daemon --config /etc/rpg/config.toml
 ExecReload=/bin/kill -HUP $MAINPID
 
 # Environment
-EnvironmentFile=-/etc/samo/env
+EnvironmentFile=-/etc/rpg/env
 
 # Security hardening
 NoNewPrivileges=yes
@@ -44,7 +44,7 @@ LockPersonality=yes
 MemoryDenyWriteExecute=yes
 
 # Allow writing PID file and logs
-ReadWritePaths=/run/samo /var/log/samo
+ReadWritePaths=/run/rpg /var/log/rpg
 
 # Restart policy
 Restart=on-failure
@@ -58,7 +58,7 @@ LimitNOFILE=65536
 # Logging
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=samo
+SyslogIdentifier=rpg
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Renames `deploy/samo.service` → `deploy/rpg.service`
- Renames `deploy/com.samo.agent.plist` → `deploy/com.rpg.agent.plist`
- Updates all references in Dockerfile, Windows service script, and helm templates
- Uses `--daemon` flag (not `daemon` subcommand) matching current CLI
- Bumps Rust version in Dockerfile to 1.85
- Closes #451

## Test plan

- [x] No remaining `samo` references in deploy/
- [x] File renames tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)