### PR TITLE
feat(daemon): add Telegram bot notification

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -156,6 +156,8 @@ pub enum NotificationChannel {
     Email { to: String },
     /// `PagerDuty` Events API v2 routing key.
     PagerDuty { routing_key: String },
+    /// Telegram bot token and chat ID.
+    Telegram { bot_token: String, chat_id: String },
     /// Log to stderr (always active).
     Stderr,
 }
@@ -171,6 +173,9 @@ pub async fn notify(channel: &NotificationChannel, message: &str) {
         }
         NotificationChannel::PagerDuty { routing_key } => {
             send_pagerduty_notification(routing_key, message).await;
+        }
+        NotificationChannel::Telegram { bot_token, chat_id } => {
+            send_telegram_notification(bot_token, chat_id, message).await;
         }
         NotificationChannel::Email { to } => {
             eprintln!("[daemon] Email notification to {to}: {message}");
@@ -269,6 +274,39 @@ async fn send_pagerduty_notification(routing_key: &str, message: &str) {
         }
         Err(e) => {
             crate::logging::warn("daemon", &format!("PagerDuty notification error: {e}"));
+        }
+    }
+}
+
+async fn send_telegram_notification(bot_token: &str, chat_id: &str, message: &str) {
+    let url = format!("https://api.telegram.org/bot{bot_token}/sendMessage");
+    let payload = serde_json::to_string(&serde_json::json!({
+        "chat_id": chat_id,
+        "text": message,
+        "parse_mode": "Markdown",
+    }))
+    .unwrap_or_else(|_| {
+        r#"{"chat_id":"","text":"(encoding error)","parse_mode":"Markdown"}"#.to_owned()
+    });
+
+    match reqwest::Client::new()
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .body(payload)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            crate::logging::debug("daemon", "Telegram notification sent");
+        }
+        Ok(resp) => {
+            crate::logging::warn(
+                "daemon",
+                &format!("Telegram notification failed: HTTP {}", resp.status()),
+            );
+        }
+        Err(e) => {
+            crate::logging::warn("daemon", &format!("Telegram notification error: {e}"));
         }
     }
 }
@@ -1397,6 +1435,34 @@ mod tests {
         if let NotificationChannel::PagerDuty { routing_key } = ch {
             assert!(!routing_key.is_empty());
         }
+    }
+
+    #[test]
+    fn notification_channel_telegram_has_fields() {
+        let ch = NotificationChannel::Telegram {
+            bot_token: "123456:ABCdef".to_owned(),
+            chat_id: "-1001234567890".to_owned(),
+        };
+        if let NotificationChannel::Telegram { bot_token, chat_id } = ch {
+            assert!(!bot_token.is_empty());
+            assert!(!chat_id.is_empty());
+        }
+    }
+
+    #[test]
+    fn telegram_payload_has_required_fields() {
+        let chat_id = "-1001234567890";
+        let message = "test pg alert";
+        let payload = serde_json::to_string(&serde_json::json!({
+            "chat_id": chat_id,
+            "text": message,
+            "parse_mode": "Markdown",
+        }))
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(v["chat_id"], chat_id);
+        assert_eq!(v["text"], message);
+        assert_eq!(v["parse_mode"], "Markdown");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,6 +374,14 @@ struct Cli {
     #[arg(long, value_name = "KEY")]
     pagerduty_key: Option<String>,
 
+    /// Telegram bot token for daemon notifications.
+    #[arg(long, value_name = "TOKEN")]
+    telegram_bot_token: Option<String>,
+
+    /// Telegram chat ID for daemon notifications.
+    #[arg(long, value_name = "ID")]
+    telegram_chat_id: Option<String>,
+
     /// Path to PID file for daemon mode.
     #[arg(long, value_name = "PATH")]
     pid_file: Option<String>,
@@ -905,6 +913,14 @@ async fn main() {
                 if let Some(ref key) = cli.pagerduty_key {
                     channels.push(daemon::NotificationChannel::PagerDuty {
                         routing_key: key.clone(),
+                    });
+                }
+                if let (Some(ref token), Some(ref chat_id)) =
+                    (&cli.telegram_bot_token, &cli.telegram_chat_id)
+                {
+                    channels.push(daemon::NotificationChannel::Telegram {
+                        bot_token: token.clone(),
+                        chat_id: chat_id.clone(),
                     });
                 }
 


### PR DESCRIPTION
## Summary
- Add `Telegram { bot_token, chat_id }` variant to `NotificationChannel` enum
- Implement `send_telegram_notification()` using Telegram Bot API `sendMessage`
- Add `--telegram-bot-token` and `--telegram-chat-id` CLI flags
- Wire into daemon channel setup (requires both flags)
- 2 unit tests

Closes #460

## Test plan
- [x] `cargo test notification_channel_telegram` — tests pass
- [x] `cargo clippy` clean
- [x] Rebase clean on #465
- [ ] Manual: run with `--daemon --telegram-bot-token <token> --telegram-chat-id <id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)