### PR TITLE
feat(repl): wire health check commands into REPL

### DIFF
--- a/src/health_check_commands.rs
+++ b/src/health_check_commands.rs
@@ -1,11 +1,7 @@
 //! CLI command handlers for health check management.
 //!
 //! Provides formatting and management functions for [`HealthCheckRegistry`]
-//! entries. These functions are intended for REPL integration (backslash
-//! commands) but are kept in a dedicated module to allow independent testing.
-//!
-//! REPL wiring comes in a later phase; this module compiles cleanly today
-//! with `#[allow(dead_code)]` suppressing unused-item warnings.
+//! entries. Wired into the REPL via `\health` backslash commands.
 //!
 //! ## Limitation
 //!
@@ -13,9 +9,6 @@
 //! `list_by_feature()` — it has no `list_all()`. As a result,
 //! `format_health_list` shows only enabled checks. Disabled checks become
 //! visible again once the registry gains a public `list_all()` iterator.
-
-// Phase 2/3 infrastructure — not yet wired into the main dispatch loop.
-#![allow(dead_code)]
 
 use std::fs;
 use std::path::Path;
@@ -157,6 +150,7 @@ fn indent_sql(sql: &str) -> String {
 ///
 /// Returns an error string when `path` cannot be read as a directory or when
 /// every TOML file in the directory fails to parse.
+#[allow(dead_code)]
 pub fn load_health_checks_from_dir(
     registry: &mut HealthCheckRegistry,
     path: &Path,

--- a/src/health_checks.rs
+++ b/src/health_checks.rs
@@ -27,9 +27,6 @@
 //! enabled = true
 //! ```
 
-// Phase 2/3 infrastructure — not yet wired into the main dispatch loop.
-#![allow(dead_code)]
-
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -87,6 +84,7 @@ pub struct HealthCheckDefinition {
 /// name = "..."
 /// ...
 /// ```
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct CheckFile {
     checks: Vec<HealthCheckDefinition>,
@@ -127,6 +125,7 @@ impl HealthCheckRegistry {
     ///
     /// Returns an error string if the TOML is malformed or does not match
     /// the expected schema.
+    #[allow(dead_code)]
     pub fn load_from_toml(content: &str) -> Result<Vec<HealthCheckDefinition>, String> {
         toml::from_str::<CheckFile>(content)
             .map(|f| f.checks)
@@ -150,6 +149,7 @@ impl HealthCheckRegistry {
     }
 
     /// Return all checks belonging to a given feature area.
+    #[allow(dead_code)]
     pub fn list_by_feature(&self, feature: &str) -> Vec<&HealthCheckDefinition> {
         self.checks
             .iter()
@@ -168,6 +168,7 @@ impl HealthCheckRegistry {
     }
 
     /// Return `true` when the registry contains no checks.
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.checks.is_empty()
     }

--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -355,6 +355,18 @@ pub enum MetaCmd {
     /// (display mode).  `area` is `"all"` for the bulk-set variant.
     Autonomy(String, String),
 
+    // -- Health check commands (#514) --------------------------------------
+    /// `\health [list | show <name> | enable <name> | disable <name>]`
+    ///
+    /// - `\health` / `\health list` — list all health checks.
+    /// - `\health show <name>` — show details for a named check.
+    /// - `\health enable <name>` — enable a named check.
+    /// - `\health disable <name>` — disable a named check.
+    ///
+    /// The raw argument string (everything after `\health `) is stored here
+    /// for dispatch-time parsing.
+    HealthCheck(String),
+
     // -- Large object commands (#400) --------------------------------------
     /// `\lo_import <filename> [<comment>]` — import a file as a large object.
     ///
@@ -977,6 +989,13 @@ fn parse_c_family(input: &str) -> ParsedMeta {
 /// treated as the topic argument, so `\h SELECT` passes `"SELECT"` and plain
 /// `\h` passes `None`.
 fn parse_h(input: &str) -> ParsedMeta {
+    // `\health` — health check commands (check before bare `\h`)
+    if let Some(rest) = input.strip_prefix("health") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            return ParsedMeta::simple(MetaCmd::HealthCheck(rest.trim().to_owned()));
+        }
+    }
+
     let Some(rest) = input.strip_prefix('h') else {
         return ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()));
     };

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1039,6 +1039,12 @@ pub struct ReplSettings {
     /// hint is suppressed for any error produced by the fixed query,
     /// avoiding suggestion loops.  Cleared after each query execution.
     pub last_was_fix: bool,
+    /// Health check registry for `\health` commands.
+    ///
+    /// Pre-populated with the built-in default checks at session start.
+    /// Checks can be enabled or disabled at runtime via
+    /// `\health enable <name>` / `\health disable <name>`.
+    pub health_checks: crate::health_checks::HealthCheckRegistry,
 }
 
 impl std::fmt::Debug for ReplSettings {
@@ -1133,6 +1139,10 @@ impl std::fmt::Debug for ReplSettings {
             .field("last_query_duration_ms", &self.last_query_duration_ms)
             .field("auto_suggest_fix", &self.auto_suggest_fix)
             .field("last_was_fix", &self.last_was_fix)
+            .field(
+                "health_checks",
+                &format!("{} checks", self.health_checks.len()),
+            )
             .finish()
     }
 }
@@ -1194,6 +1204,7 @@ impl Default for ReplSettings {
             last_query_duration_ms: None,
             auto_suggest_fix: true,
             last_was_fix: false,
+            health_checks: crate::health_checks::HealthCheckRegistry::with_defaults(),
         }
     }
 }
@@ -1689,6 +1700,12 @@ AI commands:
   /clear            clear AI conversation context
   /compact [focus]  compact conversation context (optional focus topic)
   /budget           show token usage and remaining budget
+
+Health checks:
+  \health [list]        list all health checks
+  \health show <name>   show details for a named health check
+  \health enable <name> enable a health check
+  \health disable <name> disable a health check
 
 Named queries:
   \ns <name> <query>  save a named query (name: alphanumerics + underscores)
@@ -3136,6 +3153,10 @@ async fn dispatch_meta(
                 return result;
             }
         }
+        // Health check commands (#514).
+        MetaCmd::HealthCheck(ref args) => {
+            dispatch_health(args, settings);
+        }
         // Autonomy control (#386).
         MetaCmd::Autonomy(ref area, ref level) => {
             dispatch_autonomy(area, level, settings);
@@ -3164,6 +3185,67 @@ async fn dispatch_meta(
     }
 
     MetaResult::Continue
+}
+
+// ---------------------------------------------------------------------------
+// Health check commands (#514)
+// ---------------------------------------------------------------------------
+
+/// Handle `\health [list | show <name> | enable <name> | disable <name>]`.
+fn dispatch_health(args: &str, settings: &mut ReplSettings) {
+    let mut parts = args.splitn(2, char::is_whitespace);
+    let sub = parts.next().unwrap_or("").trim();
+    let name = parts.next().map_or("", str::trim);
+
+    match sub {
+        "" | "list" => {
+            let output = crate::health_check_commands::format_health_list(&settings.health_checks);
+            print!("{output}");
+        }
+        "show" => {
+            if name.is_empty() {
+                eprintln!("\\health show: check name required");
+            } else {
+                let output =
+                    crate::health_check_commands::format_health_show(&settings.health_checks, name);
+                print!("{output}");
+            }
+        }
+        "enable" => {
+            if name.is_empty() {
+                eprintln!("\\health enable: check name required");
+            } else {
+                match crate::health_check_commands::toggle_health_check(
+                    &mut settings.health_checks,
+                    name,
+                    true,
+                ) {
+                    Ok(()) => println!("Health check \"{name}\" enabled."),
+                    Err(e) => eprintln!("\\health enable: {e}"),
+                }
+            }
+        }
+        "disable" => {
+            if name.is_empty() {
+                eprintln!("\\health disable: check name required");
+            } else {
+                match crate::health_check_commands::toggle_health_check(
+                    &mut settings.health_checks,
+                    name,
+                    false,
+                ) {
+                    Ok(()) => println!("Health check \"{name}\" disabled."),
+                    Err(e) => eprintln!("\\health disable: {e}"),
+                }
+            }
+        }
+        other => {
+            eprintln!(
+                "\\health: unknown subcommand \"{other}\". \
+                 Valid: list, show <name>, enable <name>, disable <name>"
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Wire `\health` commands into REPL via MetaCmd::HealthCheck
- Supported: `\health list`, `\health show <name>`, `\health enable/disable <name>`
- HealthCheckRegistry initialized with defaults in ReplSettings
- Added to `\?` help output
- Removed blanket dead_code allows, added targeted ones

Closes #514

## Test plan
- [x] `cargo clippy` clean
- [x] `cargo test` — 2039 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)