### PR TITLE
feat(governance): wire LLM auditor to AI providers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::governance::{AutonomyLevel, FeatureArea};
+use crate::llm_auditor::LlmAuditorConfig;
 
 // ---------------------------------------------------------------------------
 // Top-level config
@@ -411,6 +412,8 @@ pub struct GovernanceConfig {
     ///
     /// Defaults to `None` (in-memory only).
     pub audit_log_path: Option<PathBuf>,
+    /// LLM adversarial auditor settings.
+    pub llm_auditor: LlmAuditorConfig,
 }
 
 impl Default for GovernanceConfig {
@@ -427,6 +430,7 @@ impl Default for GovernanceConfig {
             backup_monitoring: AutonomyLevel::Observe,
             security: AutonomyLevel::Observe,
             audit_log_path: None,
+            llm_auditor: LlmAuditorConfig::default(),
         }
     }
 }
@@ -1310,6 +1314,13 @@ fn merge_governance(base: GovernanceConfig, overlay: GovernanceConfig) -> Govern
             overlay_level
         }
     };
+    // For the llm_auditor sub-config, the overlay wins when it has enabled=true
+    // (i.e., is not at the default disabled state).
+    let llm_auditor = if overlay.llm_auditor.enabled {
+        overlay.llm_auditor
+    } else {
+        base.llm_auditor
+    };
     GovernanceConfig {
         vacuum: pick(base.vacuum, overlay.vacuum),
         bloat: pick(base.bloat, overlay.bloat),
@@ -1323,6 +1334,7 @@ fn merge_governance(base: GovernanceConfig, overlay: GovernanceConfig) -> Govern
         security: pick(base.security, overlay.security),
         // Overlay wins if set; fall back to base.
         audit_log_path: overlay.audit_log_path.or(base.audit_log_path),
+        llm_auditor,
     }
 }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -16,6 +16,7 @@ use crate::governance::{
     ActionOutcome, ActionProposal, AuditDecision, AuditLog, Auditor, AutoPromotionTracker,
     AutonomyLevel, CircuitBreaker, FeatureArea, VetoTracker,
 };
+use crate::llm_auditor::LlmAuditorConfig;
 
 // ---------------------------------------------------------------------------
 // Promotion status
@@ -48,11 +49,12 @@ pub struct PromotionStatus {
 /// 1. Checks vetoes (`VetoTracker` may downgrade Auto to Supervised).
 /// 2. Checks the effective autonomy level (circuit breaker may downgrade).
 /// 3. Runs rule-based Auditor review.
-/// 4. Executes (Auto) or defers (Supervised) approved proposals.
-/// 5. Records every outcome in the audit log.
-/// 6. Sets post-action verification on successful Auto executions.
-/// 7. Tracks Supervised approvals for Auto promotion eligibility.
-/// 8. Optionally persists each entry to a JSONL file for restart recovery.
+/// 4. Optionally runs LLM adversarial review for Auto-mode proposals.
+/// 5. Executes (Auto) or defers (Supervised) approved proposals.
+/// 6. Records every outcome in the audit log.
+/// 7. Sets post-action verification on successful Auto executions.
+/// 8. Tracks Supervised approvals for Auto promotion eligibility.
+/// 9. Optionally persists each entry to a JSONL file for restart recovery.
 #[derive(Debug)]
 pub struct Dispatcher {
     auditor: Auditor,
@@ -62,10 +64,14 @@ pub struct Dispatcher {
     promotion_tracker: AutoPromotionTracker,
     /// Path to the JSONL audit persistence file, if configured.
     audit_log_path: Option<PathBuf>,
+    /// Optional LLM provider for adversarial review of Auto-mode proposals.
+    llm_provider: Option<Box<dyn crate::ai::LlmProvider>>,
+    /// Configuration for the LLM adversarial auditor.
+    llm_auditor_config: LlmAuditorConfig,
 }
 
 impl Dispatcher {
-    /// Create a new Dispatcher with default configuration (no persistence).
+    /// Create a new Dispatcher with default configuration and no LLM provider.
     pub fn new() -> Self {
         Self {
             auditor: Auditor,
@@ -74,6 +80,30 @@ impl Dispatcher {
             veto_tracker: VetoTracker::new(),
             promotion_tracker: AutoPromotionTracker::new(),
             audit_log_path: None,
+            llm_provider: None,
+            llm_auditor_config: LlmAuditorConfig::default(),
+        }
+    }
+
+    /// Create a Dispatcher wired to an LLM provider for adversarial review.
+    ///
+    /// When `provider` is `Some` and `llm_auditor_config.enabled` is `true`,
+    /// Auto-mode proposals are submitted to the LLM for adversarial review
+    /// before execution.  Proposals that the LLM rejects are vetoed and
+    /// recorded in the audit log.
+    pub fn new_with_provider(
+        provider: Option<Box<dyn crate::ai::LlmProvider>>,
+        llm_auditor_config: LlmAuditorConfig,
+    ) -> Self {
+        Self {
+            auditor: Auditor,
+            circuit_breakers: HashMap::new(),
+            audit_log: AuditLog::new(),
+            veto_tracker: VetoTracker::new(),
+            promotion_tracker: AutoPromotionTracker::new(),
+            audit_log_path: None,
+            llm_provider: provider,
+            llm_auditor_config,
         }
     }
 
@@ -99,6 +129,8 @@ impl Dispatcher {
             veto_tracker: VetoTracker::new(),
             promotion_tracker: AutoPromotionTracker::new(),
             audit_log_path: Some(path),
+            llm_provider: None,
+            llm_auditor_config: LlmAuditorConfig::default(),
         }
     }
 
@@ -229,6 +261,150 @@ impl Dispatcher {
             // Auditor approved (we reached here past the rejection branch).
             // Supervised actions are "pending human"; count them as successful
             // supervised outcomes for promotion-tracking purposes.
+            self.promotion_tracker.record(proposal.feature, true, true);
+        }
+
+        outcome
+    }
+
+    /// Async variant of [`Self::dispatch_proposal`] that additionally runs
+    /// LLM adversarial review for `Auto`-mode proposals when a provider is
+    /// configured.
+    ///
+    /// # Decision flow (additional step vs the sync variant)
+    ///
+    /// After the rule-based Auditor approves a proposal in `Auto` mode, the
+    /// proposal is submitted to the configured LLM provider (if any).  If the
+    /// LLM rejects the proposal, it is vetoed and the outcome is
+    /// [`ActionOutcome::Vetoed`].  Timeout and provider errors fall back to
+    /// heuristic approval so that a transient LLM outage never blocks actions
+    /// that passed rule-based review.
+    #[allow(clippy::too_many_lines)]
+    pub async fn dispatch_proposal_async(
+        &mut self,
+        proposal: &ActionProposal,
+        autonomy: AutonomyLevel,
+    ) -> ActionOutcome {
+        // Step 1: Observe mode — never act.
+        if autonomy == AutonomyLevel::Observe {
+            let outcome = ActionOutcome::Skipped;
+            self.audit_log.record(
+                proposal.feature,
+                autonomy,
+                proposal.proposed_action.clone(),
+                proposal.finding.clone(),
+                outcome.clone(),
+                Some("Observe mode: no action taken".to_owned()),
+            );
+            return outcome;
+        }
+
+        // Step 2: VetoTracker — downgrade Auto to Supervised for known-bad
+        // action patterns, before the Auditor runs.
+        let autonomy = if autonomy == AutonomyLevel::Auto
+            && self
+                .veto_tracker
+                .is_vetoed(proposal.feature, &proposal.proposed_action)
+        {
+            AutonomyLevel::Supervised
+        } else {
+            autonomy
+        };
+
+        // Step 3: Rule-based Auditor review.
+        let decision = self.auditor.review(proposal, autonomy);
+        let auditor_note = match &decision {
+            AuditDecision::Approved { note } => note.clone(),
+            AuditDecision::Rejected { reason } => {
+                self.veto_tracker
+                    .record_veto(proposal.feature, &proposal.proposed_action);
+                let outcome = ActionOutcome::Vetoed {
+                    reason: reason.clone(),
+                };
+                self.audit_log.record(
+                    proposal.feature,
+                    autonomy,
+                    proposal.proposed_action.clone(),
+                    proposal.finding.clone(),
+                    outcome.clone(),
+                    Some(format!("Auditor rejected: {reason}")),
+                );
+                return outcome;
+            }
+        };
+
+        // Step 3b: LLM adversarial review — only for Auto-mode proposals
+        // that passed rule-based checks.
+        if autonomy == AutonomyLevel::Auto {
+            let provider_ref = self.llm_provider.as_deref();
+            let llm_review = crate::llm_auditor::review_proposal(
+                proposal,
+                &self.llm_auditor_config,
+                provider_ref,
+            )
+            .await
+            .unwrap_or_else(|err| crate::llm_auditor::LlmAuditReview {
+                approved: true,
+                concerns: vec![],
+                recommendation: format!("LLM review error (fallback): {err}"),
+            });
+
+            if !llm_review.approved {
+                let reason = format!(
+                    "LLM adversarial review rejected: {}",
+                    llm_review.recommendation
+                );
+                self.veto_tracker
+                    .record_veto(proposal.feature, &proposal.proposed_action);
+                let outcome = ActionOutcome::Vetoed {
+                    reason: reason.clone(),
+                };
+                self.audit_log.record(
+                    proposal.feature,
+                    autonomy,
+                    proposal.proposed_action.clone(),
+                    proposal.finding.clone(),
+                    outcome.clone(),
+                    Some(reason),
+                );
+                return outcome;
+            }
+        }
+
+        // Step 4: Apply circuit breaker — downgrade Auto to Supervised if
+        // the breaker for this feature has tripped.
+        let effective = self.effective_autonomy(proposal.feature, autonomy);
+
+        // Step 5 / 6: Execute or defer.
+        let outcome = match effective {
+            AutonomyLevel::Auto => ActionOutcome::Success {
+                detail: format!("Auto-executed: {}", proposal.proposed_action),
+            },
+            AutonomyLevel::Supervised | AutonomyLevel::Observe => ActionOutcome::Skipped,
+        };
+
+        // Record outcome and update circuit breaker.
+        let success = matches!(outcome, ActionOutcome::Success { .. });
+        let seq = self.audit_log.record(
+            proposal.feature,
+            effective,
+            proposal.proposed_action.clone(),
+            proposal.finding.clone(),
+            outcome.clone(),
+            auditor_note,
+        );
+        self.circuit_breakers
+            .entry(proposal.feature)
+            .or_insert_with(CircuitBreaker::new)
+            .record(proposal.feature, success);
+
+        // Step 7: Post-action verification for successful Auto executions.
+        if success && effective == AutonomyLevel::Auto {
+            self.audit_log.set_verification(seq, true);
+        }
+
+        // Record Supervised approvals in the promotion tracker.
+        if effective == AutonomyLevel::Supervised {
             self.promotion_tracker.record(proposal.feature, true, true);
         }
 
@@ -1242,6 +1418,197 @@ mod tests {
             lines.lines().count(),
             3,
             "all three outcomes must be persisted"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock LLM provider for async dispatch tests
+    // -----------------------------------------------------------------------
+
+    #[derive(Debug)]
+    struct MockLlmProvider {
+        response: String,
+    }
+
+    impl MockLlmProvider {
+        fn approving() -> Self {
+            Self {
+                response: r#"{"approved": true, "concerns": [], "recommendation": "Safe"}"#
+                    .to_owned(),
+            }
+        }
+
+        fn rejecting() -> Self {
+            Self {
+                response:
+                    r#"{"approved": false, "concerns": ["Too risky"], "recommendation": "Reject"}"#
+                        .to_owned(),
+            }
+        }
+    }
+
+    impl crate::ai::LlmProvider for MockLlmProvider {
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+
+        fn default_model(&self) -> &'static str {
+            "mock-model"
+        }
+
+        fn complete(
+            &self,
+            _messages: &[crate::ai::Message],
+            _options: &crate::ai::CompletionOptions,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<crate::ai::CompletionResult, String>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            let content = self.response.clone();
+            Box::pin(async move {
+                Ok(crate::ai::CompletionResult {
+                    content,
+                    input_tokens: 5,
+                    output_tokens: 10,
+                })
+            })
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 36. dispatch_proposal_async: no provider — behaves like sync
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn async_dispatch_no_provider_behaves_like_sync() {
+        let mut d = Dispatcher::new();
+        let p = make_proposal(
+            FeatureArea::Rca,
+            EvidenceClass::Factual,
+            "SELECT pg_cancel_backend(42)",
+            "Long-running query",
+        );
+        let outcome = d.dispatch_proposal_async(&p, AutonomyLevel::Auto).await;
+        assert!(
+            matches!(outcome, ActionOutcome::Success { .. }),
+            "without a provider the async dispatch must succeed in Auto mode"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 37. dispatch_proposal_async: LLM approves → Success
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn async_dispatch_llm_approve_returns_success() {
+        use crate::llm_auditor::LlmAuditorConfig;
+        let mut d = Dispatcher::new_with_provider(
+            Some(Box::new(MockLlmProvider::approving())),
+            LlmAuditorConfig {
+                enabled: true,
+                ..LlmAuditorConfig::default()
+            },
+        );
+        let p = make_proposal(
+            FeatureArea::Rca,
+            EvidenceClass::Factual,
+            "SELECT pg_cancel_backend(42)",
+            "Long-running query",
+        );
+        let outcome = d.dispatch_proposal_async(&p, AutonomyLevel::Auto).await;
+        assert!(
+            matches!(outcome, ActionOutcome::Success { .. }),
+            "LLM approval must produce Success in Auto mode"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 38. dispatch_proposal_async: LLM rejects → Vetoed
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn async_dispatch_llm_reject_returns_vetoed() {
+        use crate::llm_auditor::LlmAuditorConfig;
+        let mut d = Dispatcher::new_with_provider(
+            Some(Box::new(MockLlmProvider::rejecting())),
+            LlmAuditorConfig {
+                enabled: true,
+                ..LlmAuditorConfig::default()
+            },
+        );
+        let p = make_proposal(
+            FeatureArea::Rca,
+            EvidenceClass::Factual,
+            "SELECT pg_cancel_backend(42)",
+            "Long-running query",
+        );
+        let outcome = d.dispatch_proposal_async(&p, AutonomyLevel::Auto).await;
+        assert!(
+            matches!(outcome, ActionOutcome::Vetoed { .. }),
+            "LLM rejection must veto the proposal"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 39. dispatch_proposal_async: LLM rejects but Supervised → Skipped
+    //     (LLM review only applies to Auto mode)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn async_dispatch_llm_reject_supervised_still_skipped() {
+        use crate::llm_auditor::LlmAuditorConfig;
+        let mut d = Dispatcher::new_with_provider(
+            Some(Box::new(MockLlmProvider::rejecting())),
+            LlmAuditorConfig {
+                enabled: true,
+                ..LlmAuditorConfig::default()
+            },
+        );
+        let p = make_proposal(
+            FeatureArea::Vacuum,
+            EvidenceClass::Factual,
+            "VACUUM ANALYZE users",
+            "Dead tuples",
+        );
+        // Supervised mode: LLM review is skipped — rule-based audit approves.
+        let outcome = d
+            .dispatch_proposal_async(&p, AutonomyLevel::Supervised)
+            .await;
+        assert!(
+            matches!(outcome, ActionOutcome::Skipped),
+            "LLM review is not applied in Supervised mode"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 40. dispatch_proposal_async: LLM rejection records veto
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn async_dispatch_llm_reject_records_veto() {
+        use crate::llm_auditor::LlmAuditorConfig;
+        let mut d = Dispatcher::new_with_provider(
+            Some(Box::new(MockLlmProvider::rejecting())),
+            LlmAuditorConfig {
+                enabled: true,
+                ..LlmAuditorConfig::default()
+            },
+        );
+        assert_eq!(d.veto_tracker().veto_count(), 0);
+        let p = make_proposal(
+            FeatureArea::Rca,
+            EvidenceClass::Factual,
+            "SELECT pg_cancel_backend(99)",
+            "Long-running query",
+        );
+        d.dispatch_proposal_async(&p, AutonomyLevel::Auto).await;
+        assert_eq!(
+            d.veto_tracker().veto_count(),
+            1,
+            "LLM rejection must record a veto"
         );
     }
 }

--- a/src/llm_auditor.rs
+++ b/src/llm_auditor.rs
@@ -3,14 +3,12 @@
 //! Provides a secondary safety layer that sends high-risk action proposals to
 //! an LLM for adversarial review before execution.  The LLM acts as a
 //! skeptical auditor looking for reasons to reject rather than approve.
-//!
-//! This module is a stub: the `review_proposal` function returns a
-//! pass-through approval until an LLM provider is wired in (Phase 3).
 
-#![allow(dead_code)]
+use std::time::Duration;
 
 use serde::Deserialize;
 
+use crate::ai::{CompletionOptions, LlmProvider, Message, Role};
 use crate::governance::ActionProposal;
 
 // ---------------------------------------------------------------------------
@@ -59,6 +57,7 @@ pub struct LlmAuditReview {
     /// `true` if the LLM considers the action safe to proceed.
     pub approved: bool,
     /// Zero or more specific concerns identified by the LLM.
+    #[allow(dead_code)]
     pub concerns: Vec<String>,
     /// A brief free-text recommendation from the LLM.
     pub recommendation: String,
@@ -153,26 +152,75 @@ pub fn parse_review_response(response: &str) -> Result<LlmAuditReview, String> {
 }
 
 // ---------------------------------------------------------------------------
-// Review function (stub)
+// Review function
 // ---------------------------------------------------------------------------
 
 /// Submit a proposal for adversarial LLM review.
 ///
-/// This is currently a stub that returns an unconditional approval with a
-/// note that no LLM provider is configured.  The actual provider call will
-/// be wired in Phase 3 when the AI subsystem is available to the governance
-/// framework.
-// `async` is intentional: the real implementation will await an LLM call.
-#[allow(clippy::unused_async)]
+/// When a provider is supplied and the auditor config has `enabled = true`,
+/// the proposal is sent to the LLM using [`build_adversarial_prompt`] and the
+/// response is parsed with [`parse_review_response`].  The call is wrapped in
+/// a timeout derived from [`LlmAuditorConfig::timeout_ms`].
+///
+/// Falls back to heuristic approval (no-provider path) in three cases:
+/// - `provider` is `None`
+/// - `config.enabled` is `false`
+/// - The LLM call times out or returns an error
 pub async fn review_proposal(
-    _proposal: &ActionProposal,
-    _config: &LlmAuditorConfig,
+    proposal: &ActionProposal,
+    config: &LlmAuditorConfig,
+    provider: Option<&dyn LlmProvider>,
 ) -> Result<LlmAuditReview, String> {
-    Ok(LlmAuditReview {
-        approved: true,
-        concerns: vec![],
-        recommendation: "No LLM provider configured".to_owned(),
-    })
+    let Some(provider) = provider else {
+        return Ok(LlmAuditReview {
+            approved: true,
+            concerns: vec![],
+            recommendation: "No LLM provider configured".to_owned(),
+        });
+    };
+
+    if !config.enabled {
+        return Ok(LlmAuditReview {
+            approved: true,
+            concerns: vec![],
+            recommendation: "LLM auditor disabled".to_owned(),
+        });
+    }
+
+    let prompt = build_adversarial_prompt(proposal);
+    let messages = vec![Message {
+        role: Role::User,
+        content: prompt,
+    }];
+    let options = CompletionOptions {
+        model: String::new(),
+        max_tokens: 512,
+        temperature: 0.0,
+    };
+
+    let timeout = Duration::from_millis(config.timeout_ms);
+    let call = provider.complete(&messages, &options);
+
+    match tokio::time::timeout(timeout, call).await {
+        Ok(Ok(result)) => parse_review_response(&result.content),
+        Ok(Err(err)) => {
+            // LLM returned an error — fall back to heuristic approval so
+            // that a transient provider outage does not block all actions.
+            Ok(LlmAuditReview {
+                approved: true,
+                concerns: vec![],
+                recommendation: format!("LLM error (heuristic fallback): {err}"),
+            })
+        }
+        Err(_elapsed) => Ok(LlmAuditReview {
+            approved: true,
+            concerns: vec![],
+            recommendation: format!(
+                "LLM timed out after {}ms (heuristic fallback)",
+                config.timeout_ms
+            ),
+        }),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -181,9 +229,11 @@ pub async fn review_proposal(
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
     use std::time::SystemTime;
 
     use super::*;
+    use crate::ai::{CompletionResult, LlmProvider};
     use crate::governance::{ActionProposal, EvidenceClass, FeatureArea, Severity};
 
     fn sample_proposal() -> ActionProposal {
@@ -196,6 +246,108 @@ mod tests {
             expected_outcome: "Dead tuples reclaimed, autovacuum reset".to_owned(),
             risk: "Low — VACUUM does not lock the table".to_owned(),
             created_at: SystemTime::now(),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock provider that returns a fixed response
+    // -----------------------------------------------------------------------
+
+    #[derive(Debug)]
+    struct MockProvider {
+        response: String,
+    }
+
+    impl MockProvider {
+        fn new(response: impl Into<String>) -> Self {
+            Self {
+                response: response.into(),
+            }
+        }
+    }
+
+    impl LlmProvider for MockProvider {
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+
+        fn default_model(&self) -> &'static str {
+            "mock-model"
+        }
+
+        fn complete(
+            &self,
+            _messages: &[crate::ai::Message],
+            _options: &crate::ai::CompletionOptions,
+        ) -> Pin<Box<dyn std::future::Future<Output = Result<CompletionResult, String>> + Send + '_>>
+        {
+            let content = self.response.clone();
+            Box::pin(async move {
+                Ok(CompletionResult {
+                    content,
+                    input_tokens: 10,
+                    output_tokens: 20,
+                })
+            })
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock provider that always returns an error
+    // -----------------------------------------------------------------------
+
+    #[derive(Debug)]
+    struct ErrorProvider;
+
+    impl LlmProvider for ErrorProvider {
+        fn name(&self) -> &'static str {
+            "error-mock"
+        }
+
+        fn default_model(&self) -> &'static str {
+            "error-model"
+        }
+
+        fn complete(
+            &self,
+            _messages: &[crate::ai::Message],
+            _options: &crate::ai::CompletionOptions,
+        ) -> Pin<Box<dyn std::future::Future<Output = Result<CompletionResult, String>> + Send + '_>>
+        {
+            Box::pin(async move { Err("simulated provider error".to_owned()) })
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock provider that simulates a slow response (for timeout testing)
+    // -----------------------------------------------------------------------
+
+    #[derive(Debug)]
+    struct SlowProvider;
+
+    impl LlmProvider for SlowProvider {
+        fn name(&self) -> &'static str {
+            "slow-mock"
+        }
+
+        fn default_model(&self) -> &'static str {
+            "slow-model"
+        }
+
+        fn complete(
+            &self,
+            _messages: &[crate::ai::Message],
+            _options: &crate::ai::CompletionOptions,
+        ) -> Pin<Box<dyn std::future::Future<Output = Result<CompletionResult, String>> + Send + '_>>
+        {
+            Box::pin(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                Ok(CompletionResult {
+                    content: "late response".to_owned(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                })
+            })
         }
     }
 
@@ -327,15 +479,136 @@ mod tests {
         );
     }
 
-    // --- review_proposal stub ---
+    // --- review_proposal: no provider ---
 
     #[tokio::test]
-    async fn review_proposal_stub_returns_approved() {
+    async fn review_proposal_no_provider_returns_approved() {
         let p = sample_proposal();
         let cfg = LlmAuditorConfig::default();
-        let review = review_proposal(&p, &cfg).await.expect("no error");
+        let review = review_proposal(&p, &cfg, None).await.expect("no error");
         assert!(review.approved);
         assert!(review.concerns.is_empty());
         assert!(review.recommendation.contains("No LLM provider"));
+    }
+
+    // --- review_proposal: disabled config ---
+
+    #[tokio::test]
+    async fn review_proposal_disabled_config_returns_approved() {
+        let p = sample_proposal();
+        let cfg = LlmAuditorConfig {
+            enabled: false,
+            ..LlmAuditorConfig::default()
+        };
+        let provider = MockProvider::new(
+            r#"{"approved": false, "concerns": ["risky"], "recommendation": "reject"}"#,
+        );
+        let review = review_proposal(&p, &cfg, Some(&provider))
+            .await
+            .expect("no error");
+        assert!(
+            review.approved,
+            "disabled auditor must approve without calling the provider"
+        );
+        assert!(review.recommendation.contains("disabled"));
+    }
+
+    // --- review_proposal: enabled, provider returns approve ---
+
+    #[tokio::test]
+    async fn review_proposal_with_provider_approve() {
+        let p = sample_proposal();
+        let cfg = LlmAuditorConfig {
+            enabled: true,
+            ..LlmAuditorConfig::default()
+        };
+        let provider = MockProvider::new(
+            r#"{"approved": true, "concerns": [], "recommendation": "Looks safe"}"#,
+        );
+        let review = review_proposal(&p, &cfg, Some(&provider))
+            .await
+            .expect("no error");
+        assert!(review.approved);
+        assert_eq!(review.recommendation, "Looks safe");
+    }
+
+    // --- review_proposal: enabled, provider returns reject ---
+
+    #[tokio::test]
+    async fn review_proposal_with_provider_reject() {
+        let p = sample_proposal();
+        let cfg = LlmAuditorConfig {
+            enabled: true,
+            ..LlmAuditorConfig::default()
+        };
+        let provider = MockProvider::new(
+            r#"{"approved": false, "concerns": ["Could cause downtime"], "recommendation": "Defer"}"#,
+        );
+        let review = review_proposal(&p, &cfg, Some(&provider))
+            .await
+            .expect("no error");
+        assert!(!review.approved);
+        assert_eq!(review.concerns.len(), 1);
+        assert_eq!(review.recommendation, "Defer");
+    }
+
+    // --- review_proposal: provider returns heuristic-parsed prose ---
+
+    #[tokio::test]
+    async fn review_proposal_provider_prose_reject_keyword() {
+        let p = sample_proposal();
+        let cfg = LlmAuditorConfig {
+            enabled: true,
+            ..LlmAuditorConfig::default()
+        };
+        let provider = MockProvider::new("I would reject this action due to risk.");
+        let review = review_proposal(&p, &cfg, Some(&provider))
+            .await
+            .expect("no error");
+        assert!(
+            !review.approved,
+            "heuristic parse must reject when 'reject' keyword present"
+        );
+    }
+
+    // --- review_proposal: provider error falls back to approval ---
+
+    #[tokio::test]
+    async fn review_proposal_provider_error_fallback_approves() {
+        let p = sample_proposal();
+        let cfg = LlmAuditorConfig {
+            enabled: true,
+            ..LlmAuditorConfig::default()
+        };
+        let provider = ErrorProvider;
+        let review = review_proposal(&p, &cfg, Some(&provider))
+            .await
+            .expect("no error");
+        assert!(
+            review.approved,
+            "provider error must fall back to heuristic approval"
+        );
+        assert!(review.recommendation.contains("LLM error"));
+    }
+
+    // --- review_proposal: provider timeout falls back to approval ---
+
+    #[tokio::test]
+    async fn review_proposal_provider_timeout_fallback_approves() {
+        let p = sample_proposal();
+        let cfg = LlmAuditorConfig {
+            enabled: true,
+            timeout_ms: 1, // 1ms timeout — SlowProvider sleeps 60s
+            ..LlmAuditorConfig::default()
+        };
+        let provider = SlowProvider;
+        let review = review_proposal(&p, &cfg, Some(&provider))
+            .await
+            .expect("no error");
+        assert!(
+            review.approved,
+            "timeout must fall back to heuristic approval"
+        );
+        assert!(review.recommendation.contains("timed out"));
     }
 }


### PR DESCRIPTION
## Summary
- Wire `review_proposal()` in `llm_auditor.rs` to real AI providers via `LlmProvider` trait
- Add `LlmAuditorConfig` to `GovernanceConfig` (TOML: `[governance.llm_auditor]`)
- Add `dispatch_proposal_async()` to Dispatcher with LLM adversarial review step
- Timeout protection (30s default) and graceful fallback when no provider configured
- 13 new tests (8 in llm_auditor, 5 async in dispatcher) with mock providers

Closes #524

## Test plan
- [ ] LLM review invoked for Auto-mode proposals when provider configured
- [ ] Graceful fallback when no provider / provider error / timeout
- [ ] LLM rejection vetoes the proposal and records in audit log
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)