### PR TITLE
feat(connectors): implement Supabase fetch_alerts and fetch_metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +736,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "delegate"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1301,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1381,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1414,6 +1467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,9 +1491,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2107,6 +2168,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3008,6 +3079,7 @@ dependencies = [
  "toml",
  "unicode-width",
  "webpki-roots 0.26.11",
+ "wiremock",
  "x509-certificate",
 ]
 
@@ -4706,6 +4778,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ anyhow = "1"
 serial_test = "3"
 tempfile = "3"
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
+wiremock = "0.6"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/connectors/supabase.rs
+++ b/src/connectors/supabase.rs
@@ -1,14 +1,24 @@
 //! Supabase connector — health checks via the Supabase Management API.
+//!
+//! ## API endpoints used
+//!
+//! - `GET /v1/projects/{ref}/health` — project service health, mapped to
+//!   alerts (unhealthy services become `Active` alerts).
+//! - `GET /v1/projects/{ref}/metrics` — Prometheus-format metrics, parsed
+//!   into `Metric` data points.
 
+use std::collections::HashMap;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use serde::Deserialize;
 
 use super::{
-    Alert, BackoffConfig, ConnectorCapabilities, ConnectorError, ConnectorHealth, DatabaseId,
-    Metric, RateLimitConfig, TimeWindow,
+    Alert, AlertStatus, BackoffConfig, ConnectorCapabilities, ConnectorError, ConnectorHealth,
+    DatabaseId, Metric, RateLimitConfig, TimeWindow,
 };
 use crate::connectors::Connector;
+use crate::governance::Severity;
 
 const DEFAULT_BASE_URL: &str = "https://api.supabase.com";
 
@@ -60,6 +70,121 @@ impl SupabaseConnector {
             },
         }
     }
+
+    /// Return the resolved project ref, or a `ConnectorError` if not set.
+    fn require_project_ref(&self) -> Result<&str, ConnectorError> {
+        self.project_ref.as_deref().ok_or_else(|| {
+            ConnectorError::Other("project_ref is required for this operation".to_string())
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Supabase API response types
+// ---------------------------------------------------------------------------
+
+/// A single service entry from `GET /v1/projects/{ref}/health`.
+#[derive(Debug, Deserialize)]
+struct ServiceHealth {
+    name: String,
+    healthy: bool,
+    status: Option<String>,
+}
+
+/// A Prometheus-format metric line parsed from the `/metrics` endpoint.
+///
+/// Format: `metric_name{label="value",...} value [timestamp_ms]`
+struct PrometheusLine {
+    name: String,
+    labels: HashMap<String, String>,
+    value: f64,
+}
+
+/// Parse a Prometheus exposition-format text body into individual samples.
+///
+/// Only handles the simple `name{labels} value` format; TYPE/HELP lines
+/// and histogram/summary suffixes are skipped.
+fn parse_prometheus(body: &str) -> Vec<PrometheusLine> {
+    let mut out = Vec::new();
+
+    for raw in body.lines() {
+        let line = raw.trim();
+        // Skip comments and blank lines.
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        // Split off optional trailing timestamp: `name{...} value [ts]`
+        // We only care about name+labels+value.
+        let (metric_part, _ts) = match line.rfind(' ') {
+            Some(pos) => {
+                let tail = &line[pos + 1..];
+                // If tail parses as a number it could be the value OR a
+                // Unix-ms timestamp — we always want the value column, so
+                // split differently: find the last field that looks like a
+                // timestamp (> 1e12) vs value.
+                if tail.parse::<f64>().is_ok_and(|v| v > 1e12) {
+                    // Tail is a timestamp; value is the previous field.
+                    (&line[..pos], Some(tail))
+                } else {
+                    (line, None)
+                }
+            }
+            None => (line, None),
+        };
+
+        // Split at the last space to separate `name{labels}` from `value`.
+        let (name_labels, value_str) = match metric_part.rfind(' ') {
+            Some(pos) => (&metric_part[..pos], &metric_part[pos + 1..]),
+            None => continue,
+        };
+
+        let value: f64 = match value_str.parse() {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        // Parse `metric_name` or `metric_name{k="v",...}`.
+        let (name, labels) = if let Some(brace) = name_labels.find('{') {
+            let metric_name = &name_labels[..brace];
+            let label_str = name_labels
+                .get(brace + 1..name_labels.len().saturating_sub(1))
+                .unwrap_or("");
+            let labels = parse_prometheus_labels(label_str);
+            (metric_name.to_string(), labels)
+        } else {
+            (name_labels.to_string(), HashMap::new())
+        };
+
+        out.push(PrometheusLine {
+            name,
+            labels,
+            value,
+        });
+    }
+
+    out
+}
+
+/// Parse the label set inside `{k="v", k2="v2"}` (the braces are already
+/// stripped by the caller).
+fn parse_prometheus_labels(s: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for part in s.split(',') {
+        let part = part.trim();
+        if let Some(eq) = part.find('=') {
+            let key = part[..eq].trim().to_string();
+            let raw_val = part[eq + 1..].trim();
+            // Strip surrounding quotes.
+            let val = raw_val
+                .strip_prefix('"')
+                .and_then(|v| v.strip_suffix('"'))
+                .unwrap_or(raw_val)
+                .to_string();
+            map.insert(key, val);
+        }
+    }
+    map
 }
 
 // ---------------------------------------------------------------------------
@@ -132,14 +257,27 @@ impl Connector for SupabaseConnector {
         })
     }
 
-    /// Fetch metrics for a database.
+    /// Fetch Prometheus-format metrics from
+    /// `GET /v1/projects/{ref}/metrics`.
     ///
-    /// Not yet implemented — returns an empty list.
+    /// Each parsed sample line is converted into a [`Metric`] whose `name`
+    /// is the Prometheus metric name, `value` the sample value, and `tags`
+    /// the Prometheus label set.
+    ///
+    /// Returns an empty `Vec` when `project_ref` is not set.
     async fn fetch_metrics(
         &self,
         database: &DatabaseId,
         window: &TimeWindow,
     ) -> Result<Vec<Metric>, ConnectorError> {
+        let Some(project_ref) = self.project_ref.as_deref() else {
+            crate::logging::debug(
+                "supabase",
+                "fetch_metrics: project_ref not set, returning empty",
+            );
+            return Ok(vec![]);
+        };
+
         let start_secs = window
             .start
             .duration_since(std::time::UNIX_EPOCH)
@@ -150,25 +288,109 @@ impl Connector for SupabaseConnector {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        crate::logging::debug(
-            "supabase",
-            &format!(
-                "fetch_metrics db={database} window={start_secs}..{end_secs} \
-                 (not yet implemented)",
-            ),
-        );
-        Ok(vec![])
+
+        let url = format!("{}/v1/projects/{}/metrics", self.base_url, project_ref);
+
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.access_token)
+            .query(&[
+                ("start", start_secs.to_string()),
+                ("end", end_secs.to_string()),
+            ])
+            .send()
+            .await
+            .map_err(|e| ConnectorError::NetworkError(e.to_string()))?;
+
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| ConnectorError::NetworkError(e.to_string()))?;
+
+        if !(200..300).contains(&(status as usize)) {
+            return Err(Self::map_error(status, &body));
+        }
+
+        let now = SystemTime::now();
+        let source = self.id().to_string();
+
+        let metrics = parse_prometheus(&body)
+            .into_iter()
+            .map(|line| {
+                let mut tags = line.labels;
+                tags.insert("database".to_string(), database.clone());
+                Metric {
+                    name: line.name,
+                    value: line.value,
+                    unit: None,
+                    timestamp: now,
+                    tags,
+                    source: source.clone(),
+                }
+            })
+            .collect();
+
+        Ok(metrics)
     }
 
-    /// Fetch alerts for a database.
+    /// Fetch service-health alerts from
+    /// `GET /v1/projects/{ref}/health`.
     ///
-    /// Not yet implemented — returns an empty list.
+    /// Each service that is not `healthy` is emitted as an `Active`
+    /// [`Alert`].  When all services are healthy the returned `Vec` is
+    /// empty.
+    ///
+    /// Returns a `ConnectorError::Other` when `project_ref` is not set.
     async fn fetch_alerts(&self, database: &DatabaseId) -> Result<Vec<Alert>, ConnectorError> {
-        crate::logging::debug(
-            "supabase",
-            &format!("fetch_alerts db={database} (not yet implemented)"),
-        );
-        Ok(vec![])
+        let project_ref = self.require_project_ref()?;
+
+        let url = format!("{}/v1/projects/{}/health", self.base_url, project_ref);
+
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.access_token)
+            .send()
+            .await
+            .map_err(|e| ConnectorError::NetworkError(e.to_string()))?;
+
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| ConnectorError::NetworkError(e.to_string()))?;
+
+        if !(200..300).contains(&(status as usize)) {
+            return Err(Self::map_error(status, &body));
+        }
+
+        let services: Vec<ServiceHealth> = serde_json::from_str(&body)
+            .map_err(|e| ConnectorError::Other(format!("failed to parse health response: {e}")))?;
+
+        let source = self.id().to_string();
+        let now = SystemTime::now();
+
+        let alerts = services
+            .into_iter()
+            .filter(|s| !s.healthy)
+            .map(|s| {
+                let status_label = s.status.as_deref().unwrap_or("unhealthy").to_string();
+                Alert {
+                    id: format!("supabase-{project_ref}-{}", s.name),
+                    title: format!("Supabase service '{}' is {}", s.name, status_label),
+                    severity: Severity::Warning,
+                    status: AlertStatus::Active,
+                    source: source.clone(),
+                    database: Some(database.clone()),
+                    created_at: now,
+                    url: None,
+                }
+            })
+            .collect();
+
+        Ok(alerts)
     }
 }
 
@@ -180,6 +402,10 @@ impl Connector for SupabaseConnector {
 mod tests {
     use super::*;
     use crate::connectors::{Connector, ConnectorCapabilities, RateLimitConfig};
+
+    // -----------------------------------------------------------------------
+    // Constructor / builder tests
+    // -----------------------------------------------------------------------
 
     #[test]
     fn new_sets_default_base_url() {
@@ -263,8 +489,102 @@ mod tests {
         assert_eq!(max_concurrent, 2);
     }
 
+    // -----------------------------------------------------------------------
+    // require_project_ref
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn require_project_ref_ok_when_set() {
+        let c = SupabaseConnector::new("t".to_string()).with_project_ref("myref".to_string());
+        assert!(c.require_project_ref().is_ok());
+        assert_eq!(c.require_project_ref().unwrap(), "myref");
+    }
+
+    #[test]
+    fn require_project_ref_err_when_unset() {
+        let c = SupabaseConnector::new("t".to_string());
+        assert!(matches!(
+            c.require_project_ref(),
+            Err(ConnectorError::Other(_))
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Prometheus parser unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_prometheus_skips_comments_and_blanks() {
+        let body = "# HELP pg_up whether postgres is up\n\
+                    # TYPE pg_up gauge\n\
+                    \n\
+                    pg_up 1";
+        let lines = parse_prometheus(body);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].name, "pg_up");
+        assert!((lines[0].value - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_prometheus_parses_labels() {
+        let body = r#"pg_stat_table_n_live_tup{schemaname="public",relname="users"} 42"#;
+        let lines = parse_prometheus(body);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].name, "pg_stat_table_n_live_tup");
+        assert!((lines[0].value - 42.0).abs() < f64::EPSILON);
+        assert_eq!(
+            lines[0].labels.get("schemaname").map(String::as_str),
+            Some("public")
+        );
+        assert_eq!(
+            lines[0].labels.get("relname").map(String::as_str),
+            Some("users")
+        );
+    }
+
+    #[test]
+    fn parse_prometheus_handles_no_labels() {
+        let body = "process_resident_memory_bytes 12345678";
+        let lines = parse_prometheus(body);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].name, "process_resident_memory_bytes");
+        assert!((lines[0].value - 12_345_678.0).abs() < f64::EPSILON);
+        assert!(lines[0].labels.is_empty());
+    }
+
+    #[test]
+    fn parse_prometheus_multiple_lines() {
+        let body = "cpu_usage 0.5\nmemory_bytes 1024\ndisk_read_bytes 2048";
+        let lines = parse_prometheus(body);
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn parse_prometheus_ignores_unparseable_value() {
+        let body = "bad_metric NaN_not_a_real_float\ngood_metric 1.0";
+        let lines = parse_prometheus(body);
+        // NaN is technically parseable in Rust; "NaN_not_a_real_float" is not
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].name, "good_metric");
+    }
+
+    // -----------------------------------------------------------------------
+    // fetch_alerts — without project_ref
+    // -----------------------------------------------------------------------
+
     #[tokio::test]
-    async fn fetch_metrics_returns_empty() {
+    async fn fetch_alerts_returns_err_when_no_project_ref() {
+        let c = SupabaseConnector::new("token".to_string());
+        let result = c.fetch_alerts(&"mydb".to_string()).await;
+        assert!(matches!(result, Err(ConnectorError::Other(_))));
+    }
+
+    // -----------------------------------------------------------------------
+    // fetch_metrics — without project_ref returns empty
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn fetch_metrics_returns_empty_when_no_project_ref() {
         use std::time::UNIX_EPOCH;
         let c = SupabaseConnector::new("t".to_string());
         let window = TimeWindow {
@@ -276,11 +596,285 @@ mod tests {
         assert!(result.unwrap().is_empty());
     }
 
+    // -----------------------------------------------------------------------
+    // fetch_alerts — mock HTTP responses via wiremock
+    // -----------------------------------------------------------------------
+
     #[tokio::test]
-    async fn fetch_alerts_returns_empty() {
-        let c = SupabaseConnector::new("t".to_string());
-        let result = c.fetch_alerts(&"mydb".to_string()).await;
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
+    async fn fetch_alerts_all_healthy_returns_empty() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/testref/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"name": "db", "healthy": true},
+                {"name": "api", "healthy": true},
+                {"name": "storage", "healthy": true}
+            ])))
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("tok".to_string())
+            .with_project_ref("testref".to_string())
+            .with_base_url(server.uri());
+
+        let alerts = c.fetch_alerts(&"mydb".to_string()).await.unwrap();
+        assert!(alerts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_alerts_unhealthy_service_produces_alert() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/testref/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"name": "db", "healthy": true},
+                {"name": "realtime", "healthy": false, "status": "degraded"}
+            ])))
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("tok".to_string())
+            .with_project_ref("testref".to_string())
+            .with_base_url(server.uri());
+
+        let alerts = c.fetch_alerts(&"mydb".to_string()).await.unwrap();
+        assert_eq!(alerts.len(), 1);
+        let a = &alerts[0];
+        assert_eq!(a.id, "supabase-testref-realtime");
+        assert!(a.title.contains("realtime"));
+        assert!(a.title.contains("degraded"));
+        assert_eq!(a.severity, Severity::Warning);
+        assert_eq!(a.status, AlertStatus::Active);
+        assert_eq!(a.source, "supabase");
+        assert_eq!(a.database.as_deref(), Some("mydb"));
+    }
+
+    #[tokio::test]
+    async fn fetch_alerts_multiple_unhealthy_services() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/ref123/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"name": "db", "healthy": false, "status": "offline"},
+                {"name": "api", "healthy": false, "status": "starting"},
+                {"name": "storage", "healthy": true}
+            ])))
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("tok".to_string())
+            .with_project_ref("ref123".to_string())
+            .with_base_url(server.uri());
+
+        let alerts = c.fetch_alerts(&"db1".to_string()).await.unwrap();
+        assert_eq!(alerts.len(), 2);
+        let ids: Vec<&str> = alerts.iter().map(|a| a.id.as_str()).collect();
+        assert!(ids.contains(&"supabase-ref123-db"));
+        assert!(ids.contains(&"supabase-ref123-api"));
+    }
+
+    #[tokio::test]
+    async fn fetch_alerts_unhealthy_without_status_field() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/ref/health"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!([{"name": "auth", "healthy": false}])),
+            )
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("tok".to_string())
+            .with_project_ref("ref".to_string())
+            .with_base_url(server.uri());
+
+        let alerts = c.fetch_alerts(&"db".to_string()).await.unwrap();
+        assert_eq!(alerts.len(), 1);
+        assert!(alerts[0].title.contains("unhealthy"));
+    }
+
+    #[tokio::test]
+    async fn fetch_alerts_returns_auth_error_on_401() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/ref/health"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("bad-tok".to_string())
+            .with_project_ref("ref".to_string())
+            .with_base_url(server.uri());
+
+        let result = c.fetch_alerts(&"db".to_string()).await;
+        assert!(matches!(result, Err(ConnectorError::AuthError(_))));
+    }
+
+    #[tokio::test]
+    async fn fetch_alerts_returns_rate_limited_on_429() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/ref/health"))
+            .respond_with(ResponseTemplate::new(429).set_body_string("Too Many Requests"))
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("tok".to_string())
+            .with_project_ref("ref".to_string())
+            .with_base_url(server.uri());
+
+        let result = c.fetch_alerts(&"db".to_string()).await;
+        assert!(matches!(result, Err(ConnectorError::RateLimited { .. })));
+    }
+
+    #[tokio::test]
+    async fn fetch_alerts_returns_api_error_on_500() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/ref/health"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("tok".to_string())
+            .with_project_ref("ref".to_string())
+            .with_base_url(server.uri());
+
+        let result = c.fetch_alerts(&"db".to_string()).await;
+        assert!(matches!(
+            result,
+            Err(ConnectorError::ApiError { status: 500, .. })
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // fetch_metrics — mock HTTP responses via wiremock
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn fetch_metrics_parses_prometheus_body() {
+        use std::time::UNIX_EPOCH;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        let prometheus_body = "# HELP pg_up Postgres up\n\
+                               # TYPE pg_up gauge\n\
+                               pg_up 1\n\
+                               pg_stat_database_numbackends{datname=\"mydb\"} 5\n";
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/ref/metrics"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(prometheus_body))
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("tok".to_string())
+            .with_project_ref("ref".to_string())
+            .with_base_url(server.uri());
+
+        let window = TimeWindow {
+            start: UNIX_EPOCH,
+            end: SystemTime::now(),
+        };
+        let metrics = c.fetch_metrics(&"mydb".to_string(), &window).await.unwrap();
+        assert_eq!(metrics.len(), 2);
+
+        let pg_up = metrics.iter().find(|m| m.name == "pg_up").unwrap();
+        assert!((pg_up.value - 1.0).abs() < f64::EPSILON);
+        assert_eq!(pg_up.source, "supabase");
+        assert_eq!(pg_up.tags.get("database").map(String::as_str), Some("mydb"));
+
+        let backends = metrics
+            .iter()
+            .find(|m| m.name == "pg_stat_database_numbackends")
+            .unwrap();
+        assert!((backends.value - 5.0).abs() < f64::EPSILON);
+        assert_eq!(
+            backends.tags.get("datname").map(String::as_str),
+            Some("mydb")
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_metrics_returns_auth_error_on_401() {
+        use std::time::UNIX_EPOCH;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/ref/metrics"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("bad-tok".to_string())
+            .with_project_ref("ref".to_string())
+            .with_base_url(server.uri());
+
+        let window = TimeWindow {
+            start: UNIX_EPOCH,
+            end: SystemTime::now(),
+        };
+        let result = c.fetch_metrics(&"db".to_string(), &window).await;
+        assert!(matches!(result, Err(ConnectorError::AuthError(_))));
+    }
+
+    #[tokio::test]
+    async fn fetch_metrics_empty_body_returns_empty_vec() {
+        use std::time::UNIX_EPOCH;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/ref/metrics"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+
+        let c = SupabaseConnector::new("tok".to_string())
+            .with_project_ref("ref".to_string())
+            .with_base_url(server.uri());
+
+        let window = TimeWindow {
+            start: UNIX_EPOCH,
+            end: SystemTime::now(),
+        };
+        let metrics = c.fetch_metrics(&"db".to_string(), &window).await.unwrap();
+        assert!(metrics.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Implement `fetch_alerts()` — calls Supabase `/v1/projects/{ref}/health`, returns alerts for unhealthy services
- Implement `fetch_metrics()` — calls `/v1/projects/{ref}/metrics`, parses Prometheus exposition format
- Add `parse_prometheus()` helper for Prometheus text format parsing
- Add `wiremock` dev-dependency for mock HTTP server tests
- 28 unit tests covering health checks, Prometheus parsing, error handling

Closes #530

## Test plan
- [ ] `fetch_alerts` returns alerts for unhealthy services
- [ ] `fetch_metrics` parses Prometheus format correctly
- [ ] HTTP error codes mapped to `ConnectorError` variants
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)