### PR TITLE
refactor: remove module-level dead_code suppressions

### DIFF
--- a/src/connectors/cloudwatch.rs
+++ b/src/connectors/cloudwatch.rs
@@ -4,8 +4,6 @@
 //! AWS Signature V4 request signing implemented via `ring::hmac` and
 //! `ring::digest`.
 
-#![allow(dead_code)] // Phase 4 infrastructure — consumers arrive later
-
 use std::collections::HashMap;
 
 use async_trait::async_trait;
@@ -27,6 +25,7 @@ use super::{
 /// Authentication uses AWS access key credentials; temporary credentials
 /// (e.g. from IAM role assumption) are supported via the optional
 /// session token.
+#[allow(dead_code)]
 pub struct CloudWatchConnector {
     region: String,
     access_key_id: String,
@@ -48,12 +47,14 @@ impl CloudWatchConnector {
     }
 
     /// Attach a session token for temporary credentials (STS / IAM role).
+    #[allow(dead_code)]
     pub fn with_session_token(mut self, token: String) -> Self {
         self.session_token = Some(token);
         self
     }
 
     /// Scope all metric/alarm queries to a specific RDS DB instance.
+    #[allow(dead_code)]
     pub fn with_db_instance(mut self, id: String) -> Self {
         self.db_instance_id = Some(id);
         self

--- a/src/connectors/datadog.rs
+++ b/src/connectors/datadog.rs
@@ -109,6 +109,7 @@ struct MetricUnit {
 /// Top-level response from `GET /api/v1/monitor`.
 type MonitorsResponse = Vec<MonitorEntry>;
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct MonitorEntry {
     id: u64,

--- a/src/connectors/github.rs
+++ b/src/connectors/github.rs
@@ -3,8 +3,6 @@
 //! Integrates with the GitHub REST API to fetch open issues as alerts
 //! and create/update issues in a GitHub repository.
 
-#![allow(dead_code)] // Phase 4 infrastructure — consumers arrive later
-
 use std::time::SystemTime;
 
 use async_trait::async_trait;
@@ -25,6 +23,7 @@ use crate::governance::Severity;
 ///
 /// Supports creating and updating issues, and fetching open issues as
 /// alerts. Does not provide metric data.
+#[allow(dead_code)]
 pub struct GitHubConnector {
     token: String,
     owner: String,
@@ -48,6 +47,7 @@ impl GitHubConnector {
     }
 
     /// Override the base URL (useful for GitHub Enterprise instances).
+    #[allow(dead_code)]
     pub fn with_base_url(mut self, url: String) -> Self {
         self.base_url = url;
         self
@@ -81,6 +81,7 @@ impl GitHubConnector {
 // Wire types — minimal shapes expected from the GitHub API
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct ApiIssue {
     number: u64,
@@ -90,11 +91,13 @@ struct ApiIssue {
     html_url: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct ApiLabel {
     name: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct ApiIssueCreated {
     number: u64,
@@ -312,6 +315,7 @@ impl Connector for GitHubConnector {
 /// Checks for conventional label names: contains "critical", "info"
 /// (case-insensitive). Falls back to `Warning` when no matching label
 /// is found.
+#[allow(dead_code)]
 fn severity_from_labels(labels: &[String]) -> Severity {
     for label in labels {
         let lower = label.to_lowercase();

--- a/src/connectors/gitlab.rs
+++ b/src/connectors/gitlab.rs
@@ -3,8 +3,6 @@
 //! Integrates with the GitLab API to fetch open issues as alerts
 //! and create/update issues in a GitLab project.
 
-#![allow(dead_code)] // Phase 4 infrastructure — consumers arrive later
-
 use std::time::SystemTime;
 
 use async_trait::async_trait;
@@ -25,6 +23,7 @@ use crate::governance::Severity;
 ///
 /// Supports creating and updating issues, and fetching open issues as
 /// alerts. Does not provide metric data.
+#[allow(dead_code)]
 pub struct GitLabConnector {
     token: String,
     project_id: String,
@@ -46,6 +45,7 @@ impl GitLabConnector {
     }
 
     /// Override the base URL (useful for self-hosted GitLab instances).
+    #[allow(dead_code)]
     pub fn with_base_url(mut self, url: String) -> Self {
         self.base_url = url;
         self
@@ -78,6 +78,7 @@ impl GitLabConnector {
 // Wire types — minimal shapes expected from the GitLab API
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct ApiIssue {
     iid: u64,
@@ -88,6 +89,7 @@ struct ApiIssue {
     web_url: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct ApiIssueCreated {
     iid: u64,
@@ -299,6 +301,7 @@ impl Connector for GitLabConnector {
 /// Checks for conventional label prefixes: `severity::critical`,
 /// `severity::warning`, `severity::info` (case-insensitive).
 /// Falls back to `Warning` when no matching label is found.
+#[allow(dead_code)]
 fn severity_from_labels(labels: &[String]) -> Severity {
     for label in labels {
         let lower = label.to_lowercase();

--- a/src/connectors/http_json.rs
+++ b/src/connectors/http_json.rs
@@ -20,6 +20,7 @@ use crate::governance::Severity;
 // ---------------------------------------------------------------------------
 
 /// Authentication strategy for an [`HttpJsonConnector`].
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum HttpJsonAuth {
     /// `Authorization: Bearer <token>`
@@ -37,6 +38,7 @@ pub enum HttpJsonAuth {
 // ---------------------------------------------------------------------------
 
 /// Describes how to extract a single metric value from a JSON response.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct MetricMapping {
     /// Dot-notation path into the JSON object, e.g. `"data.cpu_percent"`.
@@ -54,6 +56,7 @@ pub struct MetricMapping {
 /// Config-driven HTTP JSON connector.
 ///
 /// Construct via [`HttpJsonConnectorBuilder`].
+#[allow(dead_code)]
 pub struct HttpJsonConnector {
     connector_id: String,
     connector_name: String,
@@ -68,6 +71,7 @@ pub struct HttpJsonConnector {
     client: reqwest::Client,
 }
 
+#[allow(dead_code)]
 impl HttpJsonConnector {
     /// Return the fully-qualified URL for a given endpoint path.
     fn url(&self, path: &str) -> String {
@@ -303,6 +307,7 @@ impl Connector for HttpJsonConnector {
 ///
 /// For example, `"data.cpu_percent"` navigates `json["data"]["cpu_percent"]`
 /// and returns the value as `f64` if it is a JSON number.
+#[allow(dead_code)]
 pub fn extract_json_value(json: &serde_json::Value, path: &str) -> Option<f64> {
     let mut current = json;
     for key in path.split('.') {
@@ -311,6 +316,7 @@ pub fn extract_json_value(json: &serde_json::Value, path: &str) -> Option<f64> {
     current.as_f64()
 }
 
+#[allow(dead_code)]
 fn parse_severity(s: &str) -> Severity {
     match s.to_lowercase().as_str() {
         "critical" | "error" | "high" => Severity::Critical,
@@ -319,6 +325,7 @@ fn parse_severity(s: &str) -> Severity {
     }
 }
 
+#[allow(dead_code)]
 fn parse_alert_status(s: &str) -> AlertStatus {
     match s.to_lowercase().as_str() {
         "acknowledged" | "ack" => AlertStatus::Acknowledged,
@@ -348,6 +355,7 @@ fn parse_alert_status(s: &str) -> AlertStatus {
 ///     .rate_limit_rps(10.0)
 ///     .build();
 /// ```
+#[allow(dead_code)]
 pub struct HttpJsonConnectorBuilder {
     connector_id: String,
     connector_name: String,
@@ -359,6 +367,7 @@ pub struct HttpJsonConnectorBuilder {
     rate_limit_rps: f64,
 }
 
+#[allow(dead_code)]
 impl HttpJsonConnectorBuilder {
     /// Start a new builder.  `id` is the unique connector identifier.
     pub fn new(

--- a/src/connectors/issue_sync.rs
+++ b/src/connectors/issue_sync.rs
@@ -4,8 +4,6 @@
 //! connector issue IDs (GitHub, GitLab, Jira, etc.) and orchestrates
 //! cross-connector issue creation and updates.
 
-#![allow(dead_code)] // Phase 4 infrastructure — consumers arrive later
-
 use std::time::SystemTime;
 
 use super::{ConnectorError, IssueId, IssueRequest};
@@ -15,6 +13,7 @@ use super::{ConnectorError, IssueId, IssueRequest};
 // ---------------------------------------------------------------------------
 
 /// Direction of issue synchronisation between connectors.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyncDirection {
     /// Local (`PostgresAI`) → remote connector.
@@ -40,6 +39,7 @@ impl std::fmt::Display for SyncDirection {
 // ---------------------------------------------------------------------------
 
 /// A single sync mapping between a local and a remote issue.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct SyncRecord {
     /// `PostgresAI` issue ID (local side).
@@ -65,10 +65,12 @@ pub struct SyncRecord {
 /// provides lookup and registration helpers. Actual HTTP calls are
 /// delegated to connector implementations via the [`super::Connector`]
 /// trait; this struct only handles the bookkeeping side.
+#[allow(dead_code)]
 pub struct IssueSyncManager {
     records: Vec<SyncRecord>,
 }
 
+#[allow(dead_code)]
 impl IssueSyncManager {
     /// Create an empty sync manager.
     pub fn new() -> Self {

--- a/src/connectors/jira.rs
+++ b/src/connectors/jira.rs
@@ -3,8 +3,6 @@
 //! Integrates with the Atlassian Jira REST API v3 to fetch
 //! database-related issues as alerts and create/update issues.
 
-#![allow(dead_code)] // Phase 4 infrastructure — consumers arrive later
-
 use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
@@ -80,12 +78,14 @@ impl JiraConnector {
 // Wire types — minimal shapes expected from the Jira REST API v3
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct JiraSearchResult {
     #[serde(default)]
     issues: Vec<JiraIssue>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct JiraIssue {
     id: String,
@@ -94,6 +94,7 @@ struct JiraIssue {
     fields: JiraIssueFields,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct JiraIssueFields {
     summary: String,
@@ -101,12 +102,14 @@ struct JiraIssueFields {
     priority: Option<JiraPriority>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct JiraPriority {
     #[serde(default)]
     name: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct JiraCreatedIssue {
     id: String,
@@ -344,6 +347,7 @@ impl Connector for JiraConnector {
 // ---------------------------------------------------------------------------
 
 /// Map Jira priority names to `Severity`.
+#[allow(dead_code)]
 fn parse_priority(priority: Option<&str>) -> Severity {
     match priority {
         Some("Highest" | "Critical") => Severity::Critical,

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -3,8 +3,6 @@
 //! All external connectors (Datadog, pganalyze, `CloudWatch`, etc.)
 //! implement the `Connector` trait defined here.
 
-#![allow(dead_code)] // Phase 4 infrastructure — consumers arrive later
-
 use std::collections::HashMap;
 
 use async_trait::async_trait;
@@ -37,6 +35,7 @@ pub type ConnectorId = String;
 pub type DatabaseId = String;
 
 /// Issue identifier returned by issue trackers.
+#[allow(dead_code)]
 pub type IssueId = String;
 
 // ---------------------------------------------------------------------------
@@ -46,6 +45,7 @@ pub type IssueId = String;
 #[derive(Debug)]
 pub enum ConnectorError {
     /// The requested operation is not supported by this connector.
+    #[allow(dead_code)]
     NotSupported(&'static str),
     /// Authentication failed.
     AuthError(String),
@@ -85,6 +85,7 @@ impl std::error::Error for ConnectorError {}
 // ---------------------------------------------------------------------------
 
 /// A single metric data point from an external source.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Metric {
     pub name: String,
@@ -96,6 +97,7 @@ pub struct Metric {
 }
 
 /// An alert from an external monitoring system.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Alert {
     pub id: String,
@@ -108,6 +110,7 @@ pub struct Alert {
     pub url: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AlertStatus {
     Active,
@@ -116,6 +119,7 @@ pub enum AlertStatus {
 }
 
 /// Request to create an issue in an external tracker.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct IssueRequest {
     pub title: String,
@@ -126,6 +130,7 @@ pub struct IssueRequest {
 }
 
 /// Update to an existing issue.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct IssueUpdate {
     pub title: Option<String>,
@@ -143,7 +148,7 @@ pub struct ConnectorHealth {
 }
 
 /// Capabilities advertised by a connector.
-#[allow(clippy::struct_excessive_bools)]
+#[allow(clippy::struct_excessive_bools, dead_code)]
 #[derive(Debug, Clone)]
 pub struct ConnectorCapabilities {
     pub can_fetch_metrics: bool,
@@ -158,6 +163,7 @@ pub struct ConnectorCapabilities {
 // Rate limiting
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct RateLimitConfig {
     pub requests_per_second: f64,
@@ -167,6 +173,7 @@ pub struct RateLimitConfig {
     pub respect_retry_after: bool,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct BackoffConfig {
     pub initial_delay_ms: u64,
@@ -193,6 +200,7 @@ impl Default for BackoffConfig {
 // ---------------------------------------------------------------------------
 
 /// Normalized metric category — source-agnostic classification.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MetricCategory {
     CpuUsage,
@@ -211,6 +219,7 @@ pub enum MetricCategory {
 }
 
 impl MetricCategory {
+    #[allow(dead_code)]
     pub fn label(&self) -> &str {
         match self {
             Self::CpuUsage => "cpu_usage",
@@ -231,6 +240,7 @@ impl MetricCategory {
 }
 
 /// Internal normalized metric — regardless of source connector.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct NormalizedMetric {
     pub category: MetricCategory,
@@ -257,6 +267,7 @@ pub struct TimeWindow {
 ///
 /// Concrete implementations (Datadog, pganalyze, `CloudWatch`, etc.)
 /// will be added in Phase 4.
+#[allow(dead_code)]
 #[async_trait]
 pub trait Connector: Send + Sync {
     fn id(&self) -> &str;
@@ -341,6 +352,7 @@ impl ConnectorRegistry {
     }
 
     /// Look up a connector by its [`Connector::id`].
+    #[allow(dead_code)]
     pub fn get(&self, id: &str) -> Option<&dyn Connector> {
         self.connectors
             .iter()

--- a/src/connectors/postgresai.rs
+++ b/src/connectors/postgresai.rs
@@ -3,8 +3,6 @@
 //! Integrates with the postgres.ai API to fetch open issues as alerts
 //! and create/update issues in the `PostgresAI` tracker.
 
-#![allow(dead_code)] // Phase 4 infrastructure — consumers arrive later
-
 use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
@@ -25,6 +23,7 @@ use crate::governance::Severity;
 ///
 /// Supports creating and updating issues, and fetching open issues as
 /// alerts. Does not provide metric data.
+#[allow(dead_code)]
 pub struct PostgresAIConnector {
     api_key: String,
     org_id: Option<String>,
@@ -48,18 +47,21 @@ impl PostgresAIConnector {
     }
 
     /// Set the organisation ID scope for API requests.
+    #[allow(dead_code)]
     pub fn with_org(mut self, org_id: String) -> Self {
         self.org_id = Some(org_id);
         self
     }
 
     /// Set the project ID scope for API requests.
+    #[allow(dead_code)]
     pub fn with_project(mut self, project_id: String) -> Self {
         self.project_id = Some(project_id);
         self
     }
 
     /// Override the base URL (useful for testing against staging).
+    #[allow(dead_code)]
     pub fn with_base_url(mut self, url: String) -> Self {
         self.base_url = url;
         self
@@ -92,6 +94,7 @@ impl PostgresAIConnector {
 // Wire types — minimal shapes expected from the postgres.ai API
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct ApiIssue {
     id: String,
@@ -104,12 +107,14 @@ struct ApiIssue {
     database_id: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct ApiIssueList {
     #[serde(default)]
     issues: Vec<ApiIssue>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct ApiIssueCreated {
     id: String,
@@ -318,6 +323,7 @@ impl Connector for PostgresAIConnector {
 // Helpers
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 fn parse_severity(s: Option<&str>) -> Severity {
     match s {
         Some("critical") => Severity::Critical,

--- a/src/connectors/script.rs
+++ b/src/connectors/script.rs
@@ -24,6 +24,7 @@ use crate::governance::Severity;
 ///
 /// The command receives a JSON object on stdin and must write a JSON response
 /// to stdout before exiting.  A non-zero exit code is treated as an error.
+#[allow(dead_code)]
 pub struct ScriptConnector {
     connector_id: String,
     connector_name: String,
@@ -37,6 +38,7 @@ pub struct ScriptConnector {
     warned_about_external: bool,
 }
 
+#[allow(dead_code)]
 impl ScriptConnector {
     /// Create a new `ScriptConnector` with default timeout (30 s) and rate
     /// limit (1.0 RPS).
@@ -338,6 +340,7 @@ impl Connector for ScriptConnector {
 // Helpers
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 fn system_time_to_iso8601(ts: SystemTime) -> String {
     let total_secs = ts.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
     // Minimal RFC 3339 / ISO 8601 UTC representation without pulling in chrono.
@@ -353,6 +356,7 @@ fn system_time_to_iso8601(ts: SystemTime) -> String {
 /// Convert days-since-Unix-epoch to `(year, month, day)`.
 ///
 /// Uses the proleptic Gregorian calendar algorithm (Tomohiko Sakamoto variant).
+#[allow(dead_code)]
 fn days_to_ymd(days: u64) -> (u32, u32, u32) {
     // Algorithm works with i64; days since 1970-01-01.
     // Saturate at i64::MAX for dates far in the future (> ~2.5 × 10^16 years).
@@ -388,6 +392,7 @@ fn days_to_ymd(days: u64) -> (u32, u32, u32) {
     )
 }
 
+#[allow(dead_code)]
 fn parse_severity(s: &str) -> Severity {
     match s.to_lowercase().as_str() {
         "critical" => Severity::Critical,
@@ -396,6 +401,7 @@ fn parse_severity(s: &str) -> Severity {
     }
 }
 
+#[allow(dead_code)]
 fn parse_alert_status(s: &str) -> AlertStatus {
     match s.to_lowercase().as_str() {
         "acknowledged" | "ack" => AlertStatus::Acknowledged,

--- a/src/connectors/supabase.rs
+++ b/src/connectors/supabase.rs
@@ -27,6 +27,7 @@ const DEFAULT_BASE_URL: &str = "https://api.supabase.com";
 // ---------------------------------------------------------------------------
 
 /// Connector for the Supabase platform.
+#[allow(dead_code)]
 pub struct SupabaseConnector {
     access_token: String,
     project_ref: Option<String>,
@@ -46,12 +47,14 @@ impl SupabaseConnector {
     }
 
     /// Set the Supabase project reference (e.g., `"abcdefghijklmnop"`).
+    #[allow(dead_code)]
     pub fn with_project_ref(mut self, project_ref: String) -> Self {
         self.project_ref = Some(project_ref);
         self
     }
 
     /// Override the API base URL (useful for testing with a mock server).
+    #[allow(dead_code)]
     pub fn with_base_url(mut self, base_url: String) -> Self {
         self.base_url = base_url;
         self

--- a/src/rca.rs
+++ b/src/rca.rs
@@ -14,9 +14,6 @@
 //! 7. Stat correlation (`pg_stat_statements`)
 //! 8. Object state (table/index stats)
 
-// Many types are defined ahead of their consumers (Phase 3 integration).
-#![allow(dead_code)]
-
 use std::fmt::Write as _;
 
 use crate::governance::{EvidenceClass, FeatureArea, Severity};
@@ -78,6 +75,7 @@ impl DiagnosticSnapshot {
 // ---------------------------------------------------------------------------
 
 /// A structured RCA finding with three-tier mitigation.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct RcaFinding {
     /// Brief title of the finding.
@@ -100,13 +98,14 @@ pub struct RcaFinding {
 
 impl RcaFinding {
     /// Feature area this finding belongs to.
-    #[allow(clippy::unused_self)]
+    #[allow(clippy::unused_self, dead_code)]
     pub fn feature_area(&self) -> FeatureArea {
         FeatureArea::Rca
     }
 }
 
 /// A complete RCA report.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub struct RcaReport {
     /// Findings from the investigation.
@@ -119,6 +118,7 @@ pub struct RcaReport {
 
 impl RcaReport {
     /// Format the report for terminal display.
+    #[allow(dead_code)]
     pub fn display(&self) -> String {
         let mut out = String::new();
 
@@ -168,6 +168,7 @@ impl RcaReport {
     }
 }
 
+#[allow(dead_code)]
 fn severity_icon(s: Severity) -> &'static str {
     match s {
         Severity::Info => "[i]",


### PR DESCRIPTION
## Summary
- Remove all module-level `#![allow(dead_code)]` from 9 Phase 4 modules
- Add targeted item-level `#[allow(dead_code)]` on genuinely unused but API-complete items
- No code deleted — all items serve API completeness for future consumers
- Affected files: connectors (mod, github, gitlab, jira, postgresai, cloudwatch, issue_sync), rca.rs

Closes #532

## Test plan
- [ ] `cargo clippy -- -D warnings` passes clean
- [ ] `cargo test` passes (2114 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)