### PR TITLE
chore: clean up stale infrastructure comments

### DIFF
--- a/src/backup_monitoring.rs
+++ b/src/backup_monitoring.rs
@@ -14,8 +14,6 @@
 //! | Archiving disabled | Advisory | `archive_mode = off` |
 //! | Current WAL position | Factual | `pg_current_wal_lsn()` |
 
-// Phase 2/3 infrastructure — compiled but not yet wired into the main
-// dispatch loop. Items are exercised via unit tests.
 #![allow(dead_code)]
 
 use crate::governance::{EvidenceClass, Severity};

--- a/src/bloat.rs
+++ b/src/bloat.rs
@@ -16,7 +16,6 @@
 //! [`BloatReport::pgstattuple_available`] for callers that want to
 //! offer a more precise follow-up query.
 
-// Phase 2 infrastructure — compiled but not yet wired into the main dispatch loop.
 #![allow(dead_code)]
 
 use crate::governance::{EvidenceClass, Severity};

--- a/src/config.rs
+++ b/src/config.rs
@@ -876,8 +876,7 @@ pub struct SyncConfig {
 ///
 /// Channel names must match the variant tag used in the daemon's
 /// `--slack-webhook`, `--webhook-url`, etc. flags.  This config is
-/// evaluated at alert dispatch time; consumers not yet wired in v1
-/// treat an empty list as "send to all".
+/// evaluated at alert dispatch time; an empty list means "send to all".
 ///
 /// ```toml
 /// [notification_routing]

--- a/src/config_tuning.rs
+++ b/src/config_tuning.rs
@@ -17,8 +17,6 @@
 //! | `statement_timeout` disabled | Advisory | `pg_settings` |
 //! | Restart-required GUCs | Heuristic | `pg_settings` context |
 
-// Phase 2/3 infrastructure — compiled but not yet wired into the main dispatch
-// loop. Items are exercised via unit tests and will be connected in Phase 3.
 #![allow(dead_code)]
 
 use crate::governance::{EvidenceClass, Severity};

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -156,7 +156,7 @@ pub enum NotificationChannel {
     /// When `secret` is set, the payload is signed with HMAC-SHA256 and the
     /// signature is sent in the `X-Rpg-Signature-256` header.
     Webhook { url: String, secret: Option<String> },
-    /// Email (placeholder — not implemented in v1).
+    /// Email — not implemented in v1.0, see SPEC deferred items.
     #[allow(dead_code)]
     Email { to: String },
     /// `PagerDuty` Events API v2 routing key.

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,6 @@ mod ssh_tunnel;
 mod statusline;
 mod vars;
 
-// Phase 2/3 infrastructure — compiled but not yet wired into the main
-// dispatch loop. Each module suppresses dead_code at the item level.
 mod aaa_commands;
 mod alert_delivery;
 mod anomaly;

--- a/src/query_optimization.rs
+++ b/src/query_optimization.rs
@@ -13,7 +13,6 @@
 //! | Blocking chain | Factual | `pg_locks` + `pg_stat_activity` |
 //! | High session count | Heuristic | `pg_stat_activity` |
 
-// Phase 2/3 infrastructure — compiled but not yet wired into the main dispatch loop.
 #![allow(dead_code)]
 
 use crate::governance::{EvidenceClass, Severity};


### PR DESCRIPTION
## Summary
- Remove stale "Phase 2/3 infrastructure — not yet wired" comments from 5 analyzer modules (all wired since #454)
- Update `NotificationRouting` doc comment in config.rs
- Clarify email notification placeholder in daemon.rs

Closes #536

## Test plan
- [ ] `cargo test` passes (2153 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)