### PR TITLE
refactor: explicit tokio runtime construction

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -764,11 +764,16 @@ fn build_settings(
 // Entry point
 // ---------------------------------------------------------------------------
 
-// TODO: Replace #[tokio::main] with explicit runtime construction
-// to optimize thread count per operating mode (issue #2, finding #9).
-#[tokio::main]
+fn main() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+    rt.block_on(async_main());
+}
+
 #[allow(clippy::too_many_lines)]
-async fn main() {
+async fn async_main() {
     // Install the default rustls CryptoProvider before any TLS operations.
     // Required because multiple dependencies (tokio-postgres-rustls, reqwest)
     // pull in different crypto backends, preventing auto-selection.


### PR DESCRIPTION
## Summary
- Replace `#[tokio::main]` with explicit `tokio::runtime::Builder::new_multi_thread().enable_all().build()`
- Rename `async fn main()` to `async fn async_main()`, add plain `fn main()` wrapper
- Enables future customization of worker threads, stack size, etc.
- No behavioral change

Closes #540

## Test plan
- [ ] `cargo test` passes (2165 tests)
- [ ] No behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)