### PR TITLE
docs: rename samo→rpg, remove self-driving language from public files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-Rpg — self-driving Postgres agent and psql-compatible terminal. Private repo: NikolayS/project-alpha.
+Rpg — modern Postgres terminal with built-in diagnostics and AI assistant. Repo: NikolayS/project-alpha.
 
 ## Style rules
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rpg"
 version = "0.3.0"
 edition = "2021"
 rust-version = "1.82"
-description = "Self-driving Postgres agent and psql-compatible terminal"
+description = "Modern Postgres terminal with built-in diagnostics and AI assistant"
 license = "Apache-2.0"
 repository = "https://github.com/NikolayS/project-alpha"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rpg — self-driving Postgres agent
+# rpg — a modern Postgres terminal
 
 A psql-compatible terminal with built-in DBA diagnostics and AI assistant. Single binary, no dependencies, cross-platform.
 

--- a/emdaer.dm
+++ b/emdaer.dm
@@ -1,23 +1,23 @@
-# Samo
+# rpg
 
 > The best terminal for diagnosing and fixing Postgres production issues.
 
-**Status:** Vision / pre-development  
-**Language:** Rust  
-**Org:** [DBLab Inc.](https://samo.sh)
+**Status:** Active development (v0.3.0)
+**Language:** Rust
+**Org:** [DBLab Inc.](https://dblab.io)
 
 ---
 
 ## What is this?
 
-A self-driving Postgres agent that lives in your terminal. Four things that have never been combined:
+A modern Postgres terminal that combines four things that have never existed in one tool:
 
-1. **An autonomous agent** — detects, diagnoses, and resolves database issues with per-feature autonomy levels and the AAA Architecture (Analyzer/Actor/Auditor)
-2. **An AI-powered terminal** — LLM inside, understands your schema, explains errors, writes and optimizes SQL, performs root cause analysis
-3. **Batteries included** — pgcli-style autocomplete, pspg-style pager, postgres_dba diagnostics built in
-4. **psql-compatible** — common psql workflows work out of the box, respecting 30 years of muscle memory
+1. **AI-powered terminal** — LLM inside, understands your schema, explains errors, writes and optimizes SQL, performs root cause analysis
+2. **Batteries included** — pgcli-style autocomplete, built-in pager, postgres_dba diagnostics
+3. **psql-compatible** — common psql workflows work out of the box, respecting 30 years of muscle memory
+4. **DBA toolkit** — health checks, index analysis, bloat detection, vacuum monitoring, replication status
 
-Think: `self-driving postgres` at the core, `pgcli` for UX, `warp` for AI, `openclaw` for connectivity.
+Think: `pgcli` for UX, `warp` for AI, `postgres_dba` built in.
 
 ---
 
@@ -25,11 +25,9 @@ Think: `self-driving postgres` at the core, `pgcli` for UX, `warp` for AI, `open
 
 Every production Postgres incident follows the same painful loop: notice something's wrong, SSH in, run ad-hoc queries against pg_stat_activity, reconstruct what happened, figure out a fix, apply it, hope it works. This takes 30-60 minutes even for experienced DBAs.
 
-What if your terminal could do that investigation in seconds, propose the fix, and — with your permission — apply it?
-
 AI coding tools (Cursor, Warp, Claude Code) proved that putting an LLM *inside* the tool you already use is transformative. Nobody's done this for Postgres.
 
-**The opportunity:** Build the terminal where Postgres expertise meets autonomous AI operations. The psql compatibility gets you in the door; the self-driving capabilities keep you there.
+**The opportunity:** Build the terminal where Postgres expertise meets AI assistance. The psql compatibility gets you in the door; the diagnostic and AI capabilities keep you there.
 
 ---
 
@@ -37,25 +35,7 @@ AI coding tools (Cursor, Warp, Claude Code) proved that putting an LLM *inside* 
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│                       samo                          │
-│                                                     │
-│  ┌──────────────────────────────────────────────┐   │
-│  │      Autonomous Agent — AAA Architecture     │   │
-│  │                                              │   │
-│  │        ┌──────────┐                          │   │
-│  │        │ ANALYZER │ (thinks, plans)          │   │
-│  │        └──┬────┬──┘                          │   │
-│  │      ┌────▼┐ ┌─▼────────┐                   │   │
-│  │      │ACTOR│ │ AUDITOR  │ (reviews both)     │   │
-│  │      │(act)│ │(proposal │                    │   │
-│  │      └──┬──┘ │ + action)│                    │   │
-│  │         └───►└──────────┘                    │   │
-│  │                                              │   │
-│  │  Per-feature autonomy (A/G/P × 18 areas)    │   │
-│  │  RCA • Index Health • Vacuum • Config • ...  │   │
-│  │  Connectors: pg_ash │ CloudWatch/RDS         │   │
-│  │  Modes: interactive │ daemon                 │   │
-│  └──────────────────────────────────────────────┘   │
+│                       rpg                           │
 │                                                     │
 │  ┌─────────────┐  ┌──────────────┐  ┌───────────┐  │
 │  │  AI Engine  │  │  UX Layer    │  │  Core     │  │
@@ -64,7 +44,7 @@ AI coding tools (Cursor, Warp, Claude Code) proved that putting an LLM *inside* 
 │  │ NL → SQL    │  │ Highlighting │  │ \commands │  │
 │  │ EXPLAIN     │  │ TUI pager    │  │ COPY/LOB  │  │
 │  │ RCA chain   │  │ \dba diags   │  │ .psqlrc   │  │
-│  │ /ask        │  │              │  │ Formatting│  │
+│  │ /ask        │  │ Status bar   │  │ Formatting│  │
 │  └─────────────┘  └──────────────┘  └───────────┘  │
 └─────────────────────────────────────────────────────┘
 ```
@@ -90,34 +70,11 @@ A Postgres terminal compatible with common psql workflows, reimplemented in Rust
 - **Unsupported behavior:** fails loudly, never silently
 - 100% psql compatibility is a multi-year rabbit hole. Common workflows first, long tail later.
 
-### Rust Foundations
-- `tokio-postgres` — async wire protocol
-- `rustyline` — readline with history, completion
-- `clap` — CLI argument parsing
-
 ---
 
-## Layer 2: Batteries Included
+## DBA Diagnostics
 
-Everything `pgcli` and `pspg` do, built in.
-
-### Schema-Aware Autocomplete
-- Queries `pg_catalog` on connect to build completion tree
-- Table/column/function/type names contextual to the query being written
-- Keyword completion with Postgres version awareness
-
-### Syntax Highlighting
-- Real-time SQL highlighting in the input line
-- `tree-sitter-sql` or `syntect` for parsing
-
-### Integrated TUI Pager
-- Replaces the need for an external pager (less/pspg)
-- Column freezing, horizontal scroll, search
-- Built with `ratatui`
-- Can still pipe to external pager if preferred
-
-### Built-in Diagnostics (postgres_dba)
-[postgres_dba](https://github.com/NikolayS/postgres_dba) queries available as first-class commands:
+Everything `postgres_dba` does, built in as first-class commands.
 
 ```
 \dba activity     — current activity (pg_stat_activity)
@@ -128,11 +85,15 @@ Everything `pgcli` and `pspg` do, built in.
 \dba cache-hit    — buffer cache hit ratio
 \dba vacuum       — vacuum/autovacuum status
 \dba replication  — replication lag and status
+\dba indexes      — index health (unused, redundant, invalid, bloated)
+\dba config       — non-default configuration parameters
+\dba connections  — connection counts by state
+\dba io           — I/O statistics by backend type (PG 16+)
 ```
 
 ---
 
-## Layer 3: AI Terminal
+## AI Terminal
 
 An LLM lives inside the terminal.
 
@@ -142,138 +103,94 @@ An LLM lives inside the terminal.
 - **EXPLAIN analysis** — paste or run `EXPLAIN ANALYZE`, get plain-English breakdown with optimization suggestions
 - **Schema-aware context** — the LLM knows your tables, columns, indexes, constraints
 - **Query optimization** — suggest rewrites, missing indexes, better join strategies
-- **pg_ash integration** — feed wait event data to LLM for workload analysis
 
 ### Interface
 ```
 -- Natural language mode
-/ask show me the top 10 queries by total time from pg_ash
+rpg=> /ask show me the top 10 queries by total time
 
 -- Inline explanation
-samo=> SELECT * FROM orders WHERE status = 'pending';
+rpg=> SELECT * FROM orders WHERE status = 'pending';
 ERROR: column "status" does not exist
 -- 💡 Did you mean "order_status"? (orders.order_status text NOT NULL)
 
 -- EXPLAIN analysis
-samo=> /explain SELECT * FROM orders JOIN customers ON ...
+rpg=> /explain SELECT * FROM orders JOIN customers ON ...
 -- Returns annotated plan with bottleneck identification
 ```
 
 ### LLM Backend
 - Pluggable: OpenAI, Anthropic, local models (ollama)
-- Context window management — schema + recent queries + pg_ash data as context
+- Context window management — schema + recent queries as context
 - Streaming responses in terminal
 
 ---
 
-## Autonomous Agent
+## UX
 
-The core differentiator — not just a terminal, but a self-driving Postgres agent.
+### Schema-Aware Autocomplete
+- pgcli-style dropdown with arrow key navigation
+- Table/column/function/type names contextual to the query being written
+- Keyword completion with Postgres version awareness
 
-### Per-Feature Autonomy (3 levels × N feature areas)
+### Syntax Highlighting
+- Real-time SQL highlighting in the input line
+- Keywords, strings, numbers, operators, schema objects — each with distinct colors
 
-Each feature area (index health, vacuum, config tuning, upgrades, etc.) is independently configured:
+### Integrated TUI Pager
+- Replaces the need for an external pager (less/pspg)
+- Column freezing, horizontal scroll, search
+- Built with `ratatui`
 
-| Level | Name | What it means |
-|-------|------|---------------|
-| **O** | **Observe** | Read-only. Observe, diagnose, report. Zero writes. |
-| **S** | **Supervised** | Act with human approval. Proposes action, human confirms. |
-| **A** | **Auto** | Act autonomously within policy and DB permissions. Human notified after. |
+### Status Bar
+- Persistent bottom bar showing connection info, transaction state, query timing, AI token usage
 
-The **AAA Architecture** (Analyzer / Actor / Auditor) — a triangle where the Auditor cross-cuts both, reviewing proposals *and* actions. The decision-maker never has direct execution access.
+---
 
-### What the Agent Does
-- **Root cause analysis** — reconstruct block trees, correlate pg_ash wait events with metrics and locks, produce structured RCA reports with three-tier mitigation (immediate/mid-term/long-term)
-- **Continuous health monitoring** — detect anomalies, session spikes, lock cascades, bloat, stale stats
-- **Auto-remediation** — cancel blockers, reindex, vacuum, tune GUCs (within autonomy level and DB permissions)
-- **Issue tracking** — create/update issues with full RCA evidence
-- **Escalation** — when something exceeds autonomy level, create a detailed ticket or alert
+## Daemon Mode
 
-### Connectors
-
-| Source | What We Get |
-|--------|-------------|
-| **pg_ash** | Wait events, query-level performance, active session history |
-| **PostgresAI Monitoring & Checkup** | Historical metrics, health scores, checkup reports, baselines |
-| **PostgresAI Issues** | Issue tracking, RCA linkage, remediation status, evidence |
-| **Datadog** | Infrastructure metrics, custom monitors, dashboards |
-| **pganalyze** | Query statistics, EXPLAIN plans, index advisor suggestions |
-| **AWS CloudWatch** | CloudWatch metrics/logs/alarms, RDS Performance Insights, Enhanced Monitoring |
-| **Supabase** | Project management API, Postgres via pooler |
-
-### Modes
-
-**Interactive** — human at the terminal, agent assists and suggests in real-time.
-
-**Daemon/Container** — runs headless, follows protocols, reports via configured channels (Slack, email, GitHub issues). Deployable as a sidecar container next to your Postgres.
+rpg can run headless as a background monitor:
 
 ```bash
-# Interactive — agent assists in real-time
-samo --host prod-db-01 --autonomy rca:supervised,index_health:observe
-
-# Daemon mode — headless monitoring and remediation
-samo daemon --config /etc/samo/config.toml
+rpg daemon --config /etc/rpg/config.toml
 ```
+
+- Continuous health monitoring with anomaly detection
+- Notification channels: Slack, Telegram, PagerDuty, webhooks
+- Alert deduplication and severity-based routing
+- Deployable as a sidecar container
 
 ---
 
 ## Roadmap
 
-### Phase 0: Foundation (Month 1-2)
-- [ ] Wire protocol client with auth (SCRAM, SSL, password)
-- [ ] Basic REPL with rustyline
-- [ ] Core backslash commands (\d, \dt, \di, \l, \c, \x, \timing)
-- [ ] Output formatting (aligned, \x expanded)
-- [ ] Basic autocomplete (keywords + schema objects)
-- [ ] CI with cross-compilation (Linux, macOS, both architectures)
+### Phase 0: Foundation ✅
+- [x] Wire protocol client with auth (SCRAM, SSL, password)
+- [x] Basic REPL with rustyline
+- [x] Core backslash commands
+- [x] Output formatting (aligned, \x expanded)
+- [x] Basic autocomplete (keywords + schema objects)
 
-### Phase 1: Daily Driver (Month 2-4)
-- [ ] Remaining common backslash commands (\copy, \e, \i, \set, \watch)
-- [ ] Syntax highlighting
-- [ ] TUI pager (ratatui)
-- [ ] postgres_dba diagnostics as \dba commands
-- [ ] .psqlrc basic support
-- [ ] Single binary distribution
+### Phase 1: Daily Driver ✅
+- [x] Remaining common backslash commands (\copy, \e, \i, \set, \watch)
+- [x] Syntax highlighting
+- [x] TUI pager (ratatui)
+- [x] postgres_dba diagnostics as \dba commands
+- [x] Single binary distribution
 
-### Phase 2: AI Brain (Month 3-5)
-- [ ] LLM integration framework (pluggable providers)
-- [ ] /ask command — NL → SQL
-- [ ] Error explanation with schema context
-- [ ] EXPLAIN ANALYZE interpreter
-- [ ] pg_ash query and visualization
-- [ ] Context management (schema + session + history)
+### Phase 2: AI Brain ✅
+- [x] LLM integration framework (pluggable providers)
+- [x] /ask command — NL → SQL
+- [x] Error explanation with schema context
+- [x] EXPLAIN ANALYZE interpreter
+- [x] Context management (schema + session + history)
 
-### Phase 3: Agent (Month 4-7)
-- [ ] Autonomy level framework
-- [ ] Health check protocol engine
-- [ ] First connectors (pg_ash native)
-- [ ] Daemon mode
-- [ ] Issue tracker integration (GitHub)
-- [ ] Alert/notification channels
-
-### Phase 4: Ecosystem (Month 6+)
-- [ ] Additional connectors (Datadog, pganalyze, RDS, Supabase)
-- [ ] Jira/GitLab integration
-- [ ] Plugin system for custom connectors
-- [ ] Container/sidecar packaging
-- [ ] Protocol marketplace (community health check playbooks)
-
----
-
-## Rust Crate Dependencies (Initial)
-
-| Crate | Purpose |
-|-------|---------|
-| `tokio-postgres` | Wire protocol, async queries |
-| `rustls` / `native-tls` | SSL connections |
-| `rustyline` | REPL, history, completion |
-| `ratatui` + `crossterm` | TUI pager |
-| `syntect` or `tree-sitter` | Syntax highlighting |
-| `clap` | CLI argument parsing |
-| `serde` + `toml` | Config files |
-| `reqwest` | HTTP for API connectors |
-| `tracing` | Structured logging |
-| `tokio` | Async runtime |
+### Phase 3: Monitoring (current)
+- [x] Daemon mode with anomaly detection
+- [x] Health check protocol engine
+- [x] Notification channels (Slack, Telegram, PagerDuty, webhooks)
+- [ ] Connector ecosystem (Datadog, pganalyze, CloudWatch, Supabase)
+- [ ] Issue tracker integration (GitHub, GitLab, Jira)
 
 ---
 
@@ -282,20 +199,13 @@ samo daemon --config /etc/samo/config.toml
 | Tool | What We Take | What We Add |
 |------|-------------|-------------|
 | `psql` | Command set, muscle memory, wire protocol | Everything else |
-| `pgcli` | Autocomplete, highlighting, named queries, destructive warnings, fuzzy match, vi/emacs modes | Rust performance, AI, agent, TUI pager |
+| `pgcli` | Autocomplete, highlighting, named queries, destructive warnings | Rust performance, AI, TUI pager, diagnostics |
 | `pspg` | Pager UX, column freeze | Integrated, not external |
 | `postgres_dba` | Diagnostic queries | Built-in, not separate SQL files |
 | `warp` | AI in terminal, status bar | Postgres-specific, not generic |
-| `claude-code` | Plan mode, sessions, compaction, undo, MCP, project files, subagents | Database-specific domain expertise |
-| `opencode` | TUI, session persistence (SQLite), auto-compact, LSP-like intelligence | Postgres wire protocol as the "language server" |
-| `openclaw` | Multi-session, memory, connectors, cron/heartbeats, channel delivery | Native Postgres agent, not generic AI |
 
 ---
 
 ## License
 
 Apache 2.0
-
----
-
-*This document is the vision. Implementation starts with Layer 1.*

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! Rpg — self-driving Postgres agent and psql-compatible terminal.
+//! Rpg — modern Postgres terminal with built-in diagnostics and AI assistant.
 //!
 //! This is the CLI entry point. It parses psql-compatible flags and
 //! rpg-specific options, then dispatches to the appropriate subsystem.
@@ -230,7 +230,7 @@ fn long_version() -> &'static str {
     version_string()
 }
 
-/// Rpg — self-driving Postgres agent and psql-compatible terminal.
+/// Rpg — modern Postgres terminal with built-in diagnostics and AI assistant.
 ///
 /// A psql-compatible interface with built-in AI and autonomous
 /// database health management.
@@ -238,7 +238,7 @@ fn long_version() -> &'static str {
 #[command(
     name = "rpg",
     version = long_version(),
-    about = "Self-driving Postgres agent and psql-compatible terminal",
+    about = "Modern Postgres terminal with built-in diagnostics and AI assistant",
     long_about = None,
     // Disable auto-generated -h so we can use it for --host (psql compat).
     disable_help_flag = true,


### PR DESCRIPTION
Strips all 'samo' references and 'self-driving Postgres agent' language from public-facing files.

**Changes:**
- **README.md**: title changed to 'rpg — a modern Postgres terminal'
- **emdaer.dm**: full rewrite — removed autonomous agent framing, AAA architecture section, connector table, governance details. Now describes rpg as a modern Postgres terminal with diagnostics and AI. Updated roadmap with checkboxes reflecting current state.
- **Cargo.toml**: description updated
- **src/main.rs**: module doc + clap `about` string updated
- **CLAUDE.md**: project description updated

Self-driving/agent vision remains in SPEC.md (internal spec). Public files now position rpg as a 'modern Postgres terminal with built-in diagnostics and AI assistant.'

No code changes.