### PR TITLE
fix: resolve clippy approx_constant lint in test

### DIFF
--- a/src/connectors/http_json.rs
+++ b/src/connectors/http_json.rs
@@ -469,9 +469,9 @@ mod tests {
     #[test]
     fn extract_deeply_nested() {
         let json = serde_json::json!({
-            "a": { "b": { "c": 3.14 } }
+            "a": { "b": { "c": 3.15 } }
         });
-        assert_eq!(extract_json_value(&json, "a.b.c"), Some(3.14));
+        assert_eq!(extract_json_value(&json, "a.b.c"), Some(3.15));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change `3.14` to `3.15` in http_json.rs test to avoid clippy's `approx_constant` lint
- Fixes CI clippy error from review finding H4 (#547)

## Test plan
- [x] `cargo clippy -- -D warnings` passes clean
- [x] Test still validates deeply nested JSON extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)