### PR TITLE
WIP (do not merge!): docs: psql plugin system proposal (RFC draft)

### DIFF
--- a/psql-plugins-proposal.md
+++ b/psql-plugins-proposal.md
@@ -1,8 +1,8 @@
 # Proposal: Plugin System for psql
 
-**Author:** Nikolay Samokhvalov (DBLab Inc.)
-**Status:** Draft
-**Target:** PostgreSQL hackers mailing list
+- **Author:** Nik Samokhvalov 
+- **Status:** Draft
+- **Target:** PostgreSQL hackers mailing list
 
 ---
 


### PR DESCRIPTION
RFC draft proposing a plugin API for upstream psql. Mirrors the server's `shared_preload_libraries` / hook pattern but for the client.

**Core API:** `_psql_plugin_init()` + `register_command()` + lifecycle hooks (pre/post query, on_error, on_connect).

**Phase 1 scope:** Custom command registration only, ~500 lines of C. No hooks, no completers.

**Strategic angle:** If accepted, rpg's DBA diagnostics and AI features could ship as psql plugins — reaching every psql user. Even if the proposal takes years, the discussion establishes authority on Postgres client tooling.

Internal doc for now — to be adapted into a pgsql-hackers email when ready.