### PR TITLE
feat(repl): make dropdown completion experimental

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1025,6 +1025,19 @@ pub struct RpgHelper {
     ///
     /// When `false`, `complete()` returns no candidates (toggled by F2).
     completion_enabled: bool,
+    /// Whether the pgcli-style visual dropdown overlay is enabled.
+    ///
+    /// **Experimental** — `false` by default.  When `false`, Tab completion
+    /// still inserts the longest-common-prefix / cycles through candidates
+    /// as rustyline's built-in `CompletionType::List` behaviour, but the
+    /// visual dropdown menu is never shown.  Set to `true` via:
+    /// - `[display] dropdown_completion = true` in the config file, or
+    /// - `RPG_DROPDOWN_COMPLETION=1` environment variable.
+    ///
+    /// This is orthogonal to `completion_enabled` (the F2 toggle): F2
+    /// disables schema-aware completion entirely; this flag only controls
+    /// whether the dropdown overlay is rendered.
+    dropdown_completion_enabled: bool,
     /// Shared dropdown state.  Written by `Completer::complete` and by
     /// [`DropdownEventHandler`]; read by `Hinter::hint`.
     pub dropdown: Arc<Mutex<DropdownState>>,
@@ -1044,6 +1057,7 @@ impl RpgHelper {
             cache,
             highlight,
             completion_enabled: true,
+            dropdown_completion_enabled: false,
             dropdown: Arc::new(Mutex::new(DropdownState::default())),
             prompt_width: 0,
         }
@@ -1070,6 +1084,14 @@ impl RpgHelper {
     /// Enable or disable schema-aware tab completion at runtime.
     pub fn set_completion(&mut self, enabled: bool) {
         self.completion_enabled = enabled;
+    }
+
+    /// Enable or disable the experimental dropdown completion overlay.
+    ///
+    /// This is orthogonal to [`set_completion`]: disabling completion via F2
+    /// suppresses all candidates; this flag only controls the visual overlay.
+    pub fn set_dropdown_completion(&mut self, enabled: bool) {
+        self.dropdown_completion_enabled = enabled;
     }
 
     /// Record the display-column width of the current prompt.
@@ -1104,8 +1126,9 @@ impl Completer for RpgHelper {
         // ------------------------------------------------------------------
         // Check whether the dropdown is already active for this same prefix.
         // If so, advance the selection rather than recomputing candidates.
+        // Only applies when the dropdown overlay is enabled.
         // ------------------------------------------------------------------
-        {
+        if self.dropdown_completion_enabled {
             let Ok(mut dd) = self.dropdown.lock() else {
                 return Ok((pos, vec![]));
             };
@@ -1213,10 +1236,16 @@ impl Completer for RpgHelper {
         let names: Vec<String> = candidates.into_iter().map(|(n, _)| n).collect();
 
         // ------------------------------------------------------------------
-        // Activate dropdown with the fresh candidates.
+        // Activate dropdown with the fresh candidates (experimental).
+        //
+        // The dropdown is only populated when `dropdown_completion_enabled`
+        // is `true`.  When disabled, `DropdownState` stays inactive so the
+        // Hinter produces no overlay and the event handler falls through to
+        // rustyline's default key behaviour.  Tab completion itself (LCP
+        // insertion / candidate cycling via rustyline) is unaffected.
         // ------------------------------------------------------------------
         if let Ok(mut dd) = self.dropdown.lock() {
-            if names.is_empty() {
+            if !self.dropdown_completion_enabled || names.is_empty() {
                 dd.dismiss();
             } else {
                 dd.active = true;
@@ -2467,7 +2496,9 @@ mod tests {
         });
 
         let cache = Arc::new(RwLock::new(cache));
-        let helper = RpgHelper::new(cache, false);
+        let mut helper = RpgHelper::new(cache, false);
+        // Enable the experimental dropdown so the activation path is tested.
+        helper.set_dropdown_completion(true);
         let history = DefaultHistory::new();
         let ctx = Context::new(&history);
 
@@ -2505,6 +2536,44 @@ mod tests {
     }
 
     #[test]
+    fn test_dropdown_disabled_by_default() {
+        // When `dropdown_completion_enabled` is false (the default), the
+        // dropdown should never become active even when candidates are found.
+        use rustyline::history::DefaultHistory;
+
+        let mut cache = SchemaCache::default();
+        cache.tables.push(TableInfo {
+            schema: "public".to_owned(),
+            name: "users".to_owned(),
+            kind: 'r',
+        });
+        cache.tables.push(TableInfo {
+            schema: "public".to_owned(),
+            name: "user_roles".to_owned(),
+            kind: 'r',
+        });
+
+        let cache = Arc::new(RwLock::new(cache));
+        // Default helper: dropdown_completion_enabled = false.
+        let helper = RpgHelper::new(cache, false);
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        let line = "SELECT * FROM ";
+        let (_, pairs) = helper.complete(line, line.len(), &ctx).unwrap();
+
+        // Candidates should still be returned for rustyline's LCP logic.
+        assert!(!pairs.is_empty(), "candidates should still be returned");
+
+        // But the dropdown overlay must stay inactive.
+        let dd = helper.dropdown.lock().unwrap();
+        assert!(
+            !dd.active,
+            "dropdown must not activate when dropdown_completion is disabled"
+        );
+    }
+
+    #[test]
     fn test_dropdown_navigation_via_helper() {
         // Directly exercise DropdownState select_next / select_prev in the
         // context of RpgHelper's shared state.
@@ -2520,7 +2589,9 @@ mod tests {
         }
 
         let cache = Arc::new(RwLock::new(cache));
-        let helper = RpgHelper::new(cache, false);
+        let mut helper = RpgHelper::new(cache, false);
+        // Enable the experimental dropdown so the activation path is tested.
+        helper.set_dropdown_completion(true);
         let history = DefaultHistory::new();
         let ctx = Context::new(&history);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,20 @@ pub struct DisplayConfig {
     /// statusline_enabled = false
     /// ```
     pub statusline_enabled: bool,
+    /// Enable the pgcli-style visual dropdown completion menu.
+    ///
+    /// **Experimental** — disabled by default.  When `false` (the default),
+    /// Tab completion still works (longest-common-prefix / cycling via
+    /// rustyline) but no visual overlay is shown.  Set to `true` to opt in:
+    ///
+    /// ```toml
+    /// [display]
+    /// dropdown_completion = true
+    /// ```
+    ///
+    /// Can also be enabled via the `RPG_DROPDOWN_COMPLETION=1` environment
+    /// variable.
+    pub dropdown_completion: bool,
 }
 
 impl Default for DisplayConfig {
@@ -147,6 +161,8 @@ impl Default for DisplayConfig {
             vi_mode: false,
             // Default ON — overridden to OFF in non-interactive sessions.
             statusline_enabled: true,
+            // Experimental — disabled by default.
+            dropdown_completion: false,
         }
     }
 }
@@ -1034,6 +1050,12 @@ pub fn load_config() -> (Config, Vec<String>) {
     // Post-load fixup: infer provider from api_key_env when not explicit.
     config.ai.infer_provider();
 
+    // Apply RPG_* environment variable overrides.
+    // RPG_DROPDOWN_COMPLETION=1 enables the experimental dropdown menu.
+    if std::env::var("RPG_DROPDOWN_COMPLETION").as_deref() == Ok("1") {
+        config.display.dropdown_completion = true;
+    }
+
     (config, warnings)
 }
 
@@ -1235,6 +1257,9 @@ fn merge_config(base: Config, overlay: Config) -> Config {
             // Prefer explicit false from overlay over base default.
             statusline_enabled: overlay.display.statusline_enabled
                 && base.display.statusline_enabled,
+            // Opt-in: either layer enabling it is sufficient.
+            dropdown_completion: overlay.display.dropdown_completion
+                || base.display.dropdown_completion,
         },
         safety: SafetyConfig {
             destructive_warning: overlay.safety.destructive_warning,
@@ -1385,12 +1410,63 @@ mod tests {
         assert_eq!(cfg.display.pager_min_lines, None);
         assert_eq!(cfg.display.border, None);
         assert!(!cfg.display.vi_mode); // default is Emacs
+                                       // Dropdown is experimental — off by default.
+        assert!(!cfg.display.dropdown_completion);
         assert!(cfg.safety.destructive_warning);
         assert!(cfg.connection.host.is_none());
         assert!(cfg.connection.port.is_none());
         assert!(cfg.connection.user.is_none());
         assert!(cfg.connection.dbname.is_none());
         assert!(cfg.connection.sslmode.is_none());
+    }
+
+    #[test]
+    fn parse_display_dropdown_completion() {
+        let toml_str = r"
+[display]
+dropdown_completion = true
+";
+        let cfg: Config = toml::from_str(toml_str).expect("should parse");
+        assert!(cfg.display.dropdown_completion);
+    }
+
+    #[test]
+    fn merge_display_dropdown_completion_either_layer_wins() {
+        // Overlay enabling it wins.
+        let base = Config {
+            display: DisplayConfig {
+                dropdown_completion: false,
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        let overlay = Config {
+            display: DisplayConfig {
+                dropdown_completion: true,
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        let merged = merge_config(base, overlay);
+        assert!(merged.display.dropdown_completion);
+
+        // Base enabling it also wins (OR semantics).
+        let base2 = Config {
+            display: DisplayConfig {
+                dropdown_completion: true,
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        let overlay2 = Config {
+            display: DisplayConfig {
+                dropdown_completion: false,
+                ..DisplayConfig::default()
+            },
+            ..Default::default()
+        };
+        let merged2 = merge_config(base2, overlay2);
+        assert!(merged2.display.dropdown_completion);
     }
 
     #[test]

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -3747,7 +3747,9 @@ async fn run_readline_loop(
     settings.schema_cache = Some(Arc::clone(&cache));
     // Enable syntax highlighting unless the user opted out or $TERM is dumb.
     let highlight = !settings.no_highlight && std::env::var("TERM").as_deref() != Ok("dumb");
-    let helper = RpgHelper::new(Arc::clone(&cache), highlight);
+    let mut helper = RpgHelper::new(Arc::clone(&cache), highlight);
+    // Apply the experimental dropdown flag from config (disabled by default).
+    helper.set_dropdown_completion(settings.config.display.dropdown_completion);
 
     // Obtain a handle to the dropdown state *before* moving the helper into
     // the editor so we can share it with the event handlers below.


### PR DESCRIPTION
## Summary
- Dropdown completion is now **disabled by default** (experimental feature)
- Enable via config: `display.dropdown_completion = true` in rpg config
- Enable via env var: `RPG_DROPDOWN_COMPLETION=1`
- Basic tab completion (LCP/cycling) still works when dropdown is off
- 3 new tests for the config flag behavior

Closes #561

## Test plan
- [x] All tests pass
- [x] `cargo clippy` clean
- [x] Dropdown only activates when explicitly enabled
- [x] Tab completion works normally when dropdown is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)