### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpg"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Modern Postgres terminal with built-in diagnostics and AI assistant"


### PR DESCRIPTION
Version bump for v0.4.0 release.

**Changes since v0.3.0:**
- Renamed samo→rpg in all public files, removed self-driving language (#548)
- Completion dropdown aligned with cursor position (#553)
- Dropdown selection replaces buffer text, dismisses on submit (#554)
- Clippy approx_constant lint fixed (#555)
- Connector modules reorganized (#556)
- OBSERVE_SQL deduplicated (#557)
- Clear terminal screen on interactive startup (#562)
- Dropdown completion made experimental, off by default (#563)
- CHANGELOG added (#550)
- README updated for v0.3.0 features (#546)

After merge, tag `v0.4.0` on main.