### PR TITLE
fix(ci): suppress unused calls_arc warning in test mock

### DIFF
--- a/src/connectors/testing.rs
+++ b/src/connectors/testing.rs
@@ -246,6 +246,7 @@ impl<C: Connector> RecordingConnector<C> {
     /// Return a shared handle to the calls list.
     ///
     /// Useful when you need to inspect calls from a different thread.
+    #[allow(dead_code)]
     pub fn calls_arc(&self) -> Arc<Mutex<Vec<RecordedCall>>> {
         Arc::clone(&self.calls)
     }


### PR DESCRIPTION
CI fails with `-D warnings` because `MockConnector::calls_arc()` is defined but not yet called. Add `#[allow(dead_code)]` — it's test infrastructure that will be used when integration tests exercise the connector from a different thread.