### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024-2026 Nikolay Samokhvalov <nik@samokhvalov.com>
+   Copyright 2026 Nikolay Samokhvalov <nik@samokhvalov.com>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1785,7 +1785,7 @@ fn print_profiles(config: &crate::config::Config) {
 fn print_copyright(server_version: Option<&str>) {
     println!(
         "rpg — modern Postgres terminal
-Copyright (c) 2024-2026, Nikolay Samokhvalov and contributors
+Copyright (c) 2026, Nikolay Samokhvalov and contributors
 https://github.com/NikolayS/rpg
 
 Licensed under the Apache License, Version 2.0."


### PR DESCRIPTION
Remove the `2024-2026` range — it's just 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)