### PR TITLE
fix(statusline): reinstall scroll region on terminal resize

### DIFF
--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -104,11 +104,16 @@ impl StatusLine {
     }
 
     /// Refresh the cached terminal size (call on SIGWINCH / resize events).
+    ///
+    /// Re-installs the scroll region for the new terminal height so that
+    /// normal output does not overwrite the status bar row, then redraws the
+    /// bar at the correct (new) position.
     pub fn on_resize(&mut self) {
         if let Ok((cols, rows)) = crossterm::terminal::size() {
             self.term_cols = cols;
             self.term_rows = rows;
         }
+        self.setup_scroll_region();
         self.render();
     }
 


### PR DESCRIPTION
## Summary

- `on_resize()` updated the cached terminal dimensions and redrawn the footer at the new row, but left the CSR (scroll region) pointing at the old terminal height
- This caused normal output to overwrite the status bar row, and left a stale reserved row at the previous position after shrinking the window
- Fix: call `setup_scroll_region()` inside `on_resize()` after updating dimensions, so the scroll region always matches the current terminal height before the bar is redrawn

## Root cause

`StatusLine::on_resize()` in `src/statusline.rs` called `render()` (which draws the bar at `self.term_rows`) but never reinstalled the ANSI scroll region (`\x1b[1;{last}r`). The scroll region was set once at startup via `setup_scroll_region()` and never updated, so after a resize the protected region boundary was stale.

## Test plan

- [ ] Build passes: `cargo build`
- [ ] All tests pass: `cargo test` (1381 tests)
- [ ] No clippy warnings: `cargo clippy`
- [ ] Manual: open rpg in a terminal, resize the window taller and shorter — status bar should follow to the bottom row each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)