### PR TITLE
fix(execute): split no-tx statements to avoid implicit transaction

### DIFF
--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -1862,9 +1862,7 @@ mod tests {
     #[test]
     fn split_not_needed_two_regular_stmts() {
         // Two normal statements: no split needed (server handles them fine).
-        assert!(!needs_split_execution(
-            "SELECT 1; SELECT 2"
-        ));
+        assert!(!needs_split_execution("SELECT 1; SELECT 2"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `ALTER SYSTEM`, `VACUUM`, `CLUSTER`, `CREATE/DROP DATABASE`, `CREATE/DROP TABLESPACE`, and `REINDEX DATABASE/SYSTEM` cannot run inside any transaction block — including the implicit transaction that `PostgreSQL` wraps around multi-statement simple-query strings.
- Adds `is_no_tx_statement` to identify these statements and `needs_split_execution` to check whether a batch requires individual dispatch.
- When the condition is met, `execute_query` splits the SQL via the existing `split_statements` helper and executes each statement in its own `simple_query` call.

**Root cause fixed:** In t2s (text2sql) mode the AI generates `ALTER SYSTEM SET ...; SELECT pg_reload_conf()` as a two-statement block. Previously this was sent as a single `simple_query` string, which PostgreSQL wraps in an implicit transaction, causing:
```
ERROR: ALTER SYSTEM cannot run inside a transaction block
```

## Test plan

- [ ] Unit tests added for `is_no_tx_statement` (18 cases: all no-tx statement types, case-insensitive, leading whitespace, and tx-safe negative cases)
- [ ] Unit tests added for `needs_split_execution` (6 cases: mixed batch triggers split, single statement does not, two regular statements do not)
- [ ] `cargo test` — 1413 tests pass
- [ ] `cargo clippy` — no warnings
- [ ] Manual: `\t2s` → type a GUC tuning prompt → AI generates `ALTER SYSTEM ...; SELECT pg_reload_conf()` → both statements execute without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)