### PR TITLE
fix(repl): pipe \? output through pager like psql

### DIFF
--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1614,10 +1614,11 @@ pub(crate) async fn exec_lines(
 // Interactive REPL
 // ---------------------------------------------------------------------------
 
-/// Print the backslash command help text.
-fn print_help() {
-    println!("{}", crate::version_string());
-    println!(
+/// Build the backslash command help text and return it as a `String`.
+fn help_text() -> String {
+    format!(
+        "{}\n{}",
+        crate::version_string(),
         r"
 Backslash commands:
   \q              quit rpg
@@ -1706,7 +1707,7 @@ Function keys (interactive mode):
   F4 / \\f4       toggle Vi/Emacs editing mode (next session)
   F5 / \\f5       toggle auto-EXPLAIN on/off
   Ctrl-T          toggle SQL/text2sql input mode"
-    );
+    )
 }
 
 /// Print all configured connection profiles in a table format.
@@ -2887,7 +2888,31 @@ async fn dispatch_meta(
 
     match parsed.cmd {
         MetaCmd::Quit => return MetaResult::Quit,
-        MetaCmd::Help => print_help(),
+        MetaCmd::Help => {
+            let text = help_text();
+            let term_rows = crossterm::terminal::size()
+                .map(|(_, h)| h as usize)
+                .unwrap_or(24);
+            if settings.pager_enabled
+                && crate::pager::needs_paging_with_min(
+                    &text,
+                    term_rows.saturating_sub(2),
+                    settings.pager_min_lines,
+                )
+            {
+                if let Some(ref sl) = settings.statusline {
+                    sl.clear();
+                    sl.teardown_scroll_region();
+                }
+                run_pager_for_text(settings, &text, text.as_bytes());
+                if let Some(ref sl) = settings.statusline {
+                    sl.setup_scroll_region();
+                    sl.render();
+                }
+            } else {
+                println!("{text}");
+            }
+        }
         MetaCmd::Timing(mode) => apply_timing(settings, mode),
         MetaCmd::Expanded(mode) => apply_expanded(settings, mode),
         MetaCmd::ConnInfo => {


### PR DESCRIPTION
## Summary

- `\?` help output is now routed through the configured pager (built-in TUI pager or external `PAGER` command) when pager is enabled and the output exceeds the terminal height, matching psql's behaviour
- Extracted `print_help()` into `help_text() -> String` so the text can be inspected for length before deciding whether to page
- Falls back to plain `println!` when pager is disabled (`\set PAGER off`) or the terminal is tall enough to show the output without scrolling

## Test plan

- [ ] Run `cargo test` — 1438 tests pass, 0 failures
- [ ] Run `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Manual: connect with rpg, run `\?`; in a short terminal window the built-in pager opens; press `q` to exit cleanly
- [ ] Manual: `\set PAGER off` then `\?` — output printed directly without pager
- [ ] Manual: `\set PAGER less` then `\?` — output piped through `less`

🤖 Generated with [Claude Code](https://claude.com/claude-code)