### PR TITLE
fix(repl): no schema refresh after cancelled destructive statement

### DIFF
--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -177,7 +177,7 @@ pub async fn execute_query(
         if let Some(ref r) = reason {
             if !crate::safety::confirm_destructive(r) {
                 eprintln!("Statement cancelled.");
-                return true; // skipped — not an error
+                return false; // not executed — caller must not assume DDL ran
             }
         }
     }
@@ -444,7 +444,7 @@ pub async fn execute_query_extended(
         if let Some(ref r) = reason {
             if !crate::safety::confirm_destructive(r) {
                 eprintln!("Statement cancelled.");
-                return true; // skipped — not an error
+                return false; // not executed — caller must not assume DDL ran
             }
         }
     }


### PR DESCRIPTION
## Summary
- When a user cancels a destructive statement at the safety prompt (`WARNING: drop index / Are you sure? [y/N]`), `execute_query` now returns `false` instead of `true`
- This prevents `auto_refresh_schema` from running (and printing `-- Schema cache refreshed`) after a cancelled statement
- Previously, returning `true` made the caller believe the DDL succeeded

## Test plan
- [ ] Run `DROP INDEX foo;` → answer `N` at safety prompt → verify no `-- Schema cache refreshed` message
- [ ] Run `DROP INDEX foo;` → answer `y` → verify schema cache IS refreshed
- [ ] `cargo test` passes (1448 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)