### PR TITLE
fix(dba): fix redundant-idx, locks, progress vacuum queries

### DIFF
--- a/src/dba.rs
+++ b/src/dba.rs
@@ -1190,8 +1190,8 @@ async fn dba_progress_vacuum(
     // In PG 17 max_dead_tuples/num_dead_tuples were renamed to
     // max_dead_item_ids/num_dead_item_ids.
     let use_item_ids = capabilities
-        .and_then(|c| c.pg_major_version())
-        .map_or(false, |v| v >= 17);
+        .and_then(crate::capabilities::DbCapabilities::pg_major_version)
+        .is_some_and(|v| v >= 17);
     let dead_cols = if use_item_ids {
         "p.max_dead_item_ids, \
             p.num_dead_item_ids"


### PR DESCRIPTION
## Summary
- **redundant-idx**: `s.tablename` → `s.relname` — `pg_stat_user_indexes` has `relname`, not `tablename`
- **locks**: `blocked_activity.waitstart` → `blocked_locks.waitstart` — `waitstart` is on `pg_locks`, not `pg_stat_activity`
- **progress vacuum**: PG 17 renamed `max_dead_tuples`/`num_dead_tuples` to `max_dead_item_ids`/`num_dead_item_ids` — query now adapts based on PG version via capabilities
- **error display**: `run_and_print` and `collect_lock_edges` now call `e.as_db_error()` to show actual PG error messages instead of generic "db error"

Found during testing plan execution (issue #618).

## Test plan
- [ ] `\dba redundant-idx` no longer errors (was: `column s.tablename does not exist`)
- [ ] `\dba locks` no longer errors (was: `column blocked_activity.waitstart does not exist`)
- [ ] `\dba progress vacuum` works on PG 17 (was: `column p.max_dead_tuples does not exist`)
- [ ] `\dba progress vacuum` still works on PG 14-16 (uses old column names)
- [ ] Error messages show actual PG error text
- [ ] `cargo test` passes (1448 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)