### PR TITLE
fix(ai): always wrap /ask queries in read-only tx

### DIFF
--- a/src/repl/ai_commands.rs
+++ b/src/repl/ai_commands.rs
@@ -594,7 +594,7 @@ pub(super) fn wrap_in_ask_readonly_tx(sql: &str) -> String {
 ///
 /// In non-yolo mode write queries (`INSERT`/`UPDATE`/`DELETE`/`MERGE`) are
 /// refused before execution (`AskChoice::No`).  In yolo mode they reach
-/// `AskChoice::Yes` but the read-only transaction wrapper causes PostgreSQL
+/// `AskChoice::Yes` but the read-only transaction wrapper causes `PostgreSQL`
 /// to reject them at the wire level.
 #[allow(clippy::too_many_lines)]
 pub(super) async fn handle_ai_ask(

--- a/tests/integration_repl.rs
+++ b/tests/integration_repl.rs
@@ -711,10 +711,10 @@ async fn ask_readonly_tx_blocks_insert() {
 // false.
 
 /// In yolo mode, a write query that reaches `AskChoice::Yes` is still wrapped
-/// in `start transaction read only` and therefore rejected by PostgreSQL.
+/// in `start transaction read only` and therefore rejected by `PostgreSQL`.
 ///
 /// We simulate the exact SQL that `wrap_in_ask_readonly_tx` produces for an
-/// INSERT statement and verify that PostgreSQL rejects it.
+/// INSERT statement and verify that `PostgreSQL` rejects it.
 #[tokio::test]
 async fn ask_yolo_write_query_rejected_by_readonly_tx() {
     let _ = connect_or_skip!();


### PR DESCRIPTION
## Summary

- Fixes #633: write queries in yolo mode now go through `start transaction read only` wrapper, providing DB-level enforcement
- Removes the `if read_only { wrap } else { borrow }` conditional in both `AskChoice::Yes` and `AskChoice::Edit` branches — always wraps unconditionally
- Rollback-on-error no longer conditions on `read_only`; all wrapped queries need cleanup on failure
- Updates yolo-mode warning message to accurately describe that the DB will reject write queries
- Adds 2 integration tests: `ask_yolo_write_query_rejected_by_readonly_tx` (INSERT rejected) and `ask_yolo_ddl_rejected_by_readonly_tx` (CREATE TABLE rejected)

## Behavior change

| Mode | Before | After |
|---|---|---|
| Non-yolo, read-only query | wrapped in read-only tx | wrapped in read-only tx (unchanged) |
| Non-yolo, write query | refused (AskChoice::No) | refused (AskChoice::No) (unchanged) |
| Yolo, read-only query | wrapped in read-only tx | wrapped in read-only tx (unchanged) |
| **Yolo, write query** | **executed bare (no protection)** | **wrapped in read-only tx → PG rejects** |
| Edit path, any query | wrapped only if read-only | always wrapped |

## Test plan

- [x] `cargo build` — clean compile
- [x] `cargo test` — 1528 unit tests pass
- [x] `cargo fmt --check` — clean
- [ ] `cargo test --features integration` — requires running Postgres (see `docker compose -f docker-compose.test.yml up -d --wait`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)