### PR TITLE
fix(pager): guard against non-TTY stdin before starting pager

### DIFF
--- a/src/dba.rs
+++ b/src/dba.rs
@@ -157,7 +157,11 @@ fn maybe_page(settings: &mut crate::repl::ReplSettings, text: &str) {
                 print!("{text}");
             }
         } else if let Err(e) = crate::pager::run_pager(text) {
-            eprintln!("rpg: pager error: {e}");
+            // Unsupported means no TTY available (piped/non-interactive).
+            // Fall back silently — no error message, just print.
+            if e.kind() != std::io::ErrorKind::Unsupported {
+                eprintln!("rpg: pager error: {e}");
+            }
             print!("{text}");
         }
         if let Some(ref sl) = settings.statusline {

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -112,7 +112,11 @@ fn maybe_page(settings: &mut crate::repl::ReplSettings, text: &str) {
                 let _ = std::io::stdout().write_all(text.as_bytes());
             }
         } else if let Err(e) = crate::pager::run_pager(text) {
-            eprintln!("rpg: pager error: {e}");
+            // Unsupported means no TTY available (piped/non-interactive).
+            // Fall back silently — no error message, just print.
+            if e.kind() != std::io::ErrorKind::Unsupported {
+                eprintln!("rpg: pager error: {e}");
+            }
             let _ = std::io::stdout().write_all(text.as_bytes());
         }
         if let Some(ref sl) = settings.statusline {

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -26,7 +26,7 @@
 //! A brief "Copied!" or "Copied N lines!" message appears in the status bar
 //! for 1 second after copying.
 
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::process::{Command, Stdio};
 
 use crossterm::{
@@ -146,7 +146,29 @@ impl Drop for TerminalGuard {
 /// returns when the user presses `q`, `Esc`, or `Ctrl-C`.
 ///
 /// Returns `Ok(())` on clean exit, or an error if terminal control fails.
+///
+/// Returns `Err` with kind `Unsupported` when stdin is not a terminal —
+/// callers should fall back to plain `print!` without logging an error in
+/// that case.
 pub fn run_pager(content: &str) -> io::Result<()> {
+    // crossterm's event reader (mio/kqueue) requires a real TTY file
+    // descriptor that was inherited as stdin (fd 0).  When stdin is a pipe
+    // or some other non-TTY, crossterm opens /dev/tty to get a new fd, but
+    // on macOS kqueue refuses to register that newly-opened fd with
+    // EVFILT_READ, returning EINVAL.  This causes UnixInternalEventSource
+    // to fail, leaving the global event reader with source=None, which
+    // subsequently reports "Failed to initialize input reader".
+    //
+    // The safest guard: require stdin to be a real TTY.  When it is not
+    // (piped / non-interactive / redirected), return Unsupported so callers
+    // can fall back to plain stdout output without printing a spurious error.
+    if !io::stdin().is_terminal() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "pager requires a TTY on stdin (non-interactive/piped mode)",
+        ));
+    }
+
     // Split content into owned lines so they outlive this function's scope.
     let lines: Vec<String> = content.lines().map(ToOwned::to_owned).collect();
 

--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -1332,7 +1332,11 @@ pub(super) fn run_pager_for_text(settings: &ReplSettings, text: &str, raw_bytes:
             let _ = io::stdout().write_all(raw_bytes);
         }
     } else if let Err(e) = crate::pager::run_pager(text) {
-        eprintln!("rpg: pager error: {e}");
+        // Unsupported means no TTY is available (e.g. piped / non-interactive
+        // mode).  Fall back silently — no error message, just print.
+        if e.kind() != io::ErrorKind::Unsupported {
+            eprintln!("rpg: pager error: {e}");
+        }
         let _ = io::stdout().write_all(raw_bytes);
     }
 }


### PR DESCRIPTION
## Summary

- Fixes "Failed to initialize input reader" when `\?` or other backslash commands trigger the built-in pager in non-interactive/piped mode
- Root cause: on macOS, crossterm's `mio`/`kqueue` event reader fails to register a newly-opened `/dev/tty` fd (`EVFILT_READ` returns `EINVAL`). This happens when stdin is a pipe and `tty_fd()` opens `/dev/tty` as a new fd instead of reusing the inherited stdin fd 0. The global `InternalEventReader` ends up with `source=None`, causing every subsequent `event::poll()` to return "Failed to initialize input reader".
- Fix: add an early stdin TTY check in `run_pager()` — return `Err(Unsupported)` immediately when stdin is not a terminal. All three call sites (`repl/execute.rs`, `dba.rs`, `describe.rs`) suppress the error print for `Unsupported` errors (expected in piped/non-interactive mode) and fall back to plain `print!`.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` — 1528 tests pass
- [x] `cargo fmt --check` passes
- [x] Verified no "pager error" in piped mode: `printf "\\\\?\n\\\\q\n" | rpg -d postgres 2>&1 | grep "pager error"` — empty
- [x] Verified help text still prints in piped mode: `printf "\\\\?\n\\\\q\n" | rpg -d postgres 2>&1 | grep "Backslash commands"` — found
- [x] Verified no "pager error" in PTY+piped-stdin mode: `script -q /dev/null sh -c 'printf "\\\\?\n\\\\q\n" | rpg -d postgres 2>&1' | grep "pager error"` — empty

Closes #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)