### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpg"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Modern Postgres terminal with built-in diagnostics and AI assistant"


### PR DESCRIPTION
Bump version from 0.5.0 to 0.6.0 in preparation for the v0.6.0 release.