### PR TITLE
fix(repl): display zero-column SELECT results

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -245,8 +245,11 @@ pub fn format_aligned(out: &mut String, rs: &RowSet, cfg: &OutputConfig) -> usiz
     let rows = &rs.rows;
 
     if cols.is_empty() {
-        // No columns: just print the row count footer (suppressed in tuples-only).
+        // Zero-column SELECT (e.g. `SELECT FROM t`): psql renders a bare
+        // `--` separator line in the header position followed by the row-count
+        // footer.  Tuples-only mode suppresses both.
         if !cfg.tuples_only {
+            out.push_str("--\n");
             write_row_count(out, rows.len());
         }
         return rows.len();
@@ -818,8 +821,14 @@ fn format_aligned_pset(out: &mut String, rs: &RowSet, _ocfg: &OutputConfig, pcfg
     let null_str = &pcfg.null_display;
 
     if cols.is_empty() {
-        if !pcfg.tuples_only && pcfg.footer {
-            write_row_count(out, rows.len());
+        // Zero-column SELECT (e.g. `SELECT FROM t`): psql renders a bare
+        // `--` separator line in the header position followed by the row-count
+        // footer.  Tuples-only mode suppresses both header and footer.
+        if !pcfg.tuples_only {
+            out.push_str("--\n");
+            if pcfg.footer {
+                write_row_count(out, rows.len());
+            }
         }
         return;
     }
@@ -1805,6 +1814,99 @@ mod tests {
         assert!(
             out.ends_with('\n'),
             "output should end with newline: {out:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Zero-column SELECT rendering (issue #643)
+    // -----------------------------------------------------------------------
+
+    /// `SELECT FROM t WHERE i = 10` returns rows with zero columns.
+    /// psql renders `--\n(1 row)\n` — we must match that.
+    #[test]
+    fn test_aligned_zero_columns_one_row() {
+        let rs = RowSet {
+            columns: vec![],
+            // One row with no cells — matches `SELECT FROM t WHERE i = 10`
+            // when exactly one row is found.
+            rows: vec![vec![]],
+        };
+        let mut out = String::new();
+        format_aligned_pset(
+            &mut out,
+            &rs,
+            &OutputConfig::default(),
+            &PsetConfig::default(),
+        );
+        assert!(
+            out.contains("--"),
+            "zero-col header separator missing: {out:?}"
+        );
+        assert!(out.contains("(1 row)"), "row-count footer missing: {out:?}");
+    }
+
+    #[test]
+    fn test_aligned_zero_columns_zero_rows() {
+        let rs = RowSet {
+            columns: vec![],
+            rows: vec![],
+        };
+        let mut out = String::new();
+        format_aligned_pset(
+            &mut out,
+            &rs,
+            &OutputConfig::default(),
+            &PsetConfig::default(),
+        );
+        assert!(
+            out.contains("--"),
+            "zero-col header separator missing: {out:?}"
+        );
+        assert!(
+            out.contains("(0 rows)"),
+            "row-count footer missing: {out:?}"
+        );
+    }
+
+    #[test]
+    fn test_aligned_zero_columns_many_rows() {
+        let rs = RowSet {
+            columns: vec![],
+            rows: vec![vec![]; 10],
+        };
+        let mut out = String::new();
+        format_aligned_pset(
+            &mut out,
+            &rs,
+            &OutputConfig::default(),
+            &PsetConfig::default(),
+        );
+        assert!(
+            out.contains("--"),
+            "zero-col header separator missing: {out:?}"
+        );
+        assert!(
+            out.contains("(10 rows)"),
+            "row-count footer missing: {out:?}"
+        );
+    }
+
+    #[test]
+    fn test_aligned_zero_columns_tuples_only_suppresses_all() {
+        let rs = RowSet {
+            columns: vec![],
+            rows: vec![vec![]; 3],
+        };
+        let cfg = PsetConfig {
+            tuples_only: true,
+            ..Default::default()
+        };
+        let mut out = String::new();
+        format_aligned_pset(&mut out, &rs, &OutputConfig::default(), &cfg);
+        // tuples-only suppresses both the `--` header and the row-count footer.
+        assert!(
+            out.is_empty(),
+            "tuples-only must produce no output: {out:?}"
         );
     }
 }

--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -33,13 +33,18 @@ pub(super) fn print_result_set_pset(
     use crate::output::format_rowset_pset;
     use crate::query::{ColumnMeta, RowSet};
 
-    if is_select && !col_names.is_empty() {
+    if is_select {
         // Heuristic: psql right-aligns numeric columns using type OIDs from
         // the wire protocol.  The simple query protocol does not expose OIDs,
         // so we infer numeric columns by inspecting cell values.  A column is
         // treated as numeric if every non-NULL, non-empty cell in that column
         // parses as an f64 (covers integers, decimals, and scientific notation).
         // Columns that are entirely NULL/empty are NOT marked numeric.
+        //
+        // Note: `col_names` may be empty for zero-column SELECTs such as
+        // `SELECT FROM t WHERE ...`.  These are valid PostgreSQL queries that
+        // return rows with no columns.  We must still render the row-count
+        // footer (e.g. `(1 row)`) to match psql behaviour.
         let columns: Vec<ColumnMeta> = col_names
             .iter()
             .enumerate()
@@ -1705,7 +1710,8 @@ pub(super) async fn describe_buffer(client: &Client, buf: &str, verbose_errors: 
 
 #[cfg(test)]
 mod tests {
-    use super::{is_no_tx_statement, needs_split_execution};
+    use super::{is_no_tx_statement, needs_split_execution, print_result_set_pset};
+    use crate::output::PsetConfig;
 
     // -- is_no_tx_statement ---------------------------------------------------
 
@@ -1886,5 +1892,87 @@ mod tests {
     #[test]
     fn split_not_needed_empty() {
         assert!(!needs_split_execution(""));
+    }
+
+    // -- print_result_set_pset — zero-column SELECT (issue #643) --------------
+
+    /// `SELECT FROM t WHERE i = 10` is valid SQL that returns 1 row with zero
+    /// columns.  Before the fix, `print_result_set_pset` skipped the display
+    /// block entirely, producing no output.  After the fix it must emit the
+    /// row-count footer to match psql.
+    #[test]
+    fn zero_col_select_one_row_shows_row_count() {
+        let mut buf: Vec<u8> = Vec::new();
+        print_result_set_pset(
+            &mut buf,
+            &[],       // zero column names
+            &[vec![]], // one row, no cells
+            true,      // is_select
+            1,         // rows_affected (not used for SELECT)
+            true,      // is_first
+            &PsetConfig::default(),
+        );
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("(1 row)"),
+            "zero-col SELECT must show row-count footer: {out:?}"
+        );
+    }
+
+    #[test]
+    fn zero_col_select_zero_rows_shows_row_count() {
+        let mut buf: Vec<u8> = Vec::new();
+        print_result_set_pset(
+            &mut buf,
+            &[], // zero column names
+            &[], // zero rows
+            true,
+            0,
+            true,
+            &PsetConfig::default(),
+        );
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("(0 rows)"),
+            "zero-col zero-row SELECT must show footer: {out:?}"
+        );
+    }
+
+    #[test]
+    fn zero_col_select_shows_separator() {
+        let mut buf: Vec<u8> = Vec::new();
+        print_result_set_pset(
+            &mut buf,
+            &[],
+            &[vec![]],
+            true,
+            1,
+            true,
+            &PsetConfig::default(),
+        );
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("--"),
+            "zero-col SELECT must show `--` separator: {out:?}"
+        );
+    }
+
+    #[test]
+    fn non_select_zero_rows_affected_produces_no_output() {
+        let mut buf: Vec<u8> = Vec::new();
+        print_result_set_pset(
+            &mut buf,
+            &[],
+            &[],
+            false, // not a SELECT
+            0,     // zero rows affected (e.g. UPDATE that matched nothing)
+            true,
+            &PsetConfig::default(),
+        );
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.is_empty(),
+            "non-SELECT with 0 rows affected must produce no output: {out:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #643: `select from t1 where i = 10;` produced no output
- Root cause: `print_result_set_pset` had `if is_select && !col_names.is_empty()` — the `!col_names.is_empty()` guard silently skipped the entire display block for zero-column SELECTs
- `SELECT FROM t` (without columns) is valid PostgreSQL — it returns rows with zero columns
- Fix: remove the guard so zero-column SELECTs flow through `format_rowset_pset` and render the row-count footer
- Also update `format_aligned_pset` and `format_aligned` to emit `--` before the row-count footer for zero-column results, matching psql behavior exactly
- Add 8 new unit tests covering zero-column SELECT rendering

## Test plan

- [x] `cargo test` — 1558 tests pass (8 new)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] tmux live test with real PostgreSQL:
  - `select from t1_test643 where i = 10;` → `--\n(2 rows)` (was: silent)
  - `select from t1_test643 where i = 999;` → `--\n(0 rows)` (was: silent)
  - `select * from t1_test643 where i = 10;` → still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)