### PR TITLE
fix(ai): strip trailing semicolon in is_write_query classification

### DIFF
--- a/src/repl/ai_commands.rs
+++ b/src/repl/ai_commands.rs
@@ -1446,6 +1446,8 @@ pub(super) fn is_write_query(sql: &str) -> bool {
         .split_whitespace()
         .next()
         .unwrap_or("")
+        .trim_end_matches(';')
+        .trim_end_matches(',')
         .to_ascii_uppercase();
     // WITH starts a CTE which may wrap DML (INSERT/UPDATE/DELETE/MERGE).
     // Treat all CTEs as potentially mutating to prevent silent auto-execution
@@ -2417,6 +2419,18 @@ mod tests {
         // Leading comments before SELECT must not flip the result.
         assert!(!is_write_query("-- read only\nSELECT 1;"));
         assert!(!is_write_query("/* read */\nselect * from t;"));
+    }
+
+    #[test]
+    fn is_write_trailing_semicolon_is_true() {
+        // A bare keyword followed immediately by a semicolon (no whitespace)
+        // must still be classified as a write query.
+        assert!(is_write_query("VACUUM;"));
+        assert!(is_write_query("vacuum;"));
+        assert!(is_write_query("DELETE;"));
+        assert!(is_write_query("delete;"));
+        assert!(is_write_query("CREATE;"));
+        assert!(is_write_query("create;"));
     }
 
     // -- parse_ai_response_segments + is_write_query: DDL detection ---------


### PR DESCRIPTION
## Summary

- `is_write_query("VACUUM;")` was returning `false` because `split_whitespace()` yields `"VACUUM;"` as a single token, which never matched `"VACUUM"` in the keyword list
- Strip trailing `';'` and `','` from the first token before matching — two chained `trim_end_matches` calls on the token extracted from `split_whitespace()`
- Added unit tests: `VACUUM;`, `DELETE;`, `CREATE;` (upper and lower case) all correctly return `true`

## Test plan

- [ ] `cargo test` — all 1551 tests pass including the new `is_write_trailing_semicolon_is_true` test
- [ ] `cargo fmt --check` — no formatting issues
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)