### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "rpg"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpg"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Modern Postgres terminal with built-in diagnostics and AI assistant"


### PR DESCRIPTION
## Summary

- Bump version in `Cargo.toml` and `Cargo.lock` from 0.6.0 to 0.7.0 in preparation for the v0.7.0 release

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` passes (1561 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)