### PR TITLE
fix(ci): fix codecov badge

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -233,5 +233,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary

- The codecov badge was showing "unknown" because the `CODECOV_TOKEN` secret was missing from the `codecov/codecov-action` upload step
- Without the token, Codecov rejects uploads silently (the step has `fail_ci_if_error: false`, so CI stayed green)
- Added `token: ${{ secrets.CODECOV_TOKEN }}` to authenticate the upload

## Root cause

The coverage job in `.github/workflows/checks.yml` generates `lcov.info` correctly via `cargo-llvm-cov`, but the subsequent upload step lacked authentication. Codecov v5+ requires a token for private repos and strongly recommends it for public repos to associate uploads correctly.

## Test plan

- [ ] CI passes (coverage job uploads successfully)
- [ ] Codecov badge on README shows a percentage instead of "unknown"
- [ ] Confirm `CODECOV_TOKEN` secret is set in repo Settings → Secrets → Actions

> Note: the `CODECOV_TOKEN` secret must be configured in the repository settings (Settings → Secrets and variables → Actions) for this to work. It can be obtained from the Codecov dashboard for NikolayS/rpg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)