### PR TITLE
feat(explain): add \explain share command for depesz and dalibo

### DIFF
--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -37,6 +37,7 @@
 
 pub mod issues;
 pub mod render;
+pub mod share;
 
 use std::fmt;
 

--- a/src/explain/share.rs
+++ b/src/explain/share.rs
@@ -1,0 +1,259 @@
+// Copyright 2026 Rpg contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Upload EXPLAIN plans to external visualiser services.
+//!
+//! Supports:
+//! - `explain.depesz.com` — classic Hubert Lubaczewski visualiser
+//! - `explain.dalibo.com`  — Dalibo's EXPLAIN visualiser
+//!
+//! After a successful upload the shareable URL is printed and copied to the
+//! system clipboard when a suitable clipboard tool is available.
+
+/// Upload `plan_text` to the chosen service and return the shareable URL.
+///
+/// `service` must be `"depesz"` or `"dalibo"` (case-insensitive).
+/// Returns an error string on failure.
+pub async fn share_explain_plan(plan_text: &str, service: &str) -> Result<String, String> {
+    match service {
+        "depesz" => upload_depesz(plan_text).await,
+        "dalibo" => upload_dalibo(plan_text).await,
+        other => Err(format!(
+            "unknown service \"{other}\"; valid options: depesz, dalibo"
+        )),
+    }
+}
+
+/// POST to explain.depesz.com and return the plan URL.
+///
+/// The service responds with a 302 redirect to the plan page.  `reqwest` with
+/// `redirect::Policy::none()` lets us capture the `Location` header directly
+/// instead of following the redirect (which would return HTML).
+async fn upload_depesz(plan_text: &str) -> Result<String, String> {
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+
+    let response = client
+        .post("https://explain.depesz.com/")
+        .form(&[
+            ("plan", plan_text),
+            ("title", "rpg"),
+            ("from_version", ""),
+            ("explain_format", "text"),
+        ])
+        .send()
+        .await
+        .map_err(|e| format!("request to explain.depesz.com failed: {e}"))?;
+
+    // depesz returns 302 on success with Location pointing to the plan.
+    let status = response.status();
+    if status.is_redirection() {
+        let location = response
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if location.is_empty() {
+            return Err("explain.depesz.com returned a redirect with no Location header".into());
+        }
+        // Location may be relative (e.g. "/s/abc123") — make it absolute.
+        let url = if location.starts_with("http") {
+            location.to_owned()
+        } else {
+            format!("https://explain.depesz.com{location}")
+        };
+        return Ok(url);
+    }
+
+    // Some versions return 200 with a body containing the URL.
+    if status.is_success() {
+        let body = response
+            .text()
+            .await
+            .map_err(|e| format!("failed to read explain.depesz.com response: {e}"))?;
+        // Try to extract the URL from the response body.
+        // depesz sometimes embeds the URL in the response HTML.
+        if let Some(url) = extract_depesz_url(&body) {
+            return Ok(url);
+        }
+        return Err(format!(
+            "explain.depesz.com returned status {status} \
+             but the URL could not be extracted from the response"
+        ));
+    }
+
+    Err(format!(
+        "explain.depesz.com returned unexpected status {status}"
+    ))
+}
+
+/// Extract the plan URL from a depesz response body.
+///
+/// depesz sometimes returns a 200 with the final URL embedded in the HTML or
+/// as a plain text response.  This is a best-effort extraction.
+fn extract_depesz_url(body: &str) -> Option<String> {
+    // Look for a pattern like `href="https://explain.depesz.com/s/..."`
+    // or a bare URL on its own line.
+    for line in body.lines() {
+        let line = line.trim();
+        if line.contains("explain.depesz.com/s/") {
+            // Try to find a URL-like token.
+            if let Some(start) = line.find("https://explain.depesz.com/s/") {
+                let rest = &line[start..];
+                let end = rest
+                    .find(|c: char| c == '"' || c == '\'' || c.is_whitespace())
+                    .unwrap_or(rest.len());
+                return Some(rest[..end].to_owned());
+            }
+        }
+    }
+    None
+}
+
+/// POST to explain.dalibo.com and return the plan URL.
+///
+/// Dalibo accepts a JSON body with `plan`, `query`, and `title` fields
+/// and responds with JSON containing the plan URL.
+async fn upload_dalibo(plan_text: &str) -> Result<String, String> {
+    let client = reqwest::Client::new();
+
+    let payload = serde_json::json!({
+        "plan": plan_text,
+        "title": "rpg",
+        "query": ""
+    });
+
+    let response = client
+        .post("https://explain.dalibo.com/new")
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| format!("request to explain.dalibo.com failed: {e}"))?;
+
+    let status = response.status();
+
+    // Dalibo may redirect to the plan page on success.
+    if status.is_redirection() {
+        let location = response
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if !location.is_empty() {
+            let url = if location.starts_with("http") {
+                location.to_owned()
+            } else {
+                format!("https://explain.dalibo.com{location}")
+            };
+            return Ok(url);
+        }
+    }
+
+    if !status.is_success() {
+        return Err(format!("explain.dalibo.com returned status {status}"));
+    }
+
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("failed to read explain.dalibo.com response: {e}"))?;
+
+    // Try to parse JSON response first.
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+        // Look for common URL fields in the JSON response.
+        for key in &["url", "permalink", "link", "id"] {
+            if let Some(val) = json.get(key).and_then(|v| v.as_str()) {
+                let url = if val.starts_with("http") {
+                    val.to_owned()
+                } else {
+                    format!("https://explain.dalibo.com/{val}")
+                };
+                return Ok(url);
+            }
+        }
+    }
+
+    // Fallback: try to extract a URL from the raw body text.
+    if let Some(url) = extract_dalibo_url(&body) {
+        return Ok(url);
+    }
+
+    Err(format!(
+        "explain.dalibo.com returned status {status} \
+         but the URL could not be extracted from the response"
+    ))
+}
+
+/// Extract the plan URL from a dalibo response body.
+fn extract_dalibo_url(body: &str) -> Option<String> {
+    for line in body.lines() {
+        let line = line.trim();
+        if line.contains("explain.dalibo.com/") {
+            if let Some(start) = line.find("https://explain.dalibo.com/") {
+                let rest = &line[start..];
+                let end = rest
+                    .find(|c: char| c == '"' || c == '\'' || c.is_whitespace())
+                    .unwrap_or(rest.len());
+                return Some(rest[..end].to_owned());
+            }
+        }
+    }
+    None
+}
+
+/// Copy `text` to the system clipboard.
+///
+/// Tries the following tools in order:
+/// - macOS: `pbcopy`
+/// - Linux (X11): `xclip -selection clipboard`
+/// - Linux (Wayland): `wl-clipboard` / `wl-copy`
+/// - Linux fallback: `xsel --clipboard --input`
+///
+/// Fails silently if no clipboard tool is available or the copy fails.
+pub fn copy_to_clipboard(text: &str) {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    #[cfg(target_os = "macos")]
+    let candidates: &[&[&str]] = &[&["pbcopy"]];
+
+    #[cfg(not(target_os = "macos"))]
+    let candidates: &[&[&str]] = &[
+        &["wl-copy"],
+        &["xclip", "-selection", "clipboard"],
+        &["xsel", "--clipboard", "--input"],
+    ];
+
+    for argv in candidates {
+        let (prog, args) = argv.split_first().unwrap();
+        let Ok(mut child) = Command::new(prog)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            continue;
+        };
+
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(text.as_bytes());
+        }
+        // Ignore wait errors — clipboard is best-effort.
+        let _ = child.wait();
+        return;
+    }
+}

--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -355,6 +355,14 @@ pub enum MetaCmd {
     /// Payload: the OID as a string.
     LoUnlink(String),
 
+    // -- Explain share (#655) ---------------------------------------------
+    /// `\explain share <service>` — upload the last EXPLAIN plan to an
+    /// external visualiser and print the resulting URL.
+    ///
+    /// `service` is either `"depesz"` (explain.depesz.com) or
+    /// `"dalibo"` (explain.dalibo.com).
+    ExplainShare(String),
+
     // -- Fallback ----------------------------------------------------------
     /// Unrecognised command; carries the original command token.
     Unknown(String),
@@ -1125,6 +1133,21 @@ fn split_lo_args(s: &str) -> (String, String) {
 ///
 /// Longer prefixes are checked first to avoid false prefix matches.
 fn parse_e_family(input: &str) -> ParsedMeta {
+    // `\explain share <service>` — upload last EXPLAIN plan to a visualiser.
+    // Must be checked before bare `\e` (longer prefix first).
+    if let Some(rest) = input.strip_prefix("explain") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            let args = rest.trim();
+            // `\explain share depesz` / `\explain share dalibo`
+            if let Some(share_rest) = args.strip_prefix("share") {
+                let service = share_rest.trim().to_lowercase();
+                return ParsedMeta::simple(MetaCmd::ExplainShare(service));
+            }
+            // Bare `\explain` or unknown sub-command — fall through to Unknown.
+            return ParsedMeta::simple(MetaCmd::Unknown(input.to_owned()));
+        }
+    }
+
     // `\endif` — no argument.
     if let Some(rest) = input.strip_prefix("endif") {
         if rest.is_empty() || rest.starts_with(char::is_whitespace) {
@@ -3617,5 +3640,46 @@ mod tests {
     fn parse_lo_commands_not_confused_with_list_databases() {
         // `\l` must still work after `\lo_*` is added.
         assert_eq!(parse("\\l").cmd, MetaCmd::ListDatabases);
+    }
+
+    // -- \explain share (#655) -----------------------------------------------
+
+    #[test]
+    fn parse_explain_share_depesz() {
+        let m = parse("\\explain share depesz");
+        assert_eq!(m.cmd, MetaCmd::ExplainShare("depesz".to_owned()));
+    }
+
+    #[test]
+    fn parse_explain_share_dalibo() {
+        let m = parse("\\explain share dalibo");
+        assert_eq!(m.cmd, MetaCmd::ExplainShare("dalibo".to_owned()));
+    }
+
+    #[test]
+    fn parse_explain_share_normalises_case() {
+        // Service name is lowercased by the parser.
+        let m = parse("\\explain share DEPESZ");
+        assert_eq!(m.cmd, MetaCmd::ExplainShare("depesz".to_owned()));
+    }
+
+    #[test]
+    fn parse_explain_bare_is_unknown() {
+        // `\explain` with no subcommand is Unknown (no sub-command given).
+        assert!(matches!(parse("\\explain").cmd, MetaCmd::Unknown(_)));
+    }
+
+    #[test]
+    fn parse_explain_share_not_confused_with_echo() {
+        // `\echo` must still parse correctly.
+        let m = parse("\\echo hello");
+        assert_eq!(m.cmd, MetaCmd::Echo);
+    }
+
+    #[test]
+    fn parse_explain_share_not_confused_with_encoding() {
+        // `\encoding` must still parse correctly.
+        let m = parse("\\encoding UTF8");
+        assert_eq!(m.cmd, MetaCmd::Encoding);
     }
 }

--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -209,6 +209,8 @@ pub async fn execute_query(
 
     // Capture auto-EXPLAIN plan text for optional AI interpretation.
     let mut auto_explain_plan: Option<String> = None;
+    // Whether the original SQL is a manual EXPLAIN statement (not auto-explain).
+    let is_manual_explain = is_explain_statement(sql_to_send) && !auto_explain_active;
 
     let success = match client.simple_query(sql_to_send).await {
         Ok(messages) => {
@@ -251,7 +253,7 @@ pub async fn execute_query(
                     SimpleQueryMessage::CommandComplete(n) => {
                         // Capture plan text from auto-EXPLAIN before clearing
                         // rows. EXPLAIN output is a single-column result set.
-                        if auto_explain_active && result_set_index == 0 {
+                        if (auto_explain_active || is_manual_explain) && result_set_index == 0 {
                             let plan_text: String = rows
                                 .iter()
                                 .filter_map(|r| {
@@ -260,7 +262,11 @@ pub async fn execute_query(
                                 .collect::<Vec<_>>()
                                 .join("\n");
                             if !plan_text.is_empty() {
-                                auto_explain_plan = Some(plan_text);
+                                if auto_explain_active {
+                                    auto_explain_plan = Some(plan_text.clone());
+                                }
+                                // Store for `\explain share` regardless of mode.
+                                settings.last_explain_text = Some(plan_text);
                             }
                         }
 
@@ -1011,6 +1017,8 @@ pub(super) async fn execute_query_interactive(
         && explain_format != crate::explain::ExplainFormat::Raw
     {
         let raw_text = String::from_utf8_lossy(&captured);
+        // Store the stripped plain-text EXPLAIN output for `\explain share`.
+        settings.last_explain_text = Some(strip_psql_table_format(&raw_text));
         if let Some(rendered) = try_render_explain(&raw_text, explain_format) {
             enhanced = rendered;
             display = std::borrow::Cow::Borrowed(b"");
@@ -1020,6 +1028,13 @@ pub(super) async fn execute_query_interactive(
             let s = std::str::from_utf8(&captured).unwrap_or("");
             (s, captured.as_slice())
         }
+    } else if ok && is_explain_statement(sql) {
+        // Raw format: still store the stripped text for `\explain share`.
+        let raw_text = String::from_utf8_lossy(&captured);
+        settings.last_explain_text = Some(strip_psql_table_format(&raw_text));
+        display = std::borrow::Cow::Borrowed(captured.as_slice());
+        let s = std::str::from_utf8(&captured).unwrap_or("");
+        (s, captured.as_slice())
     } else {
         display = std::borrow::Cow::Borrowed(captured.as_slice());
         let s = std::str::from_utf8(&captured).unwrap_or("");

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1050,6 +1050,12 @@ pub struct ReplSettings {
     /// `/ask` transaction (which SHOULD be rolled back if it leaks into the
     /// next command due to an error or interruption).
     pub internal_tx: bool,
+    /// Raw text of the last EXPLAIN output (plain text format).
+    ///
+    /// Populated whenever an EXPLAIN query succeeds, so that
+    /// `\explain share` can upload it to explain.depesz.com or
+    /// explain.dalibo.com.  `None` if no EXPLAIN has been run yet.
+    pub last_explain_text: Option<String>,
 }
 
 impl std::fmt::Debug for ReplSettings {
@@ -1152,6 +1158,10 @@ impl std::fmt::Debug for ReplSettings {
                 &self.last_t2s_nl_query.as_deref().map(|_| "<nl-query>"),
             )
             .field("internal_tx", &self.internal_tx)
+            .field(
+                "last_explain_text",
+                &self.last_explain_text.as_deref().map(|_| "<explain>"),
+            )
             .finish()
     }
 }
@@ -1217,6 +1227,7 @@ impl Default for ReplSettings {
             prompt_interrupted: false,
             last_t2s_nl_query: None,
             internal_tx: false,
+            last_explain_text: None,
         }
     }
 }
@@ -1726,6 +1737,10 @@ Auto-EXPLAIN:
   \\set EXPLAIN analyze  show EXPLAIN ANALYZE for every query
   \\set EXPLAIN verbose  show EXPLAIN (ANALYZE, VERBOSE, BUFFERS, TIMING)
   \\set EXPLAIN off      disable auto-EXPLAIN
+
+EXPLAIN sharing:
+  \\explain share depesz  upload last EXPLAIN plan to explain.depesz.com
+  \\explain share dalibo   upload last EXPLAIN plan to explain.dalibo.com
 
 Function keys (interactive mode):
   F2 / \\f2       toggle schema-aware tab completion on/off
@@ -3471,6 +3486,10 @@ async fn dispatch_meta(
                 return result;
             }
         }
+        // Explain share (#655).
+        MetaCmd::ExplainShare(ref service) => {
+            dispatch_explain_share(settings, service).await;
+        }
         // Large object commands (#400).
         MetaCmd::LoImport(ref filename, ref comment) => {
             let filename = filename.clone();
@@ -3495,6 +3514,49 @@ async fn dispatch_meta(
     }
 
     MetaResult::Continue
+}
+
+// ---------------------------------------------------------------------------
+// Explain share helper (#655)
+// ---------------------------------------------------------------------------
+
+/// Handle `\explain share <service>`.
+///
+/// Uploads the last stored EXPLAIN plan to the chosen external visualiser,
+/// prints the resulting URL, and copies it to the system clipboard.
+async fn dispatch_explain_share(settings: &mut ReplSettings, service: &str) {
+    let plan_text = match settings.last_explain_text.as_deref() {
+        Some(t) if !t.is_empty() => t.to_owned(),
+        _ => {
+            eprintln!(
+                "\\explain share: no EXPLAIN plan available.\n\
+                 Run an EXPLAIN query first, then use \\explain share."
+            );
+            return;
+        }
+    };
+
+    if service.is_empty() {
+        eprintln!(
+            "\\explain share: service name required.\n\
+             Usage: \\explain share depesz\n\
+             Usage: \\explain share dalibo"
+        );
+        return;
+    }
+
+    println!("Uploading EXPLAIN plan to {service}…");
+
+    match crate::explain::share::share_explain_plan(&plan_text, service).await {
+        Ok(url) => {
+            println!("Plan URL: {url}");
+            crate::explain::share::copy_to_clipboard(&url);
+            println!("(URL copied to clipboard)");
+        }
+        Err(e) => {
+            eprintln!("\\explain share: {e}");
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #655

## Summary

- Stores the raw text of the last EXPLAIN output in `ReplSettings.last_explain_text` — populated whenever an EXPLAIN query succeeds (both manual EXPLAIN and auto-explain paths)
- New `\explain share depesz` / `\explain share dalibo` meta-commands that POST the stored plan to the selected visualiser and print the shareable URL
- Clipboard support: after printing the URL, tries `pbcopy` (macOS), `wl-copy`, `xclip`, `xsel` in order and copies the URL silently (fails silently if no clipboard tool is available)
- New `src/explain/share.rs` module with the HTTP upload logic using `reqwest` (already a dependency)
- `explain.depesz.com`: POSTs form data, captures the `Location` header from the 302 redirect
- `explain.dalibo.com`: POSTs JSON `{"plan":…,"title":"rpg","query":""}`, captures the `Location` header from the 302 redirect
- Parser: `MetaCmd::ExplainShare(service)` variant; service name is lowercased, so `\explain share DEPESZ` works too
- Help text updated with EXPLAIN sharing section
- 6 new parser unit tests; all 1644 tests pass

## Test plan

- [x] `cargo build` — clean compile
- [x] `cargo test` — 1644 passed (6 new)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Live HTTP POST to `explain.depesz.com` verified via curl: returns `302` with `location: /s/a9w5`
- [x] Live HTTP POST to `explain.dalibo.com` verified via curl: returns `302` with `location: /plan/8069ggbed15gb6d6`
- [ ] Interactive test: run EXPLAIN query, then `\explain share depesz` — prints URL + copies to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)