### PR TITLE
fix(explain): show full plan details, fix infx, preserve buffer data

### DIFF
--- a/src/explain/issues.rs
+++ b/src/explain/issues.rs
@@ -188,10 +188,11 @@ pub fn check_seq_scan_large(node: &ExplainNode) -> Option<PlanIssue> {
 ///
 /// Fires when the ratio `actual_rows / estimated_rows` is outside
 /// `[0.1, 10.0]` (i.e. the planner is off by more than 10x in either
-/// direction).  Nodes with `estimated_rows == 0` are skipped to avoid
-/// division by zero.
+/// direction).  Nodes with `estimated_rows == 0` or `actual_rows == 0`
+/// are skipped to avoid division by zero (the latter also covers plain
+/// EXPLAIN without ANALYZE, where no actual rows are available).
 pub fn check_row_estimate_error(node: &ExplainNode) -> Option<PlanIssue> {
-    if node.estimated_rows <= 0.0 {
+    if node.estimated_rows <= 0.0 || node.actual_rows <= 0.0 {
         return None;
     }
 
@@ -587,6 +588,18 @@ mod tests {
             ..Default::default()
         };
         // Must not panic; should return None.
+        assert!(check_row_estimate_error(&node).is_none());
+    }
+
+    #[test]
+    fn row_estimate_zero_actual_no_crash() {
+        // Covers plain EXPLAIN without ANALYZE (actual_rows stays 0.0).
+        // Must not produce "inf" or panic.
+        let node = ExplainNode {
+            estimated_rows: 1_000.0,
+            actual_rows: 0.0,
+            ..Default::default()
+        };
         assert!(check_row_estimate_error(&node).is_none());
     }
 

--- a/src/explain/render.rs
+++ b/src/explain/render.rs
@@ -476,6 +476,82 @@ fn build_prefix(stack: &[bool], is_last: bool) -> String {
     s
 }
 
+/// Build the gutter prefix for detail lines rendered below a node line.
+///
+/// Detail lines (filter, buffers, sort) are indented to align under the node
+/// content, matching the tree gutter continuation columns.
+fn build_detail_indent(prefix_stack: &[bool], is_last: bool, is_root: bool) -> String {
+    if is_root {
+        return "  ".to_owned();
+    }
+    let mut s = String::new();
+    for &was_last in prefix_stack {
+        if was_last {
+            s.push_str("   ");
+        } else {
+            s.push_str("│  ");
+        }
+    }
+    // Continuation column for the current node.
+    if is_last {
+        s.push_str("   ");
+    } else {
+        s.push_str("│  ");
+    }
+    // Extra indent so content aligns inside the node, not at the gutter edge.
+    s.push_str("  ");
+    s
+}
+
+/// Render per-node detail lines (filter, buffers, sort) below the main node line.
+///
+/// `detail_indent` is the gutter prefix that aligns detail content under the node.
+fn render_node_details(node: &ExplainNode, detail_indent: &str, out: &mut String) {
+    // Filter condition.
+    if let Some(filter) = &node.filter {
+        writeln!(out, "{detail_indent}{DIM}Filter: {filter}{RESET}").ok();
+    }
+
+    // Rows removed by filter.
+    if let Some(removed) = node.rows_removed_by_filter {
+        if removed > 0 {
+            writeln!(
+                out,
+                "{detail_indent}{DIM}Rows removed by filter: {}{RESET}",
+                fmt_int(removed)
+            )
+            .ok();
+        }
+    }
+
+    // Buffer info per node (shared hit / read).
+    if node.shared_hit > 0 || node.shared_read > 0 {
+        let mut buf = format!(
+            "{detail_indent}{DIM}Buffers: {} hit",
+            fmt_int(node.shared_hit)
+        );
+        if node.shared_read > 0 {
+            write!(buf, ", {} read", fmt_int(node.shared_read)).ok();
+        }
+        write!(buf, "{RESET}").ok();
+        out.push_str(&buf);
+        out.push('\n');
+    }
+
+    // Sort method and space.
+    if let Some(method) = &node.sort_method {
+        if let Some(space) = &node.sort_space {
+            writeln!(
+                out,
+                "{detail_indent}{DIM}Sort Method: {method}  {space}{RESET}"
+            )
+            .ok();
+        } else {
+            writeln!(out, "{detail_indent}{DIM}Sort Method: {method}{RESET}").ok();
+        }
+    }
+}
+
 /// Render a single node line and recurse into children.
 fn render_node(
     node: &ExplainNode,
@@ -561,6 +637,11 @@ fn render_node(
 
     out.push_str(&line);
     out.push('\n');
+
+    // Render per-node detail lines: filter, buffers, sort.
+    // Indent is the tree gutter prefix for detail content under this node.
+    let detail_indent = build_detail_indent(&state.prefix_stack, is_last, is_root);
+    render_node_details(node, &detail_indent, out);
 
     // Render children recursively.
     let n = node.children.len();


### PR DESCRIPTION
## Summary

- **Bug 1 (plan details stripped)**: Added `build_detail_indent` and `render_node_details` helpers to `render.rs`. Filter conditions, rows-removed-by-filter, sort method/space, and per-node buffer info are now rendered below each node line in the tree view.
- **Bug 2 (infx / division by zero)**: `check_row_estimate_error` in `issues.rs` now guards `actual_rows <= 0.0` in addition to `estimated_rows <= 0.0`. This prevents `1.0 / ratio` from producing `inf` when a plain EXPLAIN (no ANALYZE) runs and `actual_rows` stays at 0. Added a test for this case.
- **Bug 3 (buffer data per node missing)**: The new `render_node_details` function renders `Buffers: N hit, N read` for each node that has non-zero buffer counters, in addition to the existing summary-header totals.
- **Bug 4 (raw toggle)**: Confirmed working — `try_render_explain` already returns `None` for `ExplainFormat::Raw` and `execute_query_interactive` falls through to raw passthrough. Tested with `\pset explain_format raw` producing psql-identical output.

## Test plan

- [x] `cargo test` — 1645 tests pass
- [x] `cargo fmt --check` — no formatting issues
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] tmux test: `explain select * from orders where status = 'pending' limit 10;` — shows Filter detail, no infx
- [x] tmux test: `explain analyze ...` — shows Filter, Rows removed by filter, Buffers per node
- [x] tmux test: `explain (analyze, buffers) ... join ...` — buffer info shown per node
- [x] tmux test: `\pset explain_format raw` → raw psql output; `\pset explain_format enhanced` → enhanced back

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)