### PR TITLE
fix(ci): use macos-14 for x86_64-apple-darwin in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,9 @@ jobs:
             use_cross: true
             artifact: rpg-linux-aarch64
           # macOS (native runners)
+          # x86_64 cross-compiled on aarch64 runner (macos-13 deprecated)
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
             use_cross: false
             artifact: rpg-darwin-x86_64
           - target: aarch64-apple-darwin


### PR DESCRIPTION
Cherry-pick of #649 by @gurukulkarni — needed because fork PRs can't pass required status checks.

`macos-13` was removed by GitHub on 2025-12-08, breaking x86_64 macOS builds for releases v0.4.0–v0.7.0.

Closes #649

Co-Authored-By: gurukulkarni