### PR TITLE
Add Lua scripting engine for user-defined meta commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1064,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -2073,6 +2089,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lua-src"
+version = "547.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.5.12+a4f56a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,6 +2180,34 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mlua"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0"
+dependencies = [
+ "bstr",
+ "either",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "rustversion",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2631,6 +2694,12 @@ dependencies = [
  "der 0.8.0",
  "spki 0.8.0-rc.4",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -3186,6 +3255,7 @@ dependencies = [
  "dirs",
  "futures",
  "libc",
+ "mlua",
  "ratatui",
  "reqwest",
  "ring",
@@ -4690,6 +4760,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5016,6 +5098,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/NikolayS/project-alpha"
 
 [features]
 integration = []
+lua = ["dep:mlua"]
 
 [profile.release]
 strip = true
@@ -42,6 +43,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signa
 tokio-postgres = "0.7"
 tokio-rustls = { version = "0.26", default-features = false }
 x509-certificate = { version = "0.23", default-features = false }
+mlua = { version = "0.10", features = ["lua54", "send", "vendored"], optional = true }
 unicode-width = "0.2"
 webpki-roots = "0.26"
 

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1021,6 +1021,9 @@ pub struct RpgHelper {
     cache: Arc<RwLock<SchemaCache>>,
     /// Whether syntax highlighting is active.
     highlight: bool,
+    /// Lua engine handle for completing Lua-registered command names.
+    #[cfg(feature = "lua")]
+    lua_engine: Option<std::sync::Arc<std::sync::Mutex<crate::lua_engine::LuaEngine>>>,
     /// Current input mode — SQL highlighting is suppressed in `Text2Sql` mode
     /// because the user is typing natural language, not SQL.
     input_mode: crate::repl::InputMode,
@@ -1059,12 +1062,23 @@ impl RpgHelper {
         Self {
             cache,
             highlight,
+            #[cfg(feature = "lua")]
+            lua_engine: None,
             input_mode: crate::repl::InputMode::Sql,
             completion_enabled: true,
             dropdown_completion_enabled: false,
             dropdown: Arc::new(Mutex::new(DropdownState::default())),
             prompt_width: 0,
         }
+    }
+
+    /// Set the Lua engine handle for tab completion of Lua commands.
+    #[cfg(feature = "lua")]
+    pub fn set_lua_engine(
+        &mut self,
+        engine: std::sync::Arc<std::sync::Mutex<crate::lua_engine::LuaEngine>>,
+    ) {
+        self.lua_engine = Some(engine);
     }
 
     /// Return a clone of the shared dropdown state handle.
@@ -1217,12 +1231,40 @@ impl Completer for RpgHelper {
                 .filter_map(|d| fuzzy_match(&completion_prefix, d).map(|s| (d.clone(), s)))
                 .collect(),
 
-            CompletionContext::BackslashCmd => BACKSLASH_CMDS
-                .iter()
-                .filter_map(|cmd| {
-                    fuzzy_match(&completion_prefix, cmd).map(|s| ((*cmd).to_owned(), s))
-                })
-                .collect(),
+            CompletionContext::BackslashCmd => {
+                #[allow(unused_mut)]
+                let mut cands: Vec<(String, i32)> = BACKSLASH_CMDS
+                    .iter()
+                    .filter_map(|cmd| {
+                        fuzzy_match(&completion_prefix, cmd).map(|s| ((*cmd).to_owned(), s))
+                    })
+                    .collect();
+
+                // Append Lua-registered custom commands when available.
+                #[cfg(feature = "lua")]
+                if let Some(ref engine) = self.lua_engine {
+                    if let Ok(guard) = engine.lock() {
+                        for name in guard.command_names() {
+                            if let Some(score) = fuzzy_match(&completion_prefix, &name) {
+                                cands.push((name, score));
+                            }
+                        }
+                    }
+                }
+
+                // Also add the built-in lua commands when the feature is
+                // enabled.
+                #[cfg(feature = "lua")]
+                {
+                    for extra in &["lua", "luafile"] {
+                        if let Some(score) = fuzzy_match(&completion_prefix, extra) {
+                            cands.push(((*extra).to_owned(), score));
+                        }
+                    }
+                }
+
+                cands
+            }
 
             // FileName: delegate to the OS (no DB lookup needed).  For now we
             // return nothing and let the user type the path manually.

--- a/src/lua_engine.rs
+++ b/src/lua_engine.rs
@@ -1,0 +1,281 @@
+// Copyright 2026 Rpg Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lua scripting engine for user-defined meta commands.
+//!
+//! Provides [`LuaEngine`] which initialises a Lua 5.4 VM, exposes a small
+//! `rpg` API table, and lets users register custom backslash commands from
+//! Lua scripts.  Scripts are loaded automatically from:
+//!
+//! - `~/.config/rpg/lua/*.lua`
+//! - `.rpg/lua/*.lua` (project-local)
+//!
+//! Custom commands registered via `rpg.register_command(name, desc, callback)`
+//! are dispatched by the REPL when the user types `\<name>`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use mlua::{Function, Lua, RegistryKey, Result as LuaResult};
+
+/// A user-registered Lua command.
+#[allow(dead_code)]
+pub struct LuaCommand {
+    /// Command name (without the leading `\`).
+    pub name: String,
+    /// Short description shown in help output.
+    pub description: String,
+    /// Registry key for the Lua callback function.
+    pub callback_key: RegistryKey,
+}
+
+/// Lua scripting runtime.
+///
+/// Holds the Lua VM and a registry of user-defined commands.  The engine is
+/// designed to be stored behind `Arc<Mutex<..>>` so it can be accessed from
+/// both the REPL dispatch path and tab completion.
+pub struct LuaEngine {
+    lua: Lua,
+    commands: HashMap<String, LuaCommand>,
+    /// Accumulated output from `rpg.print()` calls during a callback.
+    output_buffer: Vec<String>,
+}
+
+impl LuaEngine {
+    /// Create a new engine and expose the `rpg` API table.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Lua VM cannot be initialised or if registering
+    /// the API table fails.
+    pub fn new() -> LuaResult<Self> {
+        let lua = Lua::new();
+
+        // Open standard libraries (string, table, math, etc.).
+        // `Lua::new()` already loads the standard libraries by default.
+
+        // Create the `rpg` API table.
+        {
+            let rpg = lua.create_table()?;
+
+            // rpg.print(text) — buffer text for later display.
+            let print_fn = lua.create_function(|lua_ctx, text: String| {
+                // Store into the registry under a well-known key.
+                let tbl: mlua::Table = lua_ctx.named_registry_value("_rpg_output")?;
+                let len = tbl.raw_len();
+                tbl.raw_set(len + 1, text)?;
+                Ok(())
+            })?;
+            rpg.set("print", print_fn)?;
+
+            // rpg.register_command(name, description, callback) — register a
+            // custom backslash command.  The actual insertion into
+            // `self.commands` happens in `load_script` after the chunk runs.
+            // Here we just store pending registrations in a registry table.
+            let register_fn =
+                lua.create_function(|lua_ctx, (name, desc, cb): (String, String, Function)| {
+                    let tbl: mlua::Table = lua_ctx.named_registry_value("_rpg_pending_cmds")?;
+                    let entry = lua_ctx.create_table()?;
+                    entry.set("name", name)?;
+                    entry.set("desc", desc)?;
+                    entry.set("cb", cb)?;
+                    let len = tbl.raw_len();
+                    tbl.raw_set(len + 1, entry)?;
+                    Ok(())
+                })?;
+            rpg.set("register_command", register_fn)?;
+
+            lua.globals().set("rpg", rpg)?;
+        }
+
+        // Initialise registry tables.
+        let output_tbl = lua.create_table()?;
+        lua.set_named_registry_value("_rpg_output", output_tbl)?;
+
+        let pending_cmds = lua.create_table()?;
+        lua.set_named_registry_value("_rpg_pending_cmds", pending_cmds)?;
+
+        Ok(Self {
+            lua,
+            commands: HashMap::new(),
+            output_buffer: Vec::new(),
+        })
+    }
+
+    /// Load and execute a single Lua script file.
+    ///
+    /// Any commands registered via `rpg.register_command()` during execution
+    /// are harvested and added to the command registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or contains Lua syntax
+    /// errors.
+    pub fn load_script(&mut self, path: &Path) -> LuaResult<()> {
+        let source = std::fs::read_to_string(path).map_err(mlua::Error::external)?;
+        let chunk_name = path.display().to_string();
+
+        // Clear pending commands table before running.
+        let fresh = self.lua.create_table()?;
+        self.lua
+            .set_named_registry_value("_rpg_pending_cmds", fresh)?;
+
+        // Execute the script.
+        self.lua.load(&source).set_name(&chunk_name).exec()?;
+
+        // Harvest pending command registrations.
+        let pending: mlua::Table = self.lua.named_registry_value("_rpg_pending_cmds")?;
+        for pair in pending.sequence_values::<mlua::Table>() {
+            let entry = pair?;
+            let name: String = entry.get("name")?;
+            let desc: String = entry.get("desc")?;
+            let cb: Function = entry.get("cb")?;
+            let key = self.lua.create_registry_value(cb)?;
+            self.commands.insert(
+                name.clone(),
+                LuaCommand {
+                    name,
+                    description: desc,
+                    callback_key: key,
+                },
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Load all `*.lua` files from the standard directories.
+    ///
+    /// Directories that do not exist are silently skipped.  Errors in
+    /// individual scripts are printed to stderr but do not prevent other
+    /// scripts from loading.
+    pub fn load_user_scripts(&mut self) {
+        let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+
+        // ~/.config/rpg/lua/
+        if let Some(config_dir) = dirs::config_dir() {
+            dirs.push(config_dir.join("rpg").join("lua"));
+        }
+
+        // .rpg/lua/ (project-local)
+        dirs.push(std::path::PathBuf::from(".rpg/lua"));
+
+        for dir in &dirs {
+            if !dir.is_dir() {
+                continue;
+            }
+            let entries = match std::fs::read_dir(dir) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let mut paths: Vec<std::path::PathBuf> = entries
+                .filter_map(Result::ok)
+                .map(|e| e.path())
+                .filter(|p| p.extension().is_some_and(|ext| ext == "lua"))
+                .collect();
+            paths.sort();
+
+            for path in paths {
+                if let Err(e) = self.load_script(&path) {
+                    eprintln!("rpg: lua: error loading {}: {e}", path.display());
+                }
+            }
+        }
+    }
+
+    /// Execute an inline Lua string (from `\lua <code>`).
+    ///
+    /// Returns any text buffered via `rpg.print()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a Lua error if the code is invalid.
+    pub fn exec_inline(&mut self, code: &str) -> LuaResult<Vec<String>> {
+        self.clear_output_buffer()?;
+        self.lua.load(code).set_name("\\lua").exec()?;
+        self.drain_output_buffer()
+    }
+
+    /// Execute a Lua script file (from `\luafile <path>`).
+    ///
+    /// Returns any text buffered via `rpg.print()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a Lua error if the file cannot be read or contains errors.
+    pub fn exec_file(&mut self, path: &str) -> LuaResult<Vec<String>> {
+        let source = std::fs::read_to_string(path).map_err(mlua::Error::external)?;
+        self.clear_output_buffer()?;
+        self.lua.load(&source).set_name(path).exec()?;
+        self.drain_output_buffer()
+    }
+
+    /// Invoke a registered custom command callback.
+    ///
+    /// `args` is the raw argument string passed after the command name.
+    /// Returns `(output_lines, optional_sql)` — the callback may return a
+    /// SQL string to be executed by the REPL.
+    ///
+    /// # Errors
+    ///
+    /// Returns a Lua error if the callback fails.
+    pub fn call_command(&mut self, name: &str, args: &str) -> LuaResult<(Vec<String>, Option<String>)> {
+        let cmd = self
+            .commands
+            .get(name)
+            .ok_or_else(|| mlua::Error::external(format!("unknown lua command: {name}")))?;
+
+        let cb: Function = self.lua.registry_value(&cmd.callback_key)?;
+        self.clear_output_buffer()?;
+
+        let result: mlua::Value = cb.call(args.to_owned())?;
+
+        let sql = match result {
+            mlua::Value::String(s) => Some(s.to_str()?.to_owned()),
+            _ => None,
+        };
+
+        let output = self.drain_output_buffer()?;
+        Ok((output, sql))
+    }
+
+    /// Check whether a command name is registered.
+    #[allow(dead_code)]
+    pub fn has_command(&self, name: &str) -> bool {
+        self.commands.contains_key(name)
+    }
+
+    /// Return the names of all registered custom commands.
+    pub fn command_names(&self) -> Vec<String> {
+        self.commands.keys().cloned().collect()
+    }
+
+    /// Return a reference to the commands map.
+    #[allow(dead_code)]
+    pub fn commands(&self) -> &HashMap<String, LuaCommand> {
+        &self.commands
+    }
+
+    // -- Internal helpers ---------------------------------------------------
+
+    fn clear_output_buffer(&mut self) -> LuaResult<()> {
+        self.output_buffer.clear();
+        let fresh = self.lua.create_table()?;
+        self.lua
+            .set_named_registry_value("_rpg_output", fresh)?;
+        Ok(())
+    }
+
+    fn drain_output_buffer(&mut self) -> LuaResult<Vec<String>> {
+        let tbl: mlua::Table = self.lua.named_registry_value("_rpg_output")?;
+        let mut lines = Vec::new();
+        for v in tbl.sequence_values::<String>() {
+            lines.push(v?);
+        }
+        // Clear for next call.
+        let fresh = self.lua.create_table()?;
+        self.lua
+            .set_named_registry_value("_rpg_output", fresh)?;
+        Ok(lines)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,8 @@ mod init;
 mod io;
 mod large_object;
 mod logging;
+#[cfg(feature = "lua")]
+mod lua_engine;
 mod markdown;
 mod metacmd;
 mod named;

--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -355,6 +355,17 @@ pub enum MetaCmd {
     /// Payload: the OID as a string.
     LoUnlink(String),
 
+    // -- Lua scripting (#659) -----------------------------------------------
+    /// `\lua <code>` — execute inline Lua code.
+    #[cfg(feature = "lua")]
+    Lua,
+    /// `\luafile <path>` — execute a Lua script file.
+    #[cfg(feature = "lua")]
+    LuaFile,
+    /// A Lua-registered custom command: `\<name> [args]`.
+    #[cfg(feature = "lua")]
+    LuaCustom(String),
+
     // -- Fallback ----------------------------------------------------------
     /// Unrecognised command; carries the original command token.
     Unknown(String),
@@ -448,6 +459,27 @@ impl ParsedMeta {
             system: false,
             pattern: None,
             echo_hidden: false,
+        }
+    }
+
+    /// If this is an `Unknown` command whose name matches a Lua-registered
+    /// custom command, reclassify it as `LuaCustom`.
+    ///
+    /// `lua_names` should be the set of registered Lua command names.
+    #[cfg(feature = "lua")]
+    pub fn reclassify_lua(&mut self, lua_names: &std::collections::HashSet<String>) {
+        if let MetaCmd::Unknown(ref raw) = self.cmd {
+            // `raw` is e.g. `"mycmd some args"`.  Extract the command token.
+            let token = raw.split_whitespace().next().unwrap_or(raw);
+            if lua_names.contains(token) {
+                let args = raw[token.len()..].trim_start();
+                self.pattern = if args.is_empty() {
+                    None
+                } else {
+                    Some(args.to_owned())
+                };
+                self.cmd = MetaCmd::LuaCustom(token.to_owned());
+            }
         }
     }
 }
@@ -1010,6 +1042,44 @@ fn parse_l(input: &str) -> ParsedMeta {
     // `\log-file` and bare `\l` (longest prefix first).
     if let Some(rest) = input.strip_prefix("lo_") {
         return parse_lo_family(rest);
+    }
+
+    // `\luafile <path>` — must be checked before `\lua` (longer prefix).
+    #[cfg(feature = "lua")]
+    if let Some(rest) = input.strip_prefix("luafile") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            let path = rest.trim();
+            return ParsedMeta {
+                cmd: MetaCmd::LuaFile,
+                plus: false,
+                system: false,
+                pattern: if path.is_empty() {
+                    None
+                } else {
+                    Some(path.to_owned())
+                },
+                echo_hidden: false,
+            };
+        }
+    }
+
+    // `\lua <code>` — execute inline Lua code.
+    #[cfg(feature = "lua")]
+    if let Some(rest) = input.strip_prefix("lua") {
+        if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+            let code = rest.trim();
+            return ParsedMeta {
+                cmd: MetaCmd::Lua,
+                plus: false,
+                system: false,
+                pattern: if code.is_empty() {
+                    None
+                } else {
+                    Some(code.to_owned())
+                },
+                echo_hidden: false,
+            };
+        }
     }
 
     // `\log-file [path]` — must be checked before bare `\l` (longer prefix).

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1046,6 +1046,15 @@ pub struct ReplSettings {
     /// `/ask` transaction (which SHOULD be rolled back if it leaks into the
     /// next command due to an error or interruption).
     pub internal_tx: bool,
+
+    // -- Lua scripting (#659) -----------------------------------------------
+    /// Optional Lua scripting engine for user-defined meta commands.
+    ///
+    /// Present only when compiled with `--features lua` and initialised at
+    /// REPL startup.  Shared via `Arc<Mutex<..>>` so that tab completion
+    /// can read registered command names.
+    #[cfg(feature = "lua")]
+    pub lua_engine: Option<std::sync::Arc<std::sync::Mutex<crate::lua_engine::LuaEngine>>>,
 }
 
 impl std::fmt::Debug for ReplSettings {
@@ -1211,6 +1220,8 @@ impl Default for ReplSettings {
             prompt_interrupted: false,
             last_t2s_nl_query: None,
             internal_tx: false,
+            #[cfg(feature = "lua")]
+            lua_engine: None,
         }
     }
 }
@@ -3067,6 +3078,18 @@ async fn dispatch_meta(
         return MetaResult::Continue;
     }
 
+    // -- Reclassify Unknown → LuaCustom if a Lua command matches -----------
+    #[cfg(feature = "lua")]
+    let mut parsed = parsed;
+    #[cfg(feature = "lua")]
+    if let Some(ref engine) = settings.lua_engine {
+        if let Ok(guard) = engine.lock() {
+            let names: std::collections::HashSet<String> =
+                guard.command_names().into_iter().collect();
+            parsed.reclassify_lua(&names);
+        }
+    }
+
     // Try I/O commands first (they are the most numerous).
     if let Some(result) = dispatch_io(&parsed, client, params, settings, tx).await {
         return result;
@@ -3173,6 +3196,82 @@ async fn dispatch_meta(
         }
         MetaCmd::ToggleAutoExplain => {
             apply_fkey_toggle(FKeyAction::AutoExplain, settings);
+        }
+        // -- Lua scripting (#659) -------------------------------------------
+        #[cfg(feature = "lua")]
+        MetaCmd::Lua => {
+            match parsed.pattern.as_deref() {
+                Some(code) => {
+                    if let Some(ref engine) = settings.lua_engine {
+                        match engine.lock() {
+                            Ok(mut eng) => match eng.exec_inline(code) {
+                                Ok(lines) => {
+                                    for line in &lines {
+                                        println!("{line}");
+                                    }
+                                }
+                                Err(e) => eprintln!("\\lua: {e}"),
+                            },
+                            Err(e) => eprintln!("\\lua: engine lock failed: {e}"),
+                        }
+                    } else {
+                        eprintln!("\\lua: Lua engine not initialised");
+                    }
+                }
+                None => eprintln!("\\lua: code argument required"),
+            }
+        }
+        #[cfg(feature = "lua")]
+        MetaCmd::LuaFile => {
+            match parsed.pattern.as_deref() {
+                Some(path) => {
+                    if let Some(ref engine) = settings.lua_engine {
+                        match engine.lock() {
+                            Ok(mut eng) => match eng.exec_file(path) {
+                                Ok(lines) => {
+                                    for line in &lines {
+                                        println!("{line}");
+                                    }
+                                }
+                                Err(e) => eprintln!("\\luafile: {e}"),
+                            },
+                            Err(e) => eprintln!("\\luafile: engine lock failed: {e}"),
+                        }
+                    } else {
+                        eprintln!("\\luafile: Lua engine not initialised");
+                    }
+                }
+                None => eprintln!("\\luafile: file path required"),
+            }
+        }
+        #[cfg(feature = "lua")]
+        MetaCmd::LuaCustom(ref cmd_name) => {
+            let args = parsed.pattern.as_deref().unwrap_or("");
+            // Call the Lua callback while holding the engine lock, then
+            // drop the lock before executing any returned SQL (which needs
+            // `&mut settings`).
+            let lua_result = settings.lua_engine.as_ref().and_then(|engine| {
+                match engine.lock() {
+                    Ok(mut eng) => Some(eng.call_command(cmd_name, args)),
+                    Err(e) => {
+                        eprintln!("\\{cmd_name}: engine lock failed: {e}");
+                        None
+                    }
+                }
+            });
+            if let Some(result) = lua_result {
+                match result {
+                    Ok((lines, sql)) => {
+                        for line in &lines {
+                            println!("{line}");
+                        }
+                        if let Some(query) = sql {
+                            execute_query(client, &query, settings, tx).await;
+                        }
+                    }
+                    Err(e) => eprintln!("\\{cmd_name}: {e}"),
+                }
+            }
         }
         MetaCmd::Unknown(ref name) => {
             eprintln!("Invalid command \\{name}. Try \\? for help.");
@@ -3706,6 +3805,30 @@ pub async fn run_repl(
         }
     }
 
+    // -- Initialise Lua scripting engine (#659) ----------------------------
+    #[cfg(feature = "lua")]
+    {
+        match crate::lua_engine::LuaEngine::new() {
+            Ok(mut engine) => {
+                engine.load_user_scripts();
+                let cmd_count = engine.command_names().len();
+                if cmd_count > 0 && !settings.quiet {
+                    eprintln!(
+                        "rpg: lua: loaded {cmd_count} custom command{}",
+                        if cmd_count == 1 { "" } else { "s" }
+                    );
+                }
+                settings.lua_engine =
+                    Some(std::sync::Arc::new(std::sync::Mutex::new(engine)));
+            }
+            Err(e) => {
+                if !settings.quiet {
+                    eprintln!("rpg: lua: failed to initialise: {e}");
+                }
+            }
+        }
+    }
+
     // Build rustyline editor (skip if --no-readline).
     let use_readline = !no_readline && io::stdin().is_terminal();
 
@@ -3834,6 +3957,11 @@ async fn run_readline_loop(
     // Enable syntax highlighting unless the user opted out or $TERM is dumb.
     let highlight = !settings.no_highlight && std::env::var("TERM").as_deref() != Ok("dumb");
     let mut helper = RpgHelper::new(Arc::clone(&cache), highlight);
+    // Wire Lua engine into tab completion.
+    #[cfg(feature = "lua")]
+    if let Some(ref engine) = settings.lua_engine {
+        helper.set_lua_engine(std::sync::Arc::clone(engine));
+    }
     // Apply the experimental dropdown flag from config (disabled by default).
     helper.set_dropdown_completion(settings.config.display.dropdown_completion);
 


### PR DESCRIPTION
## Summary

This PR introduces a Lua 5.4 scripting engine that allows users to define custom backslash commands through Lua scripts. The feature is gated behind a `lua` Cargo feature flag and integrates seamlessly with the existing REPL infrastructure.

## Key Changes

- **New `lua_engine` module** (`src/lua_engine.rs`): Implements the core Lua runtime with:
  - `LuaEngine` struct that manages a Lua VM and registry of user-defined commands
  - `rpg.print()` API for buffering output from Lua callbacks
  - `rpg.register_command(name, desc, callback)` API for registering custom commands
  - Automatic script loading from `~/.config/rpg/lua/*.lua` and `.rpg/lua/*.lua`
  - Methods to execute inline code (`\lua`), load files (`\luafile`), and invoke registered commands

- **Meta command parsing** (`src/metacmd.rs`):
  - Added `MetaCmd::Lua`, `MetaCmd::LuaFile`, and `MetaCmd::LuaCustom` variants
  - Added `reclassify_lua()` method to convert unknown commands to Lua custom commands when they match registered names
  - Added parsing logic for `\lua <code>` and `\luafile <path>` commands

- **REPL integration** (`src/repl/mod.rs`):
  - Added `lua_engine` field to `ReplSettings` (behind `#[cfg(feature = "lua")]`)
  - Initialize the Lua engine at REPL startup, loading user scripts and reporting command count
  - Dispatch `\lua`, `\luafile`, and custom Lua commands through `dispatch_meta()`
  - Reclassify unknown commands as Lua custom commands when appropriate

- **Tab completion** (`src/complete.rs`):
  - Wire Lua engine into `RpgHelper` for tab completion
  - Include registered Lua command names in backslash command completions
  - Include built-in `lua` and `luafile` commands in completions

- **Dependencies** (`Cargo.toml`):
  - Added optional `mlua` dependency (Lua 5.4 bindings) behind the `lua` feature flag

## Implementation Details

- The Lua engine uses `Arc<Mutex<..>>` to allow safe sharing between the REPL dispatch path and tab completion
- Output from Lua callbacks is buffered via `rpg.print()` and returned as `Vec<String>`
- Lua callbacks can optionally return a SQL string to be executed by the REPL
- Registry keys are used to store Lua function references across multiple invocations
- Script loading errors are printed to stderr but don't prevent other scripts from loading
- All Lua-specific code is properly feature-gated to avoid compilation when the feature is disabled

https://claude.ai/code/session_01McwfYoFqv9Zh8cA3k9Vjyv