### PR TITLE
fix(explain): fix \explain share URL extraction for depesz and dalibo

### DIFF
--- a/src/explain/share.rs
+++ b/src/explain/share.rs
@@ -126,9 +126,15 @@ fn extract_depesz_url(body: &str) -> Option<String> {
 /// POST to explain.dalibo.com and return the plan URL.
 ///
 /// Dalibo accepts a JSON body with `plan`, `query`, and `title` fields
-/// and responds with JSON containing the plan URL.
+/// and responds with a 302 redirect to the plan page.  We use
+/// `redirect::Policy::none()` to capture the `Location` header directly
+/// instead of following the redirect automatically (which would give us
+/// the rendered HTML page with status 200, making URL extraction fail).
 async fn upload_dalibo(plan_text: &str) -> Result<String, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| format!("failed to build HTTP client: {e}"))?;
 
     let payload = serde_json::json!({
         "plan": plan_text,
@@ -145,73 +151,28 @@ async fn upload_dalibo(plan_text: &str) -> Result<String, String> {
 
     let status = response.status();
 
-    // Dalibo may redirect to the plan page on success.
+    // Dalibo returns 302 on success with Location pointing to the plan.
     if status.is_redirection() {
         let location = response
             .headers()
             .get("location")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
-        if !location.is_empty() {
-            let url = if location.starts_with("http") {
-                location.to_owned()
-            } else {
-                format!("https://explain.dalibo.com{location}")
-            };
-            return Ok(url);
+        if location.is_empty() {
+            return Err("explain.dalibo.com returned a redirect with no Location header".into());
         }
-    }
-
-    if !status.is_success() {
-        return Err(format!("explain.dalibo.com returned status {status}"));
-    }
-
-    let body = response
-        .text()
-        .await
-        .map_err(|e| format!("failed to read explain.dalibo.com response: {e}"))?;
-
-    // Try to parse JSON response first.
-    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
-        // Look for common URL fields in the JSON response.
-        for key in &["url", "permalink", "link", "id"] {
-            if let Some(val) = json.get(key).and_then(|v| v.as_str()) {
-                let url = if val.starts_with("http") {
-                    val.to_owned()
-                } else {
-                    format!("https://explain.dalibo.com/{val}")
-                };
-                return Ok(url);
-            }
-        }
-    }
-
-    // Fallback: try to extract a URL from the raw body text.
-    if let Some(url) = extract_dalibo_url(&body) {
+        // Location may be relative (e.g. "/plan/abc123") — make it absolute.
+        let url = if location.starts_with("http") {
+            location.to_owned()
+        } else {
+            format!("https://explain.dalibo.com{location}")
+        };
         return Ok(url);
     }
 
     Err(format!(
-        "explain.dalibo.com returned status {status} \
-         but the URL could not be extracted from the response"
+        "explain.dalibo.com returned unexpected status {status}"
     ))
-}
-
-/// Extract the plan URL from a dalibo response body.
-fn extract_dalibo_url(body: &str) -> Option<String> {
-    for line in body.lines() {
-        let line = line.trim();
-        if line.contains("explain.dalibo.com/") {
-            if let Some(start) = line.find("https://explain.dalibo.com/") {
-                let rest = &line[start..];
-                let end = rest
-                    .find(|c: char| c == '"' || c == '\'' || c.is_whitespace())
-                    .unwrap_or(rest.len());
-                return Some(rest[..end].to_owned());
-            }
-        }
-    }
-    None
 }
 
 /// Copy `text` to the system clipboard.

--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -1017,8 +1017,10 @@ pub(super) async fn execute_query_interactive(
         && explain_format != crate::explain::ExplainFormat::Raw
     {
         let raw_text = String::from_utf8_lossy(&captured);
-        // Store the stripped plain-text EXPLAIN output for `\explain share`.
-        settings.last_explain_text = Some(strip_psql_table_format(&raw_text));
+        // `last_explain_text` was already stored with correct indentation by
+        // `execute_query` (from the raw row values).  Do not overwrite it here
+        // with the psql-table-stripped version, which loses indentation and
+        // causes depesz/dalibo to reject the plan.
         if let Some(rendered) = try_render_explain(&raw_text, explain_format) {
             enhanced = rendered;
             display = std::borrow::Cow::Borrowed(b"");
@@ -1029,9 +1031,7 @@ pub(super) async fn execute_query_interactive(
             (s, captured.as_slice())
         }
     } else if ok && is_explain_statement(sql) {
-        // Raw format: still store the stripped text for `\explain share`.
-        let raw_text = String::from_utf8_lossy(&captured);
-        settings.last_explain_text = Some(strip_psql_table_format(&raw_text));
+        // Raw format: `last_explain_text` already set by `execute_query`.
         display = std::borrow::Cow::Borrowed(captured.as_slice());
         let s = std::str::from_utf8(&captured).unwrap_or("");
         (s, captured.as_slice())


### PR DESCRIPTION
Fixes #667.

## Root causes

Two bugs caused both `\explain share` commands to fail silently.

### Bug 1 — dalibo: reqwest default redirect policy swallows the 302

`upload_dalibo` used `reqwest::Client::new()` which follows 302 redirects
automatically. On redirect, reqwest re-issued the request as POST to the
plan page URL, which returned 400 Bad Request (or in some cases, followed
through to a 200 HTML page). The `status.is_redirection()` check never
fired, JSON extraction failed, and the error was returned.

**Fix:** use `redirect::Policy::none()` in `upload_dalibo`, identical to
what `upload_depesz` already does correctly.

### Bug 2 — depesz: plan indentation stripped, depesz rejects the plan

`execute_query_interactive` called `strip_psql_table_format()` on the
captured psql output and stored the result in `last_explain_text`. That
function calls `line.trim()` on every line, which destroys the leading
whitespace that encodes the plan tree structure. Without indentation,
depesz cannot parse the plan and returns HTTP 200 (the empty submission
form) instead of 302 + Location.

`execute_query` had already stored the correctly-indented plan text in
`last_explain_text` (from the raw PostgreSQL row values). The overwrite in
`execute_query_interactive` was redundant and incorrect.

**Fix:** remove the two `last_explain_text =` assignments from
`execute_query_interactive`. The value stored by `execute_query` is
authoritative and preserves indentation.

## Demo proof

Tested against `demo_saas` with `explain analyze select * from orders limit 10;`:

- `\explain share depesz` → https://explain.depesz.com/s/EcDq
- `\explain share dalibo` → https://explain.dalibo.com/plan/e16a0763a91h8g7d

Both URLs open valid visualiser pages with the uploaded plan.

## Checklist

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 1650 passed, 0 failed
- [x] Live demo with real URLs confirmed above