### PR TITLE
fix(explain): fix non-analyze rendering and Limit false positives

### DIFF
--- a/src/explain/issues.rs
+++ b/src/explain/issues.rs
@@ -393,6 +393,38 @@ fn collect_nodes<'a>(node: &'a ExplainNode, out: &mut Vec<&'a ExplainNode>) {
     }
 }
 
+/// Collect node indices that are descendants of a Limit node where the
+/// descendant's `actual_rows` equals the Limit's `actual_rows`.
+///
+/// A Limit node artificially truncates its children's output: the children
+/// may have high estimated row counts (the unfiltered estimate) while only
+/// returning exactly as many rows as the Limit allows.  Row estimate warnings
+/// on such children are false positives.
+fn collect_limit_constrained_indices(
+    node: &ExplainNode,
+    limit_rows: Option<f64>,
+    out: &mut std::collections::HashSet<usize>,
+) {
+    let effective_limit = if node.node_type == "Limit" {
+        // When entering a Limit node, its actual_rows is the cap for children.
+        Some(node.actual_rows)
+    } else {
+        limit_rows
+    };
+
+    if let Some(limit) = effective_limit {
+        if node.node_type != "Limit" && (node.actual_rows - limit).abs() < 0.5 {
+            // This node returned exactly the Limit's row count — its estimate
+            // is for the full un-limited result, so skip the row estimate check.
+            out.insert(node.index);
+        }
+    }
+
+    for child in &node.children {
+        collect_limit_constrained_indices(child, effective_limit, out);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
@@ -408,13 +440,26 @@ pub fn detect_issues(plan: &ExplainPlan) -> Vec<PlanIssue> {
     let mut nodes: Vec<&ExplainNode> = Vec::new();
     collect_nodes(&plan.root, &mut nodes);
 
+    // Build the set of nodes that are limit-constrained (descendants of a
+    // Limit node whose actual rows match the Limit's row count).  Row estimate
+    // warnings for these nodes are suppressed — the child's estimated rows
+    // reflect the full un-limited result set, not a planning error.
+    let mut limit_constrained = std::collections::HashSet::new();
+    collect_limit_constrained_indices(&plan.root, None, &mut limit_constrained);
+
     // Apply every heuristic to every node.
     let mut issues: Vec<PlanIssue> = nodes
         .iter()
         .flat_map(|node| {
+            // Skip row estimate check for limit-constrained nodes.
+            let row_est_issue = if limit_constrained.contains(&node.index) {
+                None
+            } else {
+                check_row_estimate_error(node)
+            };
             [
                 check_seq_scan_large(node),
-                check_row_estimate_error(node),
+                row_est_issue,
                 check_sort_spill(node),
                 check_hash_spill(node),
                 check_high_filter_removal(node),
@@ -1015,5 +1060,127 @@ mod tests {
         // Should not panic; time_percent stays 0.0.
         plan.compute_time_percents();
         assert!(plan.root.time_percent.abs() < f64::EPSILON);
+    }
+
+    // -----------------------------------------------------------------------
+    // Limit node false-positive suppression
+    // -----------------------------------------------------------------------
+
+    /// A Limit node stops execution after N rows.  Children under a Limit may
+    /// have large estimated row counts (the full un-limited estimate) while
+    /// returning only as many rows as the Limit allows.  The row estimate check
+    /// must not fire for these nodes — they are not a planning error.
+    #[test]
+    fn row_estimate_under_limit_no_false_positive() {
+        // Limit(10) → Index Only Scan  estimated=1_000_000, actual=10
+        // Without the fix, this would fire with "overestimated 100000x".
+        let index_scan = ExplainNode {
+            index: 1,
+            node_type: "Index Only Scan".to_owned(),
+            estimated_rows: 1_000_000.0,
+            actual_rows: 10.0,
+            actual_total_ms: 0.1,
+            time_percent: 1.0,
+            ..Default::default()
+        };
+        let limit_node = ExplainNode {
+            index: 0,
+            node_type: "Limit".to_owned(),
+            estimated_rows: 10.0,
+            actual_rows: 10.0,
+            actual_total_ms: 0.1,
+            time_percent: 1.0,
+            children: vec![index_scan],
+            ..Default::default()
+        };
+        let plan = ExplainPlan {
+            root: limit_node,
+            total_execution_ms: 0.1,
+        };
+
+        let issues = detect_issues(&plan);
+        // The index scan under Limit should NOT generate a row estimate issue.
+        let row_est_issues: Vec<&PlanIssue> = issues
+            .iter()
+            .filter(|i| i.title.contains("estimate"))
+            .collect();
+        assert!(
+            row_est_issues.is_empty(),
+            "expected no row estimate false positive under Limit, got: {row_est_issues:?}"
+        );
+    }
+
+    /// A node with a genuine estimate error NOT under a Limit should still fire.
+    #[test]
+    fn row_estimate_not_under_limit_still_fires() {
+        // No Limit ancestor: genuine row estimate error should be detected.
+        let bad_scan = ExplainNode {
+            index: 0,
+            node_type: "Seq Scan".to_owned(),
+            estimated_rows: 1_000_000.0,
+            actual_rows: 10.0,
+            actual_total_ms: 100.0,
+            time_percent: 50.0,
+            ..Default::default()
+        };
+        let plan = ExplainPlan {
+            root: bad_scan,
+            total_execution_ms: 200.0,
+        };
+
+        let issues = detect_issues(&plan);
+        let row_est_issues: Vec<&PlanIssue> = issues
+            .iter()
+            .filter(|i| i.title.contains("estimate"))
+            .collect();
+        assert!(
+            !row_est_issues.is_empty(),
+            "expected row estimate issue for genuine mismatch without Limit"
+        );
+    }
+
+    /// End-to-end: parse a real EXPLAIN ANALYZE plan with Limit, verify no
+    /// false-positive row estimate warning from the Limit-constrained child.
+    #[test]
+    fn limit_false_positive_suppressed_via_parse() {
+        // This is the text PostgreSQL emits for:
+        //   EXPLAIN ANALYZE SELECT * FROM orders WHERE status = 'pending' LIMIT 10;
+        // The Seq Scan estimates 203200 rows but only returns 10 (limited by
+        // the Limit node).  Without the fix, a "20320x overestimated" warning
+        // fires on the Seq Scan — which is a false positive.
+        let plan_text = "Limit  (cost=0.00..2.32 rows=10 width=61) (actual time=0.040..0.044 rows=10 loops=1)\n  ->  Seq Scan on orders  (cost=0.00..47139.00 rows=203200 width=61) (actual time=0.040..0.043 rows=10 loops=1)\n        Filter: (status = 'pending'::text)\n        Rows Removed by Filter: 66\n        Buffers: shared hit=2\nPlanning Time: 0.050 ms\nExecution Time: 0.034 ms\n";
+
+        let parsed = crate::explain::parse(plan_text).expect("parse should succeed");
+
+        // Verify parse tree structure.
+        assert_eq!(parsed.nodes.len(), 1, "should have one root node (Limit)");
+        let root = &parsed.nodes[0];
+        assert_eq!(root.node_type, "Limit");
+        assert_eq!(root.estimated_rows, Some(10.0));
+        assert_eq!(root.children.len(), 1, "Limit should have one child");
+        let seq_scan = &root.children[0];
+        assert_eq!(seq_scan.node_type, "Seq Scan");
+        assert_eq!(seq_scan.estimated_rows, Some(203_200.0));
+        assert_eq!(seq_scan.actual_rows, Some(10.0));
+
+        let issues_plan = crate::explain::to_issues_plan(&parsed);
+
+        // Verify issues plan structure.
+        assert_eq!(issues_plan.root.node_type, "Limit");
+        assert_eq!(issues_plan.root.index, 0);
+        assert_eq!(issues_plan.root.children.len(), 1);
+        assert_eq!(issues_plan.root.children[0].node_type, "Seq Scan");
+        assert_eq!(issues_plan.root.children[0].index, 1);
+
+        let issues = detect_issues(&issues_plan);
+
+        let row_est_issues: Vec<&PlanIssue> = issues
+            .iter()
+            .filter(|i| i.title.contains("estimate"))
+            .collect();
+        assert!(
+            row_est_issues.is_empty(),
+            "expected no row estimate false positive under Limit, got: {row_est_issues:?}"
+        );
     }
 }

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -943,11 +943,21 @@ pub fn to_render_plan(
         render::ExplainNode::default()
     };
 
+    // Pull estimated cost and rows from the root node for the summary header.
+    let estimated_cost = plan
+        .nodes
+        .first()
+        .and_then(|n| n.estimated_cost)
+        .map(|(_, total)| total);
+    let estimated_rows = plan.nodes.first().and_then(|n| n.estimated_rows);
+
     render::ExplainPlan {
         root,
         execution_time_ms: plan.execution_time_ms,
         planning_time_ms: plan.planning_time_ms,
         is_analyze: plan.execution_time_ms.is_some(),
+        estimated_cost,
+        estimated_rows,
     }
 }
 
@@ -980,6 +990,8 @@ fn to_render_node(node: &ExplainNode, issues_node: &issues::ExplainNode) -> rend
         relation: node.relation.clone(),
         actual_time_ms: node.actual_time_ms,
         actual_rows: node.actual_rows,
+        estimated_cost: node.estimated_cost,
+        estimated_rows: node.estimated_rows,
         exclusive_time_ms: node.exclusive_time_ms,
         time_percent: issues_node.time_percent,
         loops: node.loops,

--- a/src/explain/render.rs
+++ b/src/explain/render.rs
@@ -1,10 +1,12 @@
-//! EXPLAIN plan rendering: summary header and colored tree output.
+//! EXPLAIN plan rendering: summary header and colorized raw plan output.
 //!
 //! Provides static text rendering of `PostgreSQL` EXPLAIN (ANALYZE) plans
-//! with ANSI color coding, Unicode box-drawing tree lines, hot-path
-//! detection, and a summary header showing key metrics and detected issues.
+//! with ANSI color coding, a summary header showing key metrics and detected
+//! issues, and inline warning markers on problem nodes.
 //!
-//! This module is standalone — it will be wired into the REPL in a later PR.
+//! The enhanced renderer does NOT replace the raw plan text — it adds a
+//! summary header on top and applies color/annotations to the raw lines.
+//! This preserves all cost, row, and filter details that `PostgreSQL` emits.
 //!
 //! Copyright 2026
 
@@ -78,6 +80,10 @@ pub struct ExplainPlan {
     pub planning_time_ms: Option<f64>,
     /// Whether this is an EXPLAIN ANALYZE (vs plain EXPLAIN).
     pub is_analyze: bool,
+    /// Planner estimated total cost from the root node (EXPLAIN always).
+    pub estimated_cost: Option<f64>,
+    /// Planner estimated row count from the root node (EXPLAIN always).
+    pub estimated_rows: Option<f64>,
 }
 
 impl ExplainPlan {
@@ -95,6 +101,17 @@ impl ExplainPlan {
     pub fn total_rows(&self) -> Option<f64> {
         #[allow(clippy::cast_precision_loss)]
         self.root.actual_rows.map(|r| r * self.root.loops as f64)
+    }
+
+    /// Estimated rows from the root node (available for plain EXPLAIN).
+    pub fn total_estimated_rows(&self) -> Option<f64> {
+        self.estimated_rows.or(self.root.estimated_rows)
+    }
+
+    /// Estimated total cost from the root node (available for plain EXPLAIN).
+    pub fn total_estimated_cost(&self) -> Option<f64> {
+        self.estimated_cost
+            .or_else(|| self.root.estimated_cost.map(|(_, total)| total))
     }
 
     /// Peak memory usage in bytes (from Sort nodes reporting sort space).
@@ -117,6 +134,10 @@ pub struct ExplainNode {
     pub actual_time_ms: Option<(f64, f64)>,
     /// Actual rows returned per loop.
     pub actual_rows: Option<f64>,
+    /// Planner estimated cost as `(startup, total)`.
+    pub estimated_cost: Option<(f64, f64)>,
+    /// Planner estimated row count.
+    pub estimated_rows: Option<f64>,
     /// Exclusive (self) time in milliseconds, excluding children.
     pub exclusive_time_ms: f64,
     /// Fraction of total plan time spent in this node (0.0–100.0).
@@ -282,7 +303,10 @@ fn fmt_bytes_binary(bytes: u64) -> String {
 
 /// Render the summary header for an EXPLAIN plan.
 ///
-/// Produces a box like:
+/// For EXPLAIN ANALYZE plans, shows execution/planning time and actual rows.
+/// For plain EXPLAIN (no ANALYZE), shows estimated cost and estimated rows
+/// from the planner.  The buffers line is omitted for plain EXPLAIN.
+///
 /// ```text
 /// ── EXPLAIN ANALYZE ──────────────────────────────────
 ///   Execution: 1,842 ms │ Planning: 12 ms │ Rows: 48,301
@@ -292,6 +316,13 @@ fn fmt_bytes_binary(bytes: u64) -> String {
 ///     SLOW  Seq Scan on orders (2.1M rows, 1,204 ms)
 ///     WARN  Sort spilled to disk (38 MiB)
 ///     WARN  Row estimate 1,483x off on Nested Loop
+/// ─────────────────────────────────────────────────────
+/// ```
+///
+/// Plain EXPLAIN variant:
+/// ```text
+/// ── EXPLAIN ──────────────────────────────────────────
+///   Estimated cost: 0.00..0.01 │ Estimated rows: 1
 /// ─────────────────────────────────────────────────────
 /// ```
 pub fn render_summary(plan: &ExplainPlan, issues: &[PlanIssue]) -> String {
@@ -311,47 +342,66 @@ pub fn render_summary(plan: &ExplainPlan, issues: &[PlanIssue]) -> String {
     out.push_str(&top_rule);
     out.push('\n');
 
-    // Metrics line.
+    // Metrics line — differs between ANALYZE and plain EXPLAIN.
     let mut metrics = String::new();
-    if let Some(exec) = plan.execution_time_ms {
-        write!(metrics, "Execution: {}", fmt_ms(exec)).ok();
-    }
-    if let Some(plan_t) = plan.planning_time_ms {
-        if !metrics.is_empty() {
-            write!(metrics, " {DIM}│{RESET} ").ok();
+    if plan.is_analyze {
+        // EXPLAIN ANALYZE: show actual execution/planning time and actual rows.
+        if let Some(exec) = plan.execution_time_ms {
+            write!(metrics, "Execution: {}", fmt_ms(exec)).ok();
         }
-        write!(metrics, "Planning: {}", fmt_ms(plan_t)).ok();
-    }
-    if let Some(rows) = plan.total_rows() {
-        if !metrics.is_empty() {
-            write!(metrics, " {DIM}│{RESET} ").ok();
+        if let Some(plan_t) = plan.planning_time_ms {
+            if !metrics.is_empty() {
+                write!(metrics, " {DIM}│{RESET} ").ok();
+            }
+            write!(metrics, "Planning: {}", fmt_ms(plan_t)).ok();
         }
-        write!(metrics, "Rows: {}", fmt_rows(rows)).ok();
+        if let Some(rows) = plan.total_rows() {
+            if !metrics.is_empty() {
+                write!(metrics, " {DIM}│{RESET} ").ok();
+            }
+            write!(metrics, "Rows: {}", fmt_rows(rows)).ok();
+        }
+    } else {
+        // Plain EXPLAIN: show estimated cost range and estimated rows.
+        if let Some(cost) = plan.total_estimated_cost() {
+            // Also try to get startup cost for the full range display.
+            let startup = plan.root.estimated_cost.map_or(0.0, |(s, _)| s);
+            write!(metrics, "Estimated cost: {startup:.2}..{cost:.2}").ok();
+        }
+        if let Some(rows) = plan.total_estimated_rows() {
+            if !metrics.is_empty() {
+                write!(metrics, " {DIM}│{RESET} ").ok();
+            }
+            write!(metrics, "Estimated rows: {}", fmt_rows(rows)).ok();
+        }
     }
     if !metrics.is_empty() {
         writeln!(out, "  {metrics}").ok();
     }
 
-    // Buffer / memory line.
-    let hit = plan.total_shared_hit();
-    let read = plan.total_shared_read();
-    if hit > 0 || read > 0 {
-        let mut buf_line = format!("  Buffers: {} hit", fmt_int(hit));
-        if read > 0 {
-            write!(buf_line, ", {} read", fmt_int(read)).ok();
+    // Buffer / memory line — only for EXPLAIN ANALYZE (plain EXPLAIN has no
+    // buffer data since nothing actually executes).
+    if plan.is_analyze {
+        let hit = plan.total_shared_hit();
+        let read = plan.total_shared_read();
+        if hit > 0 || read > 0 {
+            let mut buf_line = format!("  Buffers: {} hit", fmt_int(hit));
+            if read > 0 {
+                write!(buf_line, ", {} read", fmt_int(read)).ok();
+            }
+            if let Some(mem) = plan.peak_memory_bytes() {
+                write!(
+                    buf_line,
+                    " {DIM}│{RESET} Peak mem: {}",
+                    fmt_bytes_binary(mem)
+                )
+                .ok();
+            }
+            out.push_str(&buf_line);
+            out.push('\n');
+        } else if let Some(mem) = plan.peak_memory_bytes() {
+            writeln!(out, "  Peak mem: {}", fmt_bytes_binary(mem)).ok();
         }
-        if let Some(mem) = plan.peak_memory_bytes() {
-            write!(
-                buf_line,
-                " {DIM}│{RESET} Peak mem: {}",
-                fmt_bytes_binary(mem)
-            )
-            .ok();
-        }
-        out.push_str(&buf_line);
-        out.push('\n');
-    } else if let Some(mem) = plan.peak_memory_bytes() {
-        writeln!(out, "  Peak mem: {}", fmt_bytes_binary(mem)).ok();
     }
 
     // Issues section.
@@ -676,14 +726,173 @@ pub fn render_colored_tree(
 }
 
 // ---------------------------------------------------------------------------
+// Raw plan colorization
+// ---------------------------------------------------------------------------
+
+/// Issue matcher: contains a node identifier string (relation or node type).
+fn issue_matches_line(issues: &[PlanIssue], line: &str) -> bool {
+    issues.iter().any(|iss| {
+        // Check if any word from the issue message appears in the node line.
+        // We look for the relation name or node type appearing in both.
+        iss.message.split_whitespace().any(|word| {
+            // Only match meaningful tokens (skip short words and punctuation).
+            word.len() >= 4 && line.contains(word)
+        })
+    })
+}
+
+/// Choose ANSI color for a node line based on timing percentage, or for
+/// plain EXPLAIN based on node type (seq scans get yellow, index scans dim).
+fn node_line_color(time_percent: f64, has_actual_time: bool, node_type: &str) -> &'static str {
+    if has_actual_time {
+        time_percent_color(time_percent)
+    } else {
+        // Plain EXPLAIN: color by node type as a heuristic.
+        match node_type {
+            s if s.contains("Seq Scan") => YELLOW,
+            s if s.contains("Index") => DIM,
+            _ => DIM,
+        }
+    }
+}
+
+/// Colorize the raw stripped EXPLAIN plan text, adding ANSI codes and
+/// inline `⚠` issue markers.
+///
+/// The raw plan text is the unmodified `PostgreSQL` output (after stripping
+/// the psql table border and `QUERY PLAN` header).  Each line is annotated:
+///
+/// - Node header lines (`(cost=...)` present): colored by time percentage
+///   or node type; `⚠` appended if the line matches a detected issue.
+/// - Detail lines (`Buffers:`, `Filter:`, `Sort Method:`, etc.): dimmed.
+/// - Planning/Execution time lines: bold-white.
+/// - Blank lines: passed through unchanged.
+///
+/// The rendered output preserves the exact structure and content of the
+/// original plan — nothing is removed or reformatted.
+pub fn render_raw_colorized(raw_plan: &str, plan: &ExplainPlan, issues: &[PlanIssue]) -> String {
+    // Build a quick lookup: for each node in DFS order, track its
+    // time_percent and whether it has actual timing.  We match lines by
+    // scanning for `(cost=` just as the parser does.
+    let mut out = String::new();
+
+    // Walk plan nodes in DFS to build a parallel iterator of (time_pct,
+    // has_actual_time, estimated_rows, actual_rows) in document order.
+    let node_annots = collect_node_annotations(&plan.root);
+    let mut node_iter = node_annots.iter();
+
+    for line in raw_plan.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() {
+            out.push('\n');
+            continue;
+        }
+
+        // Planning / Execution time lines get bold-white.
+        let lower = trimmed.to_lowercase();
+        if lower.starts_with("planning time:") || lower.starts_with("execution time:") {
+            writeln!(out, "{BOLD_WHITE}{line}{RESET}").ok();
+            continue;
+        }
+
+        // Node header lines contain "(cost=".
+        if trimmed.contains("(cost=") {
+            let annot = node_iter.next().copied();
+            let (time_pct, has_actual, _est_rows, _act_rows) =
+                annot.unwrap_or((0.0, false, None, None));
+
+            // Extract node type for plain EXPLAIN coloring.
+            let node_type = extract_node_type_from_line(trimmed);
+            let color = node_line_color(time_pct, has_actual, &node_type);
+
+            // Check if this line matches any detected issue.
+            let warn_marker = if issue_matches_line(issues, trimmed) {
+                " ⚠"
+            } else {
+                ""
+            };
+
+            // For EXPLAIN ANALYZE with row estimate mismatch, show
+            // both estimates inline after the existing line.
+            // (The raw line already contains both sets of numbers, so
+            // we just colorize it and add the warning marker.)
+            writeln!(out, "{color}{line}{warn_marker}{RESET}").ok();
+            continue;
+        }
+
+        // Detail lines: Buffers, Filter, Sort Method, etc. — dim them.
+        if trimmed.starts_with("Buffers:")
+            || trimmed.starts_with("Filter:")
+            || trimmed.starts_with("Sort Method:")
+            || trimmed.starts_with("Index Cond:")
+            || trimmed.starts_with("Hash Cond:")
+            || trimmed.starts_with("Join Filter:")
+            || lower.starts_with("rows removed by filter:")
+            || lower.starts_with("sort method:")
+            || lower.starts_with("batches:")
+            || lower.starts_with("hash batches:")
+            || lower.starts_with("workers")
+        {
+            writeln!(out, "{DIM}{line}{RESET}").ok();
+            continue;
+        }
+
+        // Everything else: pass through as-is.
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    out
+}
+
+/// A compact annotation for a single plan node, in DFS order.
+/// `(time_percent, has_actual_time, estimated_rows, actual_rows)`
+type NodeAnnot = (f64, bool, Option<f64>, Option<f64>);
+
+/// Collect node annotations in DFS (document) order.
+fn collect_node_annotations(node: &ExplainNode) -> Vec<NodeAnnot> {
+    let mut result = Vec::new();
+    collect_node_annotations_rec(node, &mut result);
+    result
+}
+
+fn collect_node_annotations_rec(node: &ExplainNode, out: &mut Vec<NodeAnnot>) {
+    out.push((
+        node.time_percent,
+        node.actual_time_ms.is_some(),
+        node.estimated_rows,
+        node.actual_rows,
+    ));
+    for child in &node.children {
+        collect_node_annotations_rec(child, out);
+    }
+}
+
+/// Extract the node type from a raw EXPLAIN line (before the first `(`).
+fn extract_node_type_from_line(trimmed: &str) -> String {
+    // Strip leading "-> " if present.
+    let s = trimmed.strip_prefix("-> ").unwrap_or(trimmed);
+    // Take the part before the first "(cost=".
+    if let Some(pos) = s.find("(cost=") {
+        s[..pos].trim().to_owned()
+    } else {
+        s.to_owned()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Combined output
 // ---------------------------------------------------------------------------
 
-/// Render the full enhanced EXPLAIN output: summary header + colored tree.
-pub fn render_enhanced(plan: &ExplainPlan, issues: &[PlanIssue], terminal_width: usize) -> String {
+/// Render the full enhanced EXPLAIN output: summary header + colorized raw plan.
+///
+/// The raw plan text is preserved verbatim; only ANSI colors and `⚠` markers
+/// are added.  This ensures all cost/row/filter details remain visible.
+pub fn render_enhanced(plan: &ExplainPlan, issues: &[PlanIssue], raw_plan: &str) -> String {
     let mut out = render_summary(plan, issues);
     out.push('\n');
-    out.push_str(&render_colored_tree(plan, issues, terminal_width));
+    out.push_str(&render_raw_colorized(raw_plan, plan, issues));
     out
 }
 
@@ -716,6 +925,8 @@ mod tests {
             relation: relation.map(str::to_owned),
             actual_time_ms,
             actual_rows: Some(actual_rows),
+            estimated_cost: None,
+            estimated_rows: None,
             exclusive_time_ms,
             time_percent,
             loops,
@@ -761,6 +972,8 @@ mod tests {
             relation: None,
             actual_time_ms: Some((0.0, 105.0)),
             actual_rows: Some(50_000.0),
+            estimated_cost: None,
+            estimated_rows: None,
             exclusive_time_ms: 5.0,
             time_percent: 0.3,
             loops: 1,
@@ -777,6 +990,8 @@ mod tests {
             relation: None,
             actual_time_ms: Some((0.0, 1842.0)),
             actual_rows: Some(48_301.0),
+            estimated_cost: None,
+            estimated_rows: None,
             exclusive_time_ms: 533.0,
             time_percent: 28.9,
             loops: 1,
@@ -793,6 +1008,8 @@ mod tests {
             execution_time_ms: Some(1842.0),
             planning_time_ms: Some(12.0),
             is_analyze: true,
+            estimated_cost: None,
+            estimated_rows: None,
         }
     }
 
@@ -1059,6 +1276,8 @@ mod tests {
             relation: None,
             actual_time_ms: None,
             actual_rows: Some(10.0),
+            estimated_cost: None,
+            estimated_rows: None,
             exclusive_time_ms: 1.0,
             time_percent: 0.5,
             loops: 1,
@@ -1076,6 +1295,8 @@ mod tests {
             relation: None,
             actual_time_ms: None,
             actual_rows: Some(100.0),
+            estimated_cost: None,
+            estimated_rows: None,
             exclusive_time_ms: 10.0,
             time_percent: 3.0,
             loops: 1,
@@ -1100,13 +1321,18 @@ mod tests {
     fn test_render_enhanced_has_both_sections() {
         let plan = simple_plan();
         let issues = issues_for_plan();
-        let out = render_enhanced(&plan, &issues, 80);
+        // Minimal raw plan text matching the simple_plan structure.
+        let raw = "Hash Join  (cost=1.09..2.22 rows=5 width=8) (actual time=0.050..1842.0 rows=48301 loops=1)\n\
+                   ->  Seq Scan on orders  (cost=0.00..1.06 rows=6 width=8) (actual time=0.010..1204.0 rows=2100000 loops=1)\n\
+                   ->  Hash  (cost=1.05..1.05 rows=5 width=4) (actual time=0.020..105.0 rows=50000 loops=1)\n\
+                         ->  Seq Scan on users  (cost=0.00..1.05 rows=5 width=4) (actual time=0.008..100.0 rows=50000 loops=1)\n";
+        let out = render_enhanced(&plan, &issues, raw);
         // Summary section.
         assert!(out.contains("EXPLAIN ANALYZE"));
         assert!(out.contains("Issues (3)"));
-        // Tree section.
+        // Raw plan content.
         assert!(out.contains("Hash Join"));
-        assert!(out.contains("╰─") || out.contains("├─"));
+        assert!(out.contains("Seq Scan on orders"));
     }
 
     // -----------------------------------------------------------------------
@@ -1125,5 +1351,107 @@ mod tests {
         let plan = simple_plan();
         // seq_orders: 3_000, seq_users: 201
         assert_eq!(plan.total_shared_read(), 3_201);
+    }
+
+    // -----------------------------------------------------------------------
+    // Plain EXPLAIN summary (non-analyze)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_summary_plain_explain_shows_estimated_cost() {
+        let mut plan = simple_plan();
+        plan.is_analyze = false;
+        plan.execution_time_ms = None;
+        plan.planning_time_ms = None;
+        plan.estimated_cost = Some(42.5);
+        plan.root.estimated_cost = Some((0.0, 42.5));
+        let summary = render_summary(&plan, &[]);
+        assert!(summary.contains("Estimated cost:"));
+        assert!(summary.contains("42.50"));
+        // Should not show Execution or Buffers for plain EXPLAIN.
+        assert!(!summary.contains("Execution:"));
+        assert!(!summary.contains("Buffers:"));
+    }
+
+    #[test]
+    fn test_summary_plain_explain_shows_estimated_rows() {
+        let mut plan = simple_plan();
+        plan.is_analyze = false;
+        plan.execution_time_ms = None;
+        plan.planning_time_ms = None;
+        plan.estimated_rows = Some(1.0);
+        plan.root.estimated_rows = Some(1.0);
+        let summary = render_summary(&plan, &[]);
+        assert!(summary.contains("Estimated rows:"));
+        assert!(summary.contains('1'));
+    }
+
+    #[test]
+    fn test_summary_plain_explain_no_buffers() {
+        // Plain EXPLAIN should not show a Buffers line even if buffer fields
+        // are non-zero (they won't be, but guard against it).
+        let mut plan = simple_plan();
+        plan.is_analyze = false;
+        plan.execution_time_ms = None;
+        plan.planning_time_ms = None;
+        // Forcibly set shared_hit so that if the buffers guard were absent,
+        // a buffers line would appear.
+        plan.root.shared_hit = 500;
+        let summary = render_summary(&plan, &[]);
+        assert!(!summary.contains("Buffers:"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Raw plan colorizer
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_raw_colorized_preserves_node_lines() {
+        let plan = simple_plan();
+        let raw = "Hash Join  (cost=1.09..2.22 rows=5 width=8) (actual time=0.050..1842.0 rows=48301 loops=1)\n\
+                   ->  Seq Scan on orders  (cost=0.00..1.06 rows=6 width=8)\n";
+        let out = render_raw_colorized(raw, &plan, &[]);
+        assert!(out.contains("Hash Join"));
+        assert!(out.contains("cost=1.09..2.22"));
+        assert!(out.contains("Seq Scan on orders"));
+    }
+
+    #[test]
+    fn test_raw_colorized_adds_warn_marker_for_matching_issue() {
+        let plan = simple_plan();
+        let issues = vec![PlanIssue {
+            severity: IssueSeverity::Slow,
+            message: "Seq Scan on orders (big scan)".to_owned(),
+        }];
+        let raw = "->  Seq Scan on orders  (cost=0.00..1.06 rows=6 width=8)\n\
+             ->  Seq Scan on users  (cost=0.00..1.05 rows=5 width=4)\n";
+        let out = render_raw_colorized(raw, &plan, &issues);
+        // The orders line should get a ⚠ marker; users line should not.
+        assert!(out.contains('⚠'));
+    }
+
+    #[test]
+    fn test_raw_colorized_no_marker_without_issues() {
+        let plan = simple_plan();
+        let raw = "->  Seq Scan on orders  (cost=0.00..1.06 rows=6 width=8)\n";
+        let out = render_raw_colorized(raw, &plan, &[]);
+        assert!(!out.contains('⚠'));
+    }
+
+    #[test]
+    fn test_raw_colorized_dims_detail_lines() {
+        let plan = simple_plan();
+        let raw = "Seq Scan on t  (cost=0.00..1.0 rows=1 width=4)\n  Filter: (x > 0)\n  Buffers: shared hit=5\n";
+        let out = render_raw_colorized(raw, &plan, &[]);
+        // DIM escape code should appear for the filter/buffers detail lines.
+        assert!(out.contains(DIM));
+    }
+
+    #[test]
+    fn test_raw_colorized_bolds_timing_lines() {
+        let plan = simple_plan();
+        let raw = "Seq Scan on t  (cost=0.00..1.0 rows=1 width=4)\nPlanning Time: 0.1 ms\nExecution Time: 0.2 ms\n";
+        let out = render_raw_colorized(raw, &plan, &[]);
+        assert!(out.contains(BOLD_WHITE));
     }
 }

--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -881,7 +881,12 @@ fn is_explain_statement(sql: &str) -> bool {
 /// When EXPLAIN results come back through `print_result_set_pset`, they are
 /// rendered as an aligned table with a `QUERY PLAN` header, border lines, and
 /// a `(N rows)` footer.  The EXPLAIN text parser expects plain lines without
-/// this decoration.
+/// this decoration, but WITH the original indentation preserved.
+///
+/// `PostgreSQL`'s aligned format adds a single leading space before each
+/// column value.  Plan node indentation (2+ spaces) is part of the plan
+/// text itself and must be preserved so that [`super::explain::parse`] can
+/// reconstruct the parent-child tree from raw indent levels.
 fn strip_psql_table_format(formatted: &str) -> String {
     let mut lines = Vec::new();
     for line in formatted.lines() {
@@ -902,13 +907,24 @@ fn strip_psql_table_format(formatted: &str) -> String {
         if trimmed.is_empty() {
             continue;
         }
-        // Strip leading "| " and trailing " |" that the aligned format adds.
-        let content = if let Some(inner) = trimmed.strip_prefix("| ") {
+
+        // Strip table decoration while PRESERVING internal indentation.
+        //
+        // psql aligned format:
+        //   - Pipe-delimited: "| <content> |" — strip the "| " prefix and " |" suffix.
+        //   - Space-padded:   " <content>  " — strip exactly one leading space.
+        //     psql adds a single space before column content; the plan's own
+        //     indentation (2+ spaces) follows that single space and must be kept.
+        let content: &str = if let Some(inner) = trimmed.strip_prefix("| ") {
+            // Pipe-delimited format: strip the leading "| " and trailing " |".
             inner.strip_suffix(" |").unwrap_or(inner).trim_end()
         } else if let Some(inner) = trimmed.strip_prefix('|') {
             inner.strip_suffix('|').unwrap_or(inner).trim()
         } else {
-            trimmed
+            // Space-padded format: psql adds exactly one space before column
+            // content.  Strip that single leading space to get the raw plan
+            // text.  Additional leading spaces are the plan's own indentation.
+            line.strip_prefix(' ').unwrap_or(line).trim_end()
         };
         if !content.is_empty() {
             lines.push(content.to_owned());
@@ -920,6 +936,9 @@ fn strip_psql_table_format(formatted: &str) -> String {
 /// Given the raw (psql-formatted) output of an EXPLAIN query, parse and render
 /// it as an enhanced view.  Returns `Some(enhanced_text)` on success, or
 /// `None` if parsing fails (caller falls back to raw output).
+///
+/// Enhanced mode: summary header (timing/cost, issues) + full raw plan text
+/// with ANSI color and inline `⚠` markers — nothing is hidden or removed.
 fn try_render_explain(raw_text: &str, format: crate::explain::ExplainFormat) -> Option<String> {
     use crate::explain::{self, ExplainFormat};
 
@@ -937,16 +956,11 @@ fn try_render_explain(raw_text: &str, format: crate::explain::ExplainFormat) -> 
             &render_plan,
             &render_issues,
         )),
-        ExplainFormat::Enhanced => {
-            let term_width = crossterm::terminal::size()
-                .map(|(w, _)| w as usize)
-                .unwrap_or(80);
-            Some(crate::explain::render::render_enhanced(
-                &render_plan,
-                &render_issues,
-                term_width,
-            ))
-        }
+        ExplainFormat::Enhanced => Some(crate::explain::render::render_enhanced(
+            &render_plan,
+            &render_issues,
+            &stripped,
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #666. Three interconnected bugs in EXPLAIN rendering:

- **Empty summary for plain EXPLAIN**: `explain select pg_sleep(1);` showed a blank summary header with no metrics. Now shows `Estimated cost: X..Y │ Estimated rows: N` for any plain EXPLAIN.
- **Custom tree replaced raw plan**: The enhanced renderer was replacing PostgreSQL's full plan output with a custom tree that omitted costs, filters, and width. Now the summary header appears on top and the **full raw plan is preserved**, with ANSI color overlaid (node lines colored, detail lines dimmed, timing lines bold-white).
- **Indentation lost in strip**: `strip_psql_table_format` was calling `.trim()` on every line, destroying the indentation that the parser uses to reconstruct parent-child relationships. Root and child nodes were becoming siblings, causing Seq Scans to be treated as root nodes (wrong estimated_rows) and breaking the Limit false-positive fix.
- **Limit false-positive WARN**: `explain analyze select * from t limit 10;` would incorrectly warn "Row estimate overestimated by Nx" on the Seq Scan child. The child's estimated_rows reflects the full table, not a planning error — the Limit stops execution early. Now suppressed for nodes that are constrained by a Limit ancestor with matching actual_rows.

## Demo proof

```
-- 1. Plain EXPLAIN (was: empty header + "Result" with no detail)
explain select pg_sleep(1);
── EXPLAIN ─────────────────────────────────────
  Estimated cost: 0.00..0.01 │ Estimated rows: 1
────────────────────────────────────────────────

Result  (cost=0.00..0.01 rows=1 width=4)

-- 2. Plain EXPLAIN with plan tree
explain select * from orders where status = 'pending' limit 10;
── EXPLAIN ─────────────────────────────────────
  Estimated cost: 0.00..2.32 │ Estimated rows: 10
────────────────────────────────────────────────

Limit  (cost=0.00..2.32 rows=10 width=61)
  ->  Seq Scan on orders  (cost=0.00..47139.00 rows=203200 width=61)   [yellow]
        Filter: (status = 'pending'::text)   [dim]

-- 3. EXPLAIN ANALYZE with Limit — NO false positive warning
explain analyze select * from orders where status = 'pending' limit 10;
── EXPLAIN ANALYZE ─────────────────────────────
  Execution: 0.043 ms │ Planning: 0.043 ms │ Rows: 10
  Buffers: 4 hit
────────────────────────────────────────────────

Limit  (cost=0.00..2.32 rows=10 width=61) (actual time=0.023..0.033 rows=10.00 loops=1)
  ->  Seq Scan on orders  (cost=0.00..47139.00 rows=203200 width=61) (actual time=0.023..0.031 rows=10.00 loops=1)
        Filter: (status = 'pending'::text)
        Rows Removed by Filter: 66
        Buffers: shared hit=2
Planning Time: 0.043 ms
Execution Time: 0.043 ms
```

## Test plan

- [x] `cargo test` — 1656 tests pass (11 new)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `explain select pg_sleep(1);` — shows estimated cost/rows, full plan
- [x] `explain select 1;` — shows estimated cost/rows, `Result` node visible
- [x] `explain select * from orders where status = 'pending' limit 10;` — full plan with color
- [x] `explain analyze select * from orders where status = 'pending' limit 10;` — no false-positive Limit warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)