### PR TITLE
fix(docker): copy benches directory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY build.rs ./
 COPY src/ src/
+COPY benches/ benches/
 
 RUN cargo build --release
 


### PR DESCRIPTION
## Summary

- `Cargo.toml` declares a `[[bench]]` for `non_ai_paths` requiring `benches/non_ai_paths.rs` at build time
- The Dockerfile `COPY` instructions in the builder stage omitted `benches/`, so Docker builds failed with:
  ```
  error: can't find `non_ai_paths` bench at `benches/non_ai_paths.rs` or `benches/non_ai_paths/main.rs`
  ```
- Added `COPY benches/ benches/` before `RUN cargo build --release` in the builder stage

Fixes #676.

## Demo proof

Local `cargo build` output (all deps compiled, rpg v0.7.0 finished):
```
   Compiling rpg v0.7.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.15s
```

`cargo fmt --check` passes with no output (clean).

## Test plan

- [ ] CI Docker build passes (the error no longer occurs)
- [ ] `cargo build` succeeds locally with `benches/` present
- [ ] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)