### PR TITLE
chore: remove all legacy 'samo' references, rename to rpg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Renamed project from Samo to Rpg across all source and deploy files (#453)
+- Renamed project to rpg across all source and deploy files (#453)
 - Connector config unified with daemon integration (#481)
 - Per-feature autonomy granularity replaces single global setting (#527)
 - Refactored to explicit Tokio runtime construction (#541)
@@ -116,5 +116,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Internal
 
 - CI connection test suite comparing rpg vs psql output (golden file tests) (#379)
-- Deploy files and scripts renamed from `samo` to `rpg` (#453)
+- Deploy files and scripts updated to rpg naming (#453)
 - Stale infrastructure comments removed (#538)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-# Samo container image — multi-stage, Alpine-based, minimal footprint.
+# rpg container image — multi-stage, Alpine-based, minimal footprint.
 #
 # Build:
-#   docker build -t samo:latest .
+#   docker build -t rpg:latest .
 #
 # Run (connect to host Postgres on macOS/Windows):
 #   docker run --rm \
-#     samo:latest \
+#     rpg:latest \
 #     -h host.docker.internal -p 5432 -U postgres -d postgres \
 #     -c "select 1"
 
@@ -44,11 +44,11 @@ FROM alpine:3.20
 # ca-certificates — needed for TLS connections to Postgres and AI APIs
 # libgcc          — runtime support for Rust/C code on musl Alpine
 RUN apk add --no-cache ca-certificates libgcc && \
-    adduser -D -H -s /sbin/nologin samo
+    adduser -D -H -s /sbin/nologin rpg
 
-COPY --from=builder /build/target/release/samo /usr/local/bin/samo
+COPY --from=builder /build/target/release/rpg /usr/local/bin/rpg
 
-USER samo
+USER rpg
 
-ENTRYPOINT ["samo"]
+ENTRYPOINT ["rpg"]
 CMD ["--help"]

--- a/tests/compat/test-compat.sh
+++ b/tests/compat/test-compat.sh
@@ -3,15 +3,15 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 # ---------------------------------------------------------------------------
-# psql vs samo golden output comparison
+# psql vs rpg golden output comparison
 #
-# Usage: test-compat.sh <path-to-samo-binary>
+# Usage: test-compat.sh <path-to-rpg-binary>
 #
-# Runs the same commands through both psql and samo, diffs the outputs, and
+# Runs the same commands through both psql and rpg, diffs the outputs, and
 # exits non-zero if any comparison fails.
 # ---------------------------------------------------------------------------
 
-SAMO="${1:?Usage: test-compat.sh <samo-binary>}"
+RPG="${1:?Usage: test-compat.sh <rpg-binary>}"
 
 PGHOST="${PGHOST:-localhost}"
 PGPORT="${PGPORT:-5432}"
@@ -54,11 +54,11 @@ normalize() {
 }
 
 # compare DESC CMD
-#   Runs CMD through both psql and samo using -c, diffs the result.
+#   Runs CMD through both psql and rpg using -c, diffs the result.
 compare() {
   local desc="${1}"
   local cmd="${2}"
-  local psql_out samo_out
+  local psql_out rpg_out
 
   psql_out=$(
     psql \
@@ -71,8 +71,8 @@ compare() {
       2>/dev/null | normalize
   ) || true
 
-  samo_out=$(
-    "${SAMO}" \
+  rpg_out=$(
+    "${RPG}" \
       -h "${PGHOST}" \
       -p "${PGPORT}" \
       -U "${PGUSER}" \
@@ -81,29 +81,29 @@ compare() {
       2>/dev/null | normalize
   ) || true
 
-  if [[ "${psql_out}" == "${samo_out}" ]]; then
+  if [[ "${psql_out}" == "${rpg_out}" ]]; then
     echo "PASS: ${desc}"
     (( PASS++ )) || true
   else
     echo "FAIL: ${desc}"
     echo "--- psql ---"
     echo "${psql_out}"
-    echo "--- samo ---"
-    echo "${samo_out}"
+    echo "--- rpg ---"
+    echo "${rpg_out}"
     echo "--- diff ---"
-    diff <(echo "${psql_out}") <(echo "${samo_out}") || true
+    diff <(echo "${psql_out}") <(echo "${rpg_out}") || true
     echo "---"
     (( FAIL++ )) || true
   fi
 }
 
 # compare_flags DESC [ARGS...]
-#   Like compare but passes the given args directly to both psql and samo.
+#   Like compare but passes the given args directly to both psql and rpg.
 #   The caller is responsible for including -c / -f / etc. in the args.
 compare_flags() {
   local desc="${1}"
   shift
-  local psql_out samo_out
+  local psql_out rpg_out
 
   psql_out=$(
     psql \
@@ -116,8 +116,8 @@ compare_flags() {
       2>/dev/null | normalize
   ) || true
 
-  samo_out=$(
-    "${SAMO}" \
+  rpg_out=$(
+    "${RPG}" \
       -h "${PGHOST}" \
       -p "${PGPORT}" \
       -U "${PGUSER}" \
@@ -126,29 +126,29 @@ compare_flags() {
       2>/dev/null | normalize
   ) || true
 
-  if [[ "${psql_out}" == "${samo_out}" ]]; then
+  if [[ "${psql_out}" == "${rpg_out}" ]]; then
     echo "PASS: ${desc}"
     (( PASS++ )) || true
   else
     echo "FAIL: ${desc}"
     echo "--- psql ---"
     echo "${psql_out}"
-    echo "--- samo ---"
-    echo "${samo_out}"
+    echo "--- rpg ---"
+    echo "${rpg_out}"
     echo "--- diff ---"
-    diff <(echo "${psql_out}") <(echo "${samo_out}") || true
+    diff <(echo "${psql_out}") <(echo "${rpg_out}") || true
     echo "---"
     (( FAIL++ )) || true
   fi
 }
 
 # compare_err DESC CMD
-#   Compares stderr output for CMD from both psql and samo.
+#   Compares stderr output for CMD from both psql and rpg.
 #   Used to verify error messages match for intentional bad SQL.
 compare_err() {
   local desc="${1}"
   local cmd="${2}"
-  local psql_out samo_out
+  local psql_out rpg_out
 
   psql_out=$(
     psql \
@@ -161,8 +161,8 @@ compare_err() {
       2>&1 >/dev/null | normalize
   ) || true
 
-  samo_out=$(
-    "${SAMO}" \
+  rpg_out=$(
+    "${RPG}" \
       -h "${PGHOST}" \
       -p "${PGPORT}" \
       -U "${PGUSER}" \
@@ -171,17 +171,17 @@ compare_err() {
       2>&1 >/dev/null | normalize
   ) || true
 
-  if [[ "${psql_out}" == "${samo_out}" ]]; then
+  if [[ "${psql_out}" == "${rpg_out}" ]]; then
     echo "PASS: ${desc}"
     (( PASS++ )) || true
   else
     echo "FAIL: ${desc}"
     echo "--- psql stderr ---"
     echo "${psql_out}"
-    echo "--- samo stderr ---"
-    echo "${samo_out}"
+    echo "--- rpg stderr ---"
+    echo "${rpg_out}"
     echo "--- diff ---"
-    diff <(echo "${psql_out}") <(echo "${samo_out}") || true
+    diff <(echo "${psql_out}") <(echo "${rpg_out}") || true
     echo "---"
     (( FAIL++ )) || true
   fi
@@ -189,19 +189,19 @@ compare_err() {
 
 # compare_file DESC FILE_CMD
 #   Runs FILE_CMD (which uses \o to redirect output to a file) via both
-#   psql and samo, then compares the contents of the two output files.
+#   psql and rpg, then compares the contents of the two output files.
 compare_file() {
   local desc="${1}"
   local cmd="${2}"
-  local psql_file samo_file
+  local psql_file rpg_file
 
   psql_file="${TMPDIR_COMPAT}/psql_$$.txt"
-  samo_file="${TMPDIR_COMPAT}/samo_$$.txt"
+  rpg_file="${TMPDIR_COMPAT}/rpg_$$.txt"
 
   # Replace the placeholder __OUTFILE__ with each tool's output path.
-  local psql_cmd samo_cmd
+  local psql_cmd rpg_cmd
   psql_cmd="${cmd//__OUTFILE__/${psql_file}}"
-  samo_cmd="${cmd//__OUTFILE__/${samo_file}}"
+  rpg_cmd="${cmd//__OUTFILE__/${rpg_file}}"
 
   psql \
     --no-psqlrc \
@@ -212,31 +212,31 @@ compare_file() {
     -c "${psql_cmd}" \
     >/dev/null 2>&1 || true
 
-  "${SAMO}" \
+  "${RPG}" \
     -h "${PGHOST}" \
     -p "${PGPORT}" \
     -U "${PGUSER}" \
     -d "${PGDATABASE}" \
-    -c "${samo_cmd}" \
+    -c "${rpg_cmd}" \
     >/dev/null 2>&1 || true
 
-  local psql_content samo_content
+  local psql_content rpg_content
   psql_content="$(normalize < "${psql_file}" 2>/dev/null || true)"
-  samo_content="$(normalize < "${samo_file}" 2>/dev/null || true)"
+  rpg_content="$(normalize < "${rpg_file}" 2>/dev/null || true)"
 
-  rm -f "${psql_file}" "${samo_file}"
+  rm -f "${psql_file}" "${rpg_file}"
 
-  if [[ "${psql_content}" == "${samo_content}" ]]; then
+  if [[ "${psql_content}" == "${rpg_content}" ]]; then
     echo "PASS: ${desc}"
     (( PASS++ )) || true
   else
     echo "FAIL: ${desc}"
     echo "--- psql file ---"
     echo "${psql_content}"
-    echo "--- samo file ---"
-    echo "${samo_content}"
+    echo "--- rpg file ---"
+    echo "${rpg_content}"
     echo "--- diff ---"
-    diff <(echo "${psql_content}") <(echo "${samo_content}") || true
+    diff <(echo "${psql_content}") <(echo "${rpg_content}") || true
     echo "---"
     (( FAIL++ )) || true
   fi
@@ -257,7 +257,7 @@ psql \
   -f tests/fixtures/schema.sql \
   2>/dev/null || true
 
-echo "=== psql vs samo compatibility tests ==="
+echo "=== psql vs rpg compatibility tests ==="
 echo ""
 
 # ---------------------------------------------------------------------------
@@ -431,7 +431,7 @@ compare_flags "unaligned csv from table" \
 # CLI flag combinations
 # ---------------------------------------------------------------------------
 
-## --json is a samo-specific extension — psql doesn't support it
+## --json is a rpg-specific extension — psql doesn't support it
 # compare_flags "json output" \
 #   --json -c "select 1 as a, 'hello' as b"
 


### PR DESCRIPTION
## Summary

- Replace all occurrences of the old project name `samo` with `rpg` across `Dockerfile`, `tests/compat/test-compat.sh`, and `CHANGELOG.md`
- Docker: update user account, binary path, image tag, and entrypoint from `samo` to `rpg`
- Test script: rename `SAMO` variable to `RPG`, rename `samo_out`/`samo_file`/`samo_cmd`/`samo_content` locals to `rpg_*`, update all output labels and comments
- Changelog: remove old-name references from historical rename entries

## Test plan

- [ ] `cargo build` passes
- [ ] `cargo test` passes (1650 tests)
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)