### PR TITLE
fix(ci): pass CODECOV_TOKEN to reusable checks workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,9 @@ name: Checks
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -235,4 +238,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   checks:
     name: Checks
     uses: ./.github/workflows/checks.yml
+    secrets: inherit
 
   build:
     name: Build (${{ matrix.artifact }})


### PR DESCRIPTION
## Summary

- **Root cause:** GitHub Actions does not automatically pass secrets to reusable workflows called via `workflow_call`. The `Coverage` job in `checks.yml` was receiving an empty token, and Codecov rejected the upload with `"Token required because branch is protected"`.
- Add `secrets: inherit` in `ci.yml` when invoking `checks.yml`, so `CODECOV_TOKEN` is forwarded.
- Declare `CODECOV_TOKEN` in `checks.yml`'s `workflow_call.secrets` block (required to accept inherited secrets).
- Switch `fail_ci_if_error: true` and add `verbose: true` so future upload failures surface as CI failures rather than being silently swallowed.

## Diagnosis evidence (from CI logs)

```
-> Token of length 0 detected
error - Upload failed: {"message":"Token required because branch is protected"}
```

## Test plan

- [ ] CI runs green on this PR
- [ ] After merge, the next push to `main` should show coverage data in Codecov and the badge should change from "unknown" to a percentage

## Copyright

Copyright 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)