### PR TITLE
fix(pager): clear screen after leaving alternate buffer

### DIFF
--- a/src/pager.rs
+++ b/src/pager.rs
@@ -126,6 +126,20 @@ impl Drop for TerminalGuard {
         // the terminal is always restored, including during panics.
         let _ = terminal::disable_raw_mode();
         let _ = execute!(io::stdout(), LeaveAlternateScreen);
+
+        // After returning to the main screen buffer, ghost characters from
+        // prior pager content can bleed into the visible area if the main
+        // buffer still holds old output at those positions.  Move the cursor
+        // to the top-left corner and erase the entire screen so the REPL
+        // always starts from a clean slate.
+        //
+        // \x1b[H  — cursor to home (row 1, col 1)
+        // \x1b[2J — erase entire display
+        // \x1b[H  — cursor back to home so callers position correctly
+        let mut stdout = io::stdout();
+        let _ = stdout.write_all(b"\x1b[H\x1b[2J\x1b[H");
+        let _ = stdout.flush();
+
         // Reset the scroll region on the main screen buffer so the REPL can
         // re-install its own DECSTBM constraint.  Without this the main buffer
         // inherits whatever scroll region was set before the pager launched,


### PR DESCRIPTION
## Summary

- Ghost characters from prior pager content bled into the visible area after pressing `q` to exit the built-in TUI pager
- Root cause: `TerminalGuard::drop` called `LeaveAlternateScreen` but did not clear the main screen buffer before returning to the REPL
- Fix: emit cursor-home (`\x1b[H`) + erase-entire-display (`\x1b[2J`) immediately after `LeaveAlternateScreen` in `TerminalGuard::drop`, giving the REPL a clean slate every time the pager exits

## Demo proof

Tested in a 130x40 tmux window with `PGDATABASE=demo_saas`:

**During pager** (`\?` triggered pager):
```
rpg 0.7.0 (4b8ccb5, built 2026-03-20)

Backslash commands:
  \q              quit rpg
  ...
 Lines 1-39 of 93 (0%) — q:quit ↑↓:scroll PgUp/PgDn:page /:search f:freeze
```

**After pressing `q`** — clean screen, no ghost characters:
```
demo_saas=#     ← prompt at top, no bleed-through content below

 /tmp:5432/demo_saas │ SQL │ tx:idle   ← status bar at bottom
```

All 1668 unit tests pass.

## Test plan

- [ ] Run `\?` (or any query that triggers the built-in pager)
- [ ] Press `q` to exit
- [ ] Verify no ghost characters appear below the prompt
- [ ] Run a query to confirm the REPL works normally after pager exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)