### PR TITLE
fix(ai): reset TxState to Idle after /ask read-only tx

### DIFF
--- a/src/repl/ai_commands.rs
+++ b/src/repl/ai_commands.rs
@@ -908,7 +908,15 @@ pub(super) async fn handle_ai_ask(
                                 // Roll back on error to leave the session
                                 // clean.
                                 let _ = client.simple_query("rollback").await;
-                                *tx = TxState::Idle;
+                            }
+                            // The wrapped query ends with `commit;` (or was
+                            // rolled back above) so the session is always idle
+                            // at this point regardless of outcome.
+                            // update_from_sql() only saw `start transaction`
+                            // and set InTransaction; correct it here.
+                            *tx = TxState::Idle;
+                            if let Some(ref mut sl) = settings.statusline {
+                                sl.set_tx_state(TxState::Idle);
                             }
                             // Clear the internal-tx flag — the transaction
                             // has been committed or rolled back.
@@ -958,7 +966,15 @@ pub(super) async fn handle_ai_ask(
                                     .await;
                                     if !ok {
                                         let _ = client.simple_query("rollback").await;
-                                        *tx = TxState::Idle;
+                                    }
+                                    // The wrapped query ends with `commit;` (or
+                                    // was rolled back above) so the session is
+                                    // always idle at this point.
+                                    // update_from_sql() only saw `start
+                                    // transaction`; correct it here.
+                                    *tx = TxState::Idle;
+                                    if let Some(ref mut sl) = settings.statusline {
+                                        sl.set_tx_state(TxState::Idle);
                                     }
                                     settings.internal_tx = false;
                                     ok

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -97,6 +97,16 @@ impl StatusLine {
         self.render();
     }
 
+    /// Correct the displayed transaction state and re-render.
+    ///
+    /// Used when the REPL knows the true server-side state differs from what
+    /// the last `update()` recorded (e.g. after an internal read-only
+    /// transaction whose trailing `commit;` is invisible to `update_from_sql`).
+    pub fn set_tx_state(&mut self, state: TxState) {
+        self.tx_state = state;
+        self.render();
+    }
+
     /// Set the current auto-EXPLAIN level and re-render.
     pub fn set_auto_explain(&mut self, mode: AutoExplain) {
         self.auto_explain = mode;


### PR DESCRIPTION
## Bug

After `/ask` executes a query wrapped in `start transaction read only; ...; commit;`, `update_from_sql()` only parses the leading `start transaction` keywords and sets `TxState::InTransaction`. The trailing `commit;` is never processed, leaving the prompt stuck at `=*#` (in-transaction) even though the DB session is idle.

Root cause: `update_from_sql()` only looks at the first 3 words of the SQL string and cannot parse a multi-statement batch.

## Fix

In `src/repl/ai_commands.rs`, after `execute_query_interactive` returns for the wrapped `/ask` read-only query:

- **Both `AskChoice::Yes` and `AskChoice::Edit` paths**: unconditionally set `*tx = TxState::Idle` after the call returns (success or error/rollback — both leave the session idle)
- Also call the new `StatusLine::set_tx_state(TxState::Idle)` so the status bar is corrected immediately (not just the prompt)
- Added `StatusLine::set_tx_state()` helper in `src/statusline.rs`

## Demo proof

Before fix: prompt showed `=*#` and statusline showed `tx:in-tx` after `/ask`.

After fix (captured from tmux):
```
demo_saas=# /ask how many customers are on the free plan
To find out how many customers are on the free plan, you can run the following SQL query:
SELECT COUNT(*) AS free_plan_customers
FROM customers
WHERE plan = 'free';
 free_plan_customers
---------------------
                1662
(1 row)

demo_saas=#
 /tmp:5432/demo_saas │ SQL │ tx:idle │ last: 2ms │ ai: 384/0tok

demo_saas=# /ask top 5 customers by order count
   id |     name     | order_count
------+--------------+-------------
 4047 | Mia Thompson |         258
 9318 | Xander Moore |         252
 1757 | Beth Lee     |         251
 5408 | Henry Jones  |         250
 6159 | Henry Moore  |         248
(5 rows)

demo_saas=#
 /tmp:5432/demo_saas │ SQL │ tx:idle │ last: 128ms │ ai: 890/0tok
```

Prompt shows `=#` (not `=*#`) and statusline shows `tx:idle` after both `/ask` commands.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 1668 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Manual: `/ask how many customers are on the free plan` → prompt `=#`, statusline `tx:idle`
- [x] Manual: `/ask top 5 customers by order count` → prompt `=#`, statusline `tx:idle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)