### PR TITLE
fix(ci): add codecov.yml and workflow_dispatch to fix badge unknown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,41 @@
+# Copyright 2026
+# Codecov configuration for NikolayS/rpg.
+#
+# Key goal: prevent the badge from showing "unknown" when Codecov's
+# processing queue is slow or when a commit only touches non-code files.
+# We achieve this via carryforward: true on the default flag so Codecov
+# reuses coverage data from the last successful upload when no new
+# report has been processed for the HEAD commit yet.
+#
+# https://docs.codecov.com/docs/carryforward-flags
+
+codecov:
+  notify:
+    after_n_builds: 1
+
+coverage:
+  precision: 2
+  round: nearest
+  range: "50...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        # If the commit has no coverage report yet, do not mark as failed.
+        if_not_found: success
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        if_not_found: success
+
+flags:
+  unit:
+    carryforward: true
+
+ignore:
+  - "benches/**"
+  - "tests/**"
+  - "examples/**"
+  - "demos/**"


### PR DESCRIPTION
## Root cause analysis

The Codecov badge started showing \"unknown\" after PR #679 (which correctly fixed the token issue). The diagnosis reveals **two compounding problems**:

### Problem 1: Codecov backend processing failure (transient)

All three recent commits on main (`e066f1`, `b9b339`, `bf55513`) have uploads that **succeeded** (HTTP 200, `Process Upload complete`) but Codecov's worker never ingested them into its database. Evidence:

- Codecov API returns `"state": null, "totals": null` for these commits
- The last successfully processed commit is `c06779` at 18:58 UTC
- All uploads after 18:58 UTC sit in GCS `shelter/github/NikolayS:::rpg/` but are unprocessed
- Codecov API is returning 503 at time of investigation, confirming a backend issue

The uploads themselves are working correctly — this is a Codecov-side processing outage.

### Problem 2: No way to manually re-trigger CI

Without `workflow_dispatch`, there is no way to re-run the Coverage job after Codecov recovers, without making an empty code push.

## Changes

- **`codecov.yml`** — new config file:
  - `carryforward: true` on the `unit` flag: Codecov reuses coverage from the last successful commit when a new report hasn't been processed yet (prevents badge going to "unknown" during delays)
  - `if_not_found: success` on project/patch status: prevents CI status from failing when Codecov hasn't processed the commit yet
  - `ignore` list for non-code directories
- **`.github/workflows/ci.yml`** — add `workflow_dispatch` trigger so the full CI (including Coverage) can be manually re-run once Codecov's processing queue recovers

## What to do after merge

Once this PR is merged, go to the Actions tab and manually trigger the CI workflow (`workflow_dispatch`) to re-upload coverage for the new HEAD commit. This should populate Codecov and fix the badge.

**If Codecov is still down**, the badge will remain "unknown" until Codecov recovers. After recovery, Codecov may retroactively process the queued uploads from GCS, or a new manual trigger will be needed.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, manually trigger CI via Actions tab → the Coverage job uploads coverage
- [ ] Codecov badge changes from "unknown" to a percentage

Copyright 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)