### PR TITLE
fix(repl): correct double backslash in \? help and tab completion

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -480,6 +480,30 @@ const BACKSLASH_CMDS: &[&str] = &[
     "watch",
     "x",
     "z",
+    // rpg-specific commands
+    "version",
+    "explain",
+    "commands",
+    "text2sql",
+    "t2s",
+    "plan",
+    "yolo",
+    "interactive",
+    "mode",
+    "sql",
+    "n",
+    "ns",
+    "nd",
+    "np",
+    "profiles",
+    "dba",
+    "f2",
+    "f3",
+    "f4",
+    "f5",
+    "refresh",
+    "session",
+    "log-file",
 ];
 
 // ---------------------------------------------------------------------------
@@ -1163,11 +1187,18 @@ impl Completer for RpgHelper {
 
         // For schema-qualified or dot-preceded words, the replacement should
         // start after the dot, not at the beginning of the whole word.
+        // For backslash commands, the replacement starts after the `\` so
+        // that the leading backslash is preserved and only the command name
+        // portion is replaced (e.g., `\vers` → keeps `\`, replaces `vers`
+        // with `version`).
         let (completion_start, completion_prefix) =
             if let CompletionContext::SchemaObject { ref schema } = context {
                 // "public.us" → start after the dot
                 let dot_offset = start + schema.len() + 1;
                 (dot_offset, prefix[schema.len() + 1..].to_owned())
+            } else if context == CompletionContext::BackslashCmd && prefix.starts_with('\\') {
+                // "\vers" → start after the backslash, prefix = "vers"
+                (start + 1, prefix[1..].to_owned())
             } else {
                 (start, prefix.clone())
             };

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1743,25 +1743,34 @@ Input/execution modes:
   \yolo             YOLO mode: auto-enable text2sql, hide SQL box, auto-execute
   \interactive      return to interactive mode (default)
   \mode             show current input and execution mode
-  \\set TEXT2SQL_SHOW_SQL on/off   show/hide SQL preview box in text2sql mode
+  \set TEXT2SQL_SHOW_SQL on/off   show/hide SQL preview box in text2sql mode
 
 Auto-EXPLAIN:
-  \\set EXPLAIN on       show EXPLAIN for every query
-  \\set EXPLAIN analyze  show EXPLAIN ANALYZE for every query
-  \\set EXPLAIN verbose  show EXPLAIN (ANALYZE, VERBOSE, BUFFERS, TIMING)
-  \\set EXPLAIN off      disable auto-EXPLAIN
+  \set EXPLAIN on       show EXPLAIN for every query
+  \set EXPLAIN analyze  show EXPLAIN ANALYZE for every query
+  \set EXPLAIN verbose  show EXPLAIN (ANALYZE, VERBOSE, BUFFERS, TIMING)
+  \set EXPLAIN off      disable auto-EXPLAIN
 
 EXPLAIN sharing:
-  \\explain share depesz    upload last EXPLAIN plan to explain.depesz.com
-  \\explain share dalibo    upload last EXPLAIN plan to explain.dalibo.com
-  \\explain share pgmustard upload last EXPLAIN plan to app.pgmustard.com
-                            (requires PGMUSTARD_API_KEY env var or config)
+  \explain share depesz    upload last EXPLAIN plan to explain.depesz.com
+  \explain share dalibo    upload last EXPLAIN plan to explain.dalibo.com
+  \explain share pgmustard upload last EXPLAIN plan to app.pgmustard.com
+                           (requires PGMUSTARD_API_KEY env var or config)
+
+Output format:
+  \pset format markdown       switch output to Markdown table format
+  \pset explain_format raw     show raw EXPLAIN text (default)
+  \pset explain_format enhanced show EXPLAIN with visual highlights
+  \pset explain_format compact  show compact EXPLAIN summary
+
+Lua commands:
+  \commands         list custom Lua meta-commands (if any are configured)
 
 Function keys (interactive mode):
-  F2 / \\f2       toggle schema-aware tab completion on/off
-  F3 / \\f3       toggle single-line mode on/off
-  F4 / \\f4       toggle Vi/Emacs editing mode (next session)
-  F5 / \\f5       toggle auto-EXPLAIN on/off
+  F2 / \f2       toggle schema-aware tab completion on/off
+  F3 / \f3       toggle single-line mode on/off
+  F4 / \f4       toggle Vi/Emacs editing mode (next session)
+  F5 / \f5       toggle auto-EXPLAIN on/off
   Ctrl-T          toggle SQL/text2sql input mode"
     )
 }


### PR DESCRIPTION
## Summary

- **Bug 1 — double backslash in `\?` help**: The `help_text()` function used a raw string `r"..."` where `\\set`, `\\explain`, `\\f2`–`\\f5` are two literal backslash characters, causing the terminal to display `\\set` instead of `\set`. Fixed all affected lines in the raw string to use single `\`.

- **Bug 2 — tab completion for rpg-specific commands**: `\version`, `\explain`, `\commands`, `\text2sql`, `\t2s`, `\plan`, `\yolo`, `\interactive`, `\mode`, `\sql`, `\n`/`\ns`/`\nd`/`\np`, `\profiles`, `\dba`, `\f2`–`\f5`, `\refresh`, `\session`, `\log-file` were missing from `BACKSLASH_CMDS` in `src/complete.rs`. Added all of them.

- **Bug 3 — backslash prefix in completion logic**: The `BackslashCmd` completion path passed the full `\vers` (including the leading `\`) to `fuzzy_match()`, which tried to match `\` as a character in candidate names and always failed. Fixed by stripping the leading `\` from the completion prefix (similar to how `SchemaObject` strips the `.`), and setting `completion_start` to 1 past the `\` so rustyline replaces only the command name portion.

- **Missing `\?` entries**: Added `\pset format markdown`, `\pset explain_format raw/enhanced/compact`, and `\commands` sections to the help text.

## Demo

`\?` output (no double backslashes):
```
Input/execution modes:
  \sql              switch to SQL input mode (default)
  \text2sql / \t2s  switch to text2sql input mode
  ...
  \set TEXT2SQL_SHOW_SQL on/off   show/hide SQL preview box in text2sql mode

Auto-EXPLAIN:
  \set EXPLAIN on       show EXPLAIN for every query
  ...

EXPLAIN sharing:
  \explain share depesz    upload last EXPLAIN plan to explain.depesz.com
  ...

Function keys (interactive mode):
  F2 / \f2       toggle schema-aware tab completion on/off
```

Tab completion:
- `\versio<TAB>` → `\version` (unique match completes inline)
- `\vers<TAB>` → shows `version errverbose` dropdown candidates
- `\expl<TAB>` → `\explain`

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — 1687 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `\?` output verified in tmux — no double backslashes anywhere
- [x] `\versio<TAB>` completes to `\version`
- [x] `\expl<TAB>` completes to `\explain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)