### PR TITLE
fix(main): suppress config messages in non-interactive mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -641,13 +641,20 @@ async fn async_main() {
     let project_result = config::load_project_config();
     let cfg = config::merge_project_config(base_cfg, &project_result.config);
 
-    // Print project config startup messages (suppressed by --quiet).
-    if !cli.quiet {
-        if let Some(ref p) = project_result.config_path {
-            eprintln!("Using project config: {}", p.display());
-        }
-        if let Some(ref p) = project_result.postgres_md_path {
-            eprintln!("Loaded project context: {}", p.display());
+    // Print project config startup messages only in interactive mode.
+    // Suppress when: --quiet, -c/-f scripting flags, or stdin is not a TTY.
+    {
+        use std::io::IsTerminal;
+        let is_scripting = !cli.command.is_empty() || cli.file.is_some();
+        let is_piped = !cli.interactive && !std::io::stdin().is_terminal();
+        let show = !cli.quiet && !is_scripting && !is_piped;
+        if show {
+            if let Some(ref p) = project_result.config_path {
+                eprintln!("Using project config: {}", p.display());
+            }
+            if let Some(ref p) = project_result.postgres_md_path {
+                eprintln!("Loaded project context: {}", p.display());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- `"Using project config"` and `"Loaded project context"` startup messages now only print during interactive REPL sessions (stdin is a TTY and no `-c`/`-f` flags)
- Already on stderr (`eprintln!`), now also gated on `!is_scripting && !is_piped`
- Suppressed by `-q`/`--quiet` as before
- Mirrors the same `is_scripting`/`is_piped` logic used for the version banner

Fixes #691.

## Demo proof

**Before (broken):**
```
$ rpg -d demo_saas -c 'select now()' --markdown
Using project config: /Users/nik/tmp/project-alpha/.rpg.toml
Loaded project context: /Users/nik/tmp/project-alpha/POSTGRES.md
| now                           |
...
```

**After (fixed):**
```
$ ./target/debug/rpg -d demo_saas -c 'select now()' --markdown
| now                           |
|-------------------------------|
| 2026-03-20 14:41:59.723039-07 |
(1 row)
```

Messages still appear in interactive sessions (TTY, no `-c`/`-f`).

## Test plan

- [x] `cargo build` — passes
- [x] `cargo fmt --check` — passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes
- [x] `cargo test` — 1687 tests pass
- [x] `rpg -d demo_saas -c 'select 1'` — no config messages in output
- [x] `rpg -d demo_saas -c 'select now()' --markdown` — clean markdown output

🤖 Generated with [Claude Code](https://claude.com/claude-code)