### PR TITLE
feat(repl): implement \s command for history display and save

### DIFF
--- a/src/metacmd.rs
+++ b/src/metacmd.rs
@@ -368,6 +368,23 @@ pub enum MetaCmd {
     /// `~/.config/rpg/commands/*.lua`.
     ListCustomCommands,
 
+    // -- History (#history) ------------------------------------------------
+    /// `\s [filename | pattern]` — display or save command history.
+    ///
+    /// Behaviour:
+    /// - `\s` — display numbered history on screen (through pager).
+    /// - `\s filename` — save history to a file (path contains `/` or `.`
+    ///   or starts with `~`; or the argument has a file extension).
+    /// - `\s pattern` — filter and display history entries that contain
+    ///   the pattern (case-insensitive grep-like search).
+    ///
+    /// Unlike plain psql, rpg numbers entries and applies SQL syntax
+    /// highlighting when writing to the screen.
+    ///
+    /// The argument is `None` for bare `\s`; otherwise it carries the raw
+    /// argument string (filename or pattern).
+    History(Option<String>),
+
     // -- Fallback ----------------------------------------------------------
     /// Unrecognised command; carries the original command token.
     Unknown(String),
@@ -561,7 +578,7 @@ fn parse_simple_or_unknown(input: &str, token: &str, cmd: MetaCmd) -> ParsedMeta
     }
 }
 
-/// Dispatch `s`-family commands: `\set`, `\sf`, `\sv`, `\session`.
+/// Dispatch `s`-family commands: `\s`, `\set`, `\sf`, `\sv`, `\session`.
 fn parse_s_family(input: &str) -> ParsedMeta {
     // \sql — switch to SQL mode (check before \set)
     if let Some(rest) = input.strip_prefix("sql") {
@@ -579,6 +596,17 @@ fn parse_s_family(input: &str) -> ParsedMeta {
         if after.is_empty() || after.starts_with(char::is_whitespace) {
             return parse_set(input);
         }
+    }
+    // \s [filename | pattern] — show/save/filter history.
+    // Must be checked after the longer prefixes above (sql, session, set,
+    // sf, sv) so those still match.
+    if input == "s" || input.starts_with("s ") || input.starts_with("s\t") {
+        let arg = input.strip_prefix("s").unwrap_or("").trim();
+        return ParsedMeta::simple(MetaCmd::History(if arg.is_empty() {
+            None
+        } else {
+            Some(arg.to_owned())
+        }));
     }
     parse_sf_sv(input)
 }
@@ -3737,5 +3765,62 @@ mod tests {
     fn parse_commands_not_confused_with_c_reconnect() {
         // Bare `\c` must still be Reconnect.
         assert_eq!(parse("\\c").cmd, MetaCmd::Reconnect);
+    }
+
+    // -- History (#history) -------------------------------------------------
+
+    #[test]
+    fn parse_history_bare() {
+        // Bare `\s` — show all history.
+        assert_eq!(parse("\\s").cmd, MetaCmd::History(None));
+    }
+
+    #[test]
+    fn parse_history_with_filename() {
+        // `\s /tmp/history.txt` — save to file.
+        assert_eq!(
+            parse("\\s /tmp/history.txt").cmd,
+            MetaCmd::History(Some("/tmp/history.txt".to_owned()))
+        );
+    }
+
+    #[test]
+    fn parse_history_with_pattern() {
+        // `\s orders` — filter history by pattern.
+        assert_eq!(
+            parse("\\s orders").cmd,
+            MetaCmd::History(Some("orders".to_owned()))
+        );
+    }
+
+    #[test]
+    fn parse_history_not_confused_with_set() {
+        // `\set` must not match `\s`.
+        let m = parse("\\set FOO bar");
+        assert_eq!(m.cmd, MetaCmd::Set("FOO".to_owned(), "bar".to_owned()));
+    }
+
+    #[test]
+    fn parse_history_not_confused_with_session() {
+        // `\session` must not match `\s`.
+        assert_eq!(parse("\\session").cmd, MetaCmd::SessionList);
+    }
+
+    #[test]
+    fn parse_history_not_confused_with_sql_mode() {
+        // `\sql` must not match `\s`.
+        assert_eq!(parse("\\sql").cmd, MetaCmd::SqlMode);
+    }
+
+    #[test]
+    fn parse_history_not_confused_with_sf() {
+        // `\sf` must not match `\s`.
+        assert_eq!(parse("\\sf myfunc").cmd, MetaCmd::ShowFunctionSource);
+    }
+
+    #[test]
+    fn parse_history_not_confused_with_sv() {
+        // `\sv` must not match `\s`.
+        assert_eq!(parse("\\sv myview").cmd, MetaCmd::ShowViewDef);
     }
 }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1681,6 +1681,7 @@ Backslash commands:
   \copyright      show rpg copyright information
   \version        show rpg version and build information
   \?              show this help
+  \s [file|pattern]    show history (numbered + highlighted); save to file or filter by pattern
 
 Session commands:
   \c [db [user [host [port]]]]  reconnect to database
@@ -3575,12 +3576,145 @@ async fn dispatch_meta(
             let loid = loid.clone();
             crate::large_object::lo_unlink(client, &loid).await;
         }
+        // History (#history).
+        MetaCmd::History(ref arg) => {
+            dispatch_history(settings, arg.as_deref());
+        }
         ref stub => {
             eprintln!("{}: not yet implemented (see #27)", stub.label());
         }
     }
 
     MetaResult::Continue
+}
+
+// ---------------------------------------------------------------------------
+// History command helper (#history)
+// ---------------------------------------------------------------------------
+
+/// Decide whether `arg` looks like a file path (save mode) or a pattern
+/// (filter mode).
+///
+/// A path heuristic: contains `/`, starts with `.` or `~`, or contains a `.`
+/// after the last `/` (has a file extension).  Everything else is a pattern.
+fn arg_is_filepath(arg: &str) -> bool {
+    if arg.contains('/') {
+        return true;
+    }
+    if arg.starts_with('~') || arg.starts_with('.') {
+        return true;
+    }
+    // Has a file extension (a dot somewhere in the last component).
+    arg.contains('.')
+}
+
+/// Read history entries from the history file.
+///
+/// Returns a `Vec` of history lines in chronological order (oldest first).
+/// Returns an empty `Vec` when the file cannot be read.
+fn read_history_entries() -> Vec<String> {
+    let Some(path) = history_file() else {
+        return Vec::new();
+    };
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Handle `\s [filename | pattern]`.
+///
+/// - `\s` — display numbered, syntax-highlighted history through the pager.
+/// - `\s filename` — save raw history to a file.
+/// - `\s pattern` — filter history by substring (case-insensitive) and
+///   display through the pager.
+fn dispatch_history(settings: &mut ReplSettings, arg: Option<&str>) {
+    use std::fmt::Write as FmtWrite;
+
+    let entries = read_history_entries();
+
+    match arg {
+        // ---- Save to file ------------------------------------------------
+        Some(path) if arg_is_filepath(path) => {
+            // Expand leading `~`.
+            let resolved = if let Some(rest) = path.strip_prefix("~/") {
+                if let Some(home) = dirs::home_dir() {
+                    home.join(rest)
+                } else {
+                    std::path::PathBuf::from(path)
+                }
+            } else {
+                std::path::PathBuf::from(path)
+            };
+
+            match std::fs::write(&resolved, entries.join("\n") + "\n") {
+                Ok(()) => {
+                    if !settings.quiet {
+                        eprintln!("History saved to {}.", resolved.display());
+                    }
+                }
+                Err(e) => eprintln!("\\s: {e}"),
+            }
+        }
+
+        // ---- Filter by pattern (or show all) -----------------------------
+        arg => {
+            let pattern = arg.map(str::to_lowercase);
+            let filtered: Vec<(usize, &str)> = entries
+                .iter()
+                .enumerate()
+                .filter(|(_, entry)| {
+                    pattern
+                        .as_deref()
+                        .is_none_or(|p| entry.to_lowercase().contains(p))
+                })
+                .map(|(i, entry)| (i + 1, entry.as_str()))
+                .collect();
+
+            if filtered.is_empty() {
+                if let Some(ref p) = pattern {
+                    eprintln!("\\s: no history entries match \"{p}\"");
+                } else {
+                    eprintln!("\\s: history is empty");
+                }
+                return;
+            }
+
+            // Width of the highest line number for alignment.
+            let num_width = filtered.last().map(|(n, _)| n).copied().unwrap_or(1);
+            let width = num_width.to_string().len();
+
+            let use_color = !settings.no_highlight
+                && std::env::var("TERM").as_deref() != Ok("dumb")
+                && std::io::stdout().is_terminal();
+
+            let mut out = String::new();
+            for (num, entry) in &filtered {
+                let highlighted = if use_color && !entry.starts_with('\\') {
+                    crate::highlight::highlight_sql(entry, None).into_owned()
+                } else {
+                    (*entry).to_owned()
+                };
+                let _ = writeln!(out, "{num:>width$}  {highlighted}");
+            }
+
+            if let Some(ref p) = pattern {
+                let total = entries.len();
+                let shown = filtered.len();
+                let _ = writeln!(
+                    out,
+                    "-- {shown} of {total} entr{} match \"{p}\"",
+                    if shown == 1 { "y" } else { "ies" }
+                );
+            }
+
+            maybe_page(settings, &out);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds psql-compatible `\s` meta-command with enhanced capabilities beyond plain psql
- `\s` — displays numbered, syntax-highlighted history through the pager
- `\s filename` — saves raw history to a file (heuristic: path contains `/`, `.`, `~`, or has a file extension)
- `\s pattern` — grep-like case-insensitive filter with match summary (e.g. `\s orders` shows only queries containing "orders")

## What makes this better than psql's `\s`

- **Numbered entries** — each line shows its history number for easy reference
- **Syntax highlighting** — SQL keywords are highlighted when written to screen
- **Pattern filtering** — `\s pattern` filters history inline without needing external grep
- **Match summary** — filter results show `-- N of M entries match "pattern"`
- **Pager integration** — long history routes through the existing `maybe_page` pager

## Implementation notes

- Reads from the history file (`~/.rpg_history` or `$PSQL_HISTORY`) rather than from the in-memory `rustyline::Editor`, so it works from any dispatch path without needing to pass the editor reference through the call chain
- New `MetaCmd::History(Option<String>)` variant in `metacmd.rs`
- Parser added to `parse_s_family` — handled before `\sf`/`\sv` to avoid prefix conflicts, but after the longer prefixes (`\sql`, `\session`, `\set`)
- Handler `dispatch_history` and helper `read_history_entries` / `arg_is_filepath` added in `repl/mod.rs`
- `\s` already present in `BACKSLASH_CMDS` tab-completion array in `complete.rs`
- Help text updated in `\?`

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (1695 tests, 8 new unit tests for parser)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Manual: `\s` shows numbered history
- [x] Manual: `\s /tmp/saved_history.txt` saves to file
- [x] Manual: `\s orders` filters to matching entries with summary
- [x] Manual: `\s nonexistent` shows "no entries match" message
- [x] Manual: empty history shows "history is empty" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)