### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "rpg"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpg"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Modern Postgres terminal with built-in diagnostics and AI assistant"


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` version from 0.7.0 to 0.8.0 for the v0.8.0 release

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (1695 tests, 0 failures)
- [x] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)