### PR TITLE
fix(connection): scan for any .s.PGSQL.<port> socket, not just 5432

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -359,7 +359,7 @@ impl Default for ConnParams {
 /// Return the default `(host, port)` pair for a Unix socket connection.
 ///
 /// On Unix, scans well-known socket directories (`/var/run/postgresql`,
-/// `/tmp`) for PostgreSQL Unix-domain socket files (`.s.PGSQL.<port>`).
+/// `/tmp`) for `PostgreSQL` Unix-domain socket files (`.s.PGSQL.<port>`).
 ///
 /// - **Fast path**: checks port 5432 first (O(1)) for libpq compatibility.
 /// - **Slow path**: scans the directory for any `.s.PGSQL.<N>` socket and


### PR DESCRIPTION
## Problem

B1 audit test fails: when `rpg` is invoked with no host/port and a Postgres socket exists in `/tmp` at a non-standard port (e.g. `/tmp/.s.PGSQL.5437`), `default_host()` (now `default_host_port()`) only checked for `.s.PGSQL.5432` — hardcoded — and fell back to `localhost:5432` (connection refused).

## Fix

Replace `default_host() -> String` with `default_host_port() -> (String, u16)`:

1. **Fast path**: check for `.s.PGSQL.5432` first (libpq-compatible, O(1))
2. **Slow path**: if not found, scan the directory for any `.s.PGSQL.<N>` socket file, excluding `.lock` files, and return the first valid one with its port number

Both `resolve_host()` and `resolve_port()` updated to use `default_host_port()` as their fallback.

## Tests

- 1702 unit tests pass
- All 16 B1/connection audit tests pass locally (including B1: `rpg -c 'SHOW port'` → connects via socket at port 5437)
- `test_defaults` updated to assert against `default_host_port()` result rather than hardcoded 5432 (environment-aware)

Fixes B1 audit test.