### PR TITLE
refactor(connection): delegate URI parsing to tokio_postgres::Config

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1056,8 +1056,6 @@ fn parse_uri(uri: &str) -> Result<UriParams, ConnectionError> {
                 TokioHost::Tcp(s) => s.clone(),
                 #[cfg(unix)]
                 TokioHost::Unix(p) => p.to_string_lossy().into_owned(),
-                #[cfg(not(unix))]
-                _ => String::new(),
             };
             host_list.push((host_str, port_for(i)));
         }


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `parse_uri()` implementation with delegation to `tokio_postgres::Config::from_str()`.

## Motivation

The custom URI parser had a bug (C5 from the #709 audit): `host=` and `port=` in the URI query string fell through a `_ => {}` catch-all and were silently discarded. Rather than patch individual params, this replaces the parser wholesale with the battle-tested tokio-postgres implementation.

## What changes

**New helpers:**
- `extract_ssl_file_params()` — extracts `sslcert`, `sslkey`, `sslrootcert` from URI or connstring. These are the only params tokio-postgres omits (it delegates TLS entirely to the caller).
- `sanitize_uri_for_tokio()` — strips/rewrites params tokio-postgres doesn't recognise (`sslcert`, `sslkey`, `sslrootcert`) and maps rpg-extended `sslmode`/`target_session_attrs` values to accepted equivalents before parsing.

**`parse_uri()` internals replaced:**
- Delegates to `tokio_postgres::Config::from_str()` on the sanitized URI
- Reconstructs `UriParams` from the parsed `Config`
- Captures rpg-extended `sslmode` / `target_session_attrs` values from the raw URI before sanitization

**UriParams struct and all `resolve_*` callers: unchanged.**

## Bug fixed

C5 (#709): `postgres://host/db?host=socket_dir&port=5433` — the query-string `host` and `port` params were silently dropped by the old parser. tokio-postgres handles these correctly.

## Behavior change

Multi-host URI port assignment now matches real libpq behavior: a host without an explicit port gets the default (5432), not the last explicitly-seen port. Verified with psql: `postgresql://localhost:5432,localhost:5433,localhost/postgres` tries the third host on port 5432. Test updated accordingly.

## Tests

1702/1702 unit tests pass. Existing `parse_uri` test coverage exercises the refactored path.

Closes #709 (C5 item).