### PR TITLE
chore: bump version to 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.3] - 2026-03-24
+
+### Fixed
+
+- **URI query-string `host=` and `port=` parameters now respected.** Previously, passing `postgres://ignored:9999/db?host=localhost&port=5433` would silently discard the query-string overrides and attempt to connect to `ignored:9999`. The internal URI parser has been replaced with delegation to `tokio_postgres::Config::from_str()`, which handles all standard libpq parameters correctly. (#731)
+- **Default socket detection now finds any `.s.PGSQL.<port>` socket**, not only port 5432. `default_host_port()` scans well-known socket directories for any PostgreSQL socket file and returns the lowest-numbered port found, with port 5432 fast-pathed for the common case. (#728)
+- **Integration tests** for the full connection path matrix (groups A–G from issue #709). (#730)
+
 ## [0.8.1] - 2026-03-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "rpg"
-version = "0.8.1"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpg"
-version = "0.8.1"
+version = "0.8.3"
 edition = "2021"
 rust-version = "1.82"
 description = "Modern Postgres terminal with built-in diagnostics and AI assistant"


### PR DESCRIPTION
Version bump for v0.8.3 release.

Changes since v0.8.2:
- #731 fix(connection): delegate URI parsing to tokio_postgres::Config (fixes C5 — host=/port= query params silently dropped)
- #728 fix(connection): scan for any .s.PGSQL.<port> socket, not just 5432
- #730 test(connection): 26 integration tests for connection path matrix (#709)