### PR TITLE
test(connection): fill #709 matrix gaps — B3/B4, C6-C8, E6-E9, F4-F7, G3/G4

### DIFF
--- a/tests/connection_paths.rs
+++ b/tests/connection_paths.rs
@@ -1186,15 +1186,14 @@ fn e8_pgpassfile_env() {
     let dir = tempfile::tempdir().expect("e8: failed to create tempdir");
     let pgpass = dir.path().join(".pgpass");
 
-    // Wildcard entry so it matches any database/user on the trust instance.
-    // Trust auth ignores the password, so any value works.
+    // Write the correct password (from env or default) to .pgpass.
+    // The point of the test is that PGPASSFILE is read; we need a valid
+    // password here so password-auth servers (SCRAM in CI) also succeed.
     let host = trust_host();
     let port = trust_port();
-    std::fs::write(
-        &pgpass,
-        format!("{host}:{port}:*:*:pgpassword_test_value\n"),
-    )
-    .expect("e8: failed to write .pgpass");
+    let password = trust_password().unwrap_or_default();
+    std::fs::write(&pgpass, format!("{host}:{port}:*:*:{password}\n"))
+        .expect("e8: failed to write .pgpass");
 
     // chmod 600 — libpq ignores .pgpass files that are world-readable
     #[cfg(unix)]


### PR DESCRIPTION
## What

Adds 15 new integration tests to `tests/connection_paths.rs` covering cases from the #709 audit matrix that were not previously in CI.

## New tests

| Test | Group | What it checks |
|------|-------|----------------|
| B3 | Socket error paths | No socket in dir — clean error, no panic |
| B4 | Socket error paths | Socket exists, wrong user — auth error, no panic |
| C6 | URI edge cases | Non-numeric port in URI — parse error |
| C7 | URI edge cases | `?port=` query param regression guard (C5 fix, PR #731) |
| C8 | URI edge cases | `?host=` query param ignores authority host |
| E6 | Env vars | `PGSSLMODE=disable` suppresses TLS (ssl=f in pg_stat_ssl) |
| E7 | Env vars | `PGDATABASE` from env, no `-d` flag |
| E8 | Env vars | `PGPASSFILE` reads .pgpass file |
| E9 | Env vars | `PGCONNECT_TIMEOUT` — elapsed documented; issue #723 noted inline |
| F4 | Error quality | Error includes database name |
| F5 | Error quality | Error includes user name |
| F6 | Error quality | Error includes host on connection refused |
| F7 | Error quality | Multi-host comma-separated — canary for #724; no-panic check |
| G3 | Auth | Wrong SCRAM password — clear error, no panic |
| G4 | Auth | `PGPASSWORD` takes precedence over `PGPASSFILE` |

## Notes

- F7 is a **canary test for issue #724** (multi-host not yet implemented). It currently only checks for no-panic; once #724 is fixed the assertion should be tightened to `assert_eq!(code, 0)`.
- E9 documents the known issue #723 (timeout is ~2×configured). The bound is loose until #723 is fixed.
- D5/D6 (verify-ca/verify-full) remain SKIPped pending issue #712.
- B4, C4 (socket tests) skip cleanly when no host-mode PG socket is present in CI.

Closes part of #709.