### PR TITLE
fix(ssl): verify-ca/verify-full chain completion + sslmode=prefer timeout fix

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1743,7 +1743,7 @@ fn make_tls_config_verify_ca(params: &ConnParams) -> Result<ClientConfig, Connec
 /// Build a `ClientConfig` for `sslmode=verify-full`.
 ///
 /// Performs full chain + hostname validation.  Uses `FullVerifier` so that
-/// when the server sends only the leaf cert (PostgreSQL's default), the certs
+/// when the server sends only the leaf cert (`PostgreSQL`'s default), the certs
 /// in `sslrootcert` are tried as intermediates before giving up (issue #712).
 fn make_tls_config_verify_full(params: &ConnParams) -> Result<ClientConfig, ConnectionError> {
     let root_store = match &params.ssl_root_cert {
@@ -1969,7 +1969,7 @@ impl ServerCertVerifier for FullVerifier {
 /// ## Chain completion (issue #712)
 ///
 /// rustls requires the full certificate chain to be present in the TLS
-/// handshake.  PostgreSQL by default sends only the leaf certificate.
+/// handshake.  `PostgreSQL` by default sends only the leaf certificate.
 /// OpenSSL (used by psql/libpq) can complete the chain from the local trust
 /// store; rustls cannot.
 ///


### PR DESCRIPTION
## Fixes

Closes #712 and #723.

---

## #712 — verify-ca / verify-full fail with UnknownIssuer

### Root cause

rustls's `WebPkiServerVerifier` requires the full certificate chain in the TLS handshake. PostgreSQL by default sends only the leaf cert (`ssl_cert_file` contains only the server cert). OpenSSL/psql can complete the chain from the local trust store; rustls cannot.

### Fix

`NoCnVerifier` (verify-ca) and new `FullVerifier` (verify-full) now carry the certs parsed from `sslrootcert` as `extra_intermediates`. When initial verification fails with `UnknownIssuer`, a second attempt prepends those certs to the intermediates slice. This covers the common case — `sslrootcert` is a bundle with the CA root and any intermediates — without requiring Postgres server reconfiguration.

`FullVerifier` replaces the previous `ClientConfig::with_root_certificates` approach (which had no chain completion) with a custom `ServerCertVerifier` that does full chain + hostname validation via `WebPkiServerVerifier`.

**Workaround that still works:** Configure Postgres with `ssl_cert_file = server-chain.crt` (leaf + CA concatenated). Now the fix also works when you can't change the server.

---

## #723 — sslmode=prefer timeout ~2× configured value

### Root cause

`connect_timeout` is applied per attempt by tokio-postgres. For `sslmode=prefer`, rpg tries TLS (full timeout), then falls back to plain (full timeout again). Host unreachable = 2× elapsed.

### Fix

In the `Prefer` match arm, detect timeout errors from the TLS probe (`ConnectionFailed` with "timeout" in the reason) and propagate immediately. Timeout = host unreachable = no point in falling back. Non-timeout TLS failures (server doesn't support SSL, handshake error) still trigger the plain fallback.

---

## Changes

- `src/connection.rs`:
  - `load_certs_as_intermediates()` — load raw DER certs from PEM file for use as intermediates
  - `is_timeout_error()` — classify timeout errors (testable helper)
  - `NoCnVerifier` — carries `extra_intermediates`, two-attempt chain verification
  - `FullVerifier` — new struct, same chain completion but WITH hostname check (`verify-full`)
  - `make_tls_config_verify_full` — uses `FullVerifier` instead of `with_root_certificates`
  - `SslMode::Prefer` match arm — propagates timeout immediately

## Test note

CI's connection-tests job SKIPs D5/D6 (verify-ca/verify-full) pending #712. Once this PR merges, those SKIPs can be removed and the tests should pass with the self-signed cert bundle at `/tmp/pg-tls-certs/srv-chain.crt`.