### PR TITLE
feat(connection): support comma-separated multi-host failover (#724)

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -847,8 +847,19 @@ fn resolve_hosts(
         }
     }
 
-    // Fallback: single host from the already-resolved fields.
-    params.hosts = vec![(params.host.clone(), params.port)];
+    // Fallback: single host (or comma-separated list from -h / PGHOST) from
+    // the already-resolved fields.  Split on commas so that
+    // `-h host1,host2` and `PGHOST=host1,host2` produce multiple candidates
+    // matching libpq / psql behaviour.
+    let host_parts: Vec<&str> = params.host.split(',').map(str::trim).collect();
+    if host_parts.len() > 1 {
+        params.hosts = host_parts
+            .iter()
+            .map(|h| ((*h).to_owned(), params.port))
+            .collect();
+    } else {
+        params.hosts = vec![(params.host.clone(), params.port)];
+    }
 }
 
 fn resolve_target_session_attrs(


### PR DESCRIPTION
Implements psql-compatible multi-host failover. Closes #724.

## What

Split comma-separated host strings from `-h` / `PGHOST` into multiple entries in `params.hosts`, so that:

- `rpg -h "host1,host2,host3" -p 5432` tries hosts in order, stops at first success
- `PGHOST=host1,host2 rpg` behaves the same

URI (`postgresql://host1,host2/db`) and conninfo (`host=h1,h2 port=5432`) multi-host were already handled by existing code. This patch fills the missing fallback path in `resolve_hosts()`.

## How

In `resolve_hosts()`, before the single-host fallback, split `params.host` on commas. If multiple parts are found, each gets the resolved port. Single-host paths are unaffected.

## Test plan

- `cargo test --bin rpg` — 1702 tests, 0 failed

Copyright 2026