### PR TITLE
fix(ssl): NoCnVerifier catches all InvalidCertificate variants for verify-ca

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2027,9 +2027,14 @@ impl NoCnVerifier {
         ) {
             Ok(ok) => Ok(ok),
             // Hostname mismatch on the dummy name is expected — treat as success.
-            Err(RustlsError::InvalidCertificate(rustls::CertificateError::NotValidForName)) => {
-                Ok(ServerCertVerified::assertion())
-            }
+            // rustls 0.23 has two variants for name mismatch: the legacy
+            // `NotValidForName` and the richer `NotValidForNameContext` (which
+            // includes the expected name and presented SANs).  webpki 0.103+
+            // always returns the context variant, so we must catch both.
+            Err(RustlsError::InvalidCertificate(
+                rustls::CertificateError::NotValidForName
+                | rustls::CertificateError::NotValidForNameContext { .. },
+            )) => Ok(ServerCertVerified::assertion()),
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
## Problem

`sslmode=verify-ca` connections fail with:

```
SSL error: certificate verification failed: invalid peer certificate: certificate not valid for name "dummy.invalid"; certificate is only valid for DnsName("localhost") or IpAddress(127.0.0.1)
```

## Root Cause

`NoCnVerifier::verify_chain()` calls `WebPkiServerVerifier::verify_server_cert()` with a dummy hostname (`dummy.invalid`) specifically to trigger a hostname-mismatch error that can be safely ignored — because for `verify-ca` we only care about the certificate chain, not the hostname.

The match arm caught `CertificateError::NotValidForName` (the legacy rustls variant). However, rustls 0.23 introduced a second variant `CertificateError::NotValidForNameContext { expected, presented }` that includes the expected name and presented SANs for richer error messages. **webpki 0.103+ always returns the context variant** — so the legacy `NotValidForName` arm never fires, and the error propagates as a real failure.

## Fix

Catch both variants in the same match arm:

```rust
Err(RustlsError::InvalidCertificate(
    rustls::CertificateError::NotValidForName
    | rustls::CertificateError::NotValidForNameContext { .. },
)) => Ok(ServerCertVerified::assertion()),
```

## Testing

- `verify-ca`: connects successfully ✓
- `verify-full`: still works correctly ✓
- All 1809 unit tests pass ✓
- `cargo clippy` with `RUSTFLAGS=-D warnings` clean ✓