### PR TITLE
fix(ash): sync sampling rate to zoom level; show actual data window (#763)

### DIFF
--- a/src/ash/renderer.rs
+++ b/src/ash/renderer.rs
@@ -826,10 +826,19 @@ pub fn draw_frame(frame: &mut Frame, snapshots: &[AshSnapshot], state: &AshState
     // [0] Status bar — title + live metrics on one line
     let active = snapshots.last().map_or(0, |s| s.active_count);
     let mode_label = if state.is_history { "History" } else { "Live" };
+    // Show actual data span (samples × bucket_secs), not ring-buffer capacity.
+    // Capacity label is misleading when the ring buffer isn't full yet.
+    let actual_secs = snapshots.len() as u64 * state.bucket_secs();
+    let actual_window = if actual_secs < 60 {
+        format!("{actual_secs}s")
+    } else if actual_secs < 3600 {
+        format!("{}min", actual_secs / 60)
+    } else {
+        format!("{}h", actual_secs / 3600)
+    };
     let status_text = format!(
         "/ash  [{mode_label}]  interval: {}s   window: {}   active: {active}",
-        state.refresh_interval_secs,
-        state.window_label(),
+        state.refresh_interval_secs, actual_window,
     );
     frame.render_widget(
         Paragraph::new(status_text).style(Style::default().fg(Color::Cyan)),

--- a/src/ash/state.rs
+++ b/src/ash/state.rs
@@ -127,20 +127,6 @@ impl AshState {
         }
     }
 
-    /// Human-readable label for the time window visible in the timeline.
-    ///
-    /// Based on 600 ring-buffer samples × `bucket_secs` per bucket.
-    pub fn window_label(&self) -> String {
-        let total_secs = 600 * self.bucket_secs();
-        if total_secs < 60 {
-            format!("{total_secs}s")
-        } else if total_secs < 3600 {
-            format!("{}min", total_secs / 60)
-        } else {
-            format!("{}h", total_secs / 3600)
-        }
-    }
-
     /// Context-sensitive key hint line for the footer.
     ///
     /// Shows `b/Esc:back` only when drilled below the top level.
@@ -166,21 +152,39 @@ impl AshState {
     }
 
     /// Advance zoom level: 1→2→3→4→5→6→1.
+    ///
+    /// Also updates `refresh_interval_secs` to match the new bucket size so
+    /// live sampling rate stays consistent with the display granularity.
     pub fn zoom_cycle_forward(&mut self) {
         self.zoom_level = if self.zoom_level >= 6 {
             1
         } else {
             self.zoom_level + 1
         };
+        self.sync_refresh_to_zoom();
     }
 
     /// Retreat zoom level: 1→6→5→4→3→2→1.
+    ///
+    /// Also updates `refresh_interval_secs` to match the new bucket size so
+    /// live sampling rate stays consistent with the display granularity.
     pub fn zoom_cycle_back(&mut self) {
         self.zoom_level = if self.zoom_level <= 1 {
             6
         } else {
             self.zoom_level - 1
         };
+        self.sync_refresh_to_zoom();
+    }
+
+    /// Set `refresh_interval_secs` to match `bucket_secs` so the live
+    /// sampling interval equals the display bucket granularity.
+    ///
+    /// Capped at 60s — polling less than once per minute would make the TUI
+    /// feel unresponsive even at coarse zoom levels.
+    fn sync_refresh_to_zoom(&mut self) {
+        self.refresh_interval_secs = self.bucket_secs().min(60);
+        self.sync_aliases();
     }
 
     /// Sync the renderer-alias fields from the canonical fields.
@@ -624,5 +628,42 @@ mod tests {
         let mut s = AshState::new(false);
         s.zoom_out(); // should not panic
         assert!(matches!(s.mode, ViewMode::Live));
+    }
+
+    /// Zooming via `←`/`→` must keep `refresh_interval_secs` in sync with
+    /// `bucket_secs`, capped at 60s.
+    #[test]
+    fn zoom_cycle_syncs_refresh_to_bucket() {
+        let mut s = AshState::new(false);
+        // Start: zoom_level=1, bucket_secs=1, refresh=1
+        assert_eq!(s.refresh_interval_secs, 1);
+
+        s.zoom_cycle_forward(); // level 2 → bucket_secs=15
+        assert_eq!(s.bucket_secs(), 15);
+        assert_eq!(s.refresh_interval_secs, 15);
+
+        s.zoom_cycle_forward(); // level 3 → bucket_secs=30
+        assert_eq!(s.bucket_secs(), 30);
+        assert_eq!(s.refresh_interval_secs, 30);
+
+        s.zoom_cycle_forward(); // level 4 → bucket_secs=60
+        assert_eq!(s.bucket_secs(), 60);
+        assert_eq!(s.refresh_interval_secs, 60);
+
+        s.zoom_cycle_forward(); // level 5 → bucket_secs=300, capped at 60
+        assert_eq!(s.bucket_secs(), 300);
+        assert_eq!(s.refresh_interval_secs, 60, "refresh capped at 60s");
+
+        s.zoom_cycle_back(); // back to level 4 → bucket_secs=60
+        assert_eq!(s.refresh_interval_secs, 60);
+
+        s.zoom_cycle_back(); // back to level 3 → bucket_secs=30
+        assert_eq!(s.refresh_interval_secs, 30);
+
+        s.zoom_cycle_back(); // back to level 2 → bucket_secs=15
+        assert_eq!(s.refresh_interval_secs, 15);
+
+        s.zoom_cycle_back(); // back to level 1 → bucket_secs=1
+        assert_eq!(s.refresh_interval_secs, 1);
     }
 }


### PR DESCRIPTION
## Summary

Two UX fixes for `/ash` found during demo recording:

### Fix 1: Zoom changes sampling rate
Zooming out (→) now increases `refresh_interval_secs` to match `bucket_secs` (capped at 60s). Previously zoom only changed how existing 1s samples were aggregated for display — at 5min-bucket zoom you still had 1s live samples, so the ring buffer held only ~10min of real data regardless of zoom level. Now zoom-out = coarser sampling + wider real window.

### Fix 2: Window label shows actual data span  
Status bar `window:` now shows actual elapsed data (samples × bucket_secs) rather than ring-buffer capacity. Previously showed `10min` from the first second of launch, which was confusing. Now shows `5s`, `30s`, growing honestly as data accumulates.

Removes now-unused `window_label()` from `AshState`.

## Tests
- Added `zoom_cycle_syncs_refresh_to_bucket` unit test
- 1865 passing, 0 failed
- clippy clean, fmt clean

Fixes issue found by Nik during demo recording.