### PR TITLE
docs: bump to v0.9.0, clearer demo labels, remove pspg static screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ Or set `PAGER=pspg` in your environment before launching rpg.
 pspg adds horizontal scrolling (Right arrow), line numbers (Alt+n),
 and a vertical column cursor (Alt+v) — useful for wide result sets.
 
+![pspg external pager with theme menu](demos/pspg_screenshot.jpg)
+
+*pspg with the theme selector menu — 20+ built-in themes, horizontal scrolling, column cursor.*
+
 ### \s — command history
 
 Browse, search, and save your query history:


### PR DESCRIPTION
- `v0.7.0` → `v0.9.0` in install instructions
- `See demo` → `▶ Click to expand demo` (more obvious it's expandable)
- Remove pspg static screenshot `<details>` block (static image, not needed)