### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "rpg"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpg"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.82"
 description = "Modern Postgres terminal with built-in diagnostics and AI assistant"


### PR DESCRIPTION
Bumps version for the v0.9.1 patch release.

**What's in v0.9.1:**
- fix(repl): expand :varname aliases before checking for backslash commands (#767) — fixes postgres_dba `:dba` integration