### PR TITLE
chore: bump version to 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.10.2] - 2026-04-02
+
+### Fixed
+
+- **`/ash` cursor no longer obscures bars.** The cursor column now renders as `▐` (right half-block) with bar color preserved in the right half and a white cursor line in the left half. (#777)
+- **`/ash` floating overlay moved LEFT** of the cursor with a `▶` arrow pointing to the cursor line, so the selected bucket's wait breakdown is fully visible. Uses `Clear` to prevent transparency artifacts. (#777)
+- **`/ash` display freeze after Esc fixed.** Pressing Esc to exit cursor/history mode now returns to Live immediately instead of hanging for up to 60 seconds. (#777)
+- **`/ash` overlay timestamp** now shows `HH:MM:SS` (was `HH:MM`). (#777)
+- **`/ash` X-axis labels** right-aligned with bars and visible even with few data points; overlap prevention added. (#777)
+- **`/ash` horizontal grid lines** (`┈`) added at Y-axis label rows for easier visual alignment. (#777)
+- **Cursor column detection** fixed: panning beyond history no longer incorrectly highlights the leftmost column. (#777)
+- **Overlay positioning** uses saturating arithmetic throughout, preventing `u16` overflow panics in debug builds on wide terminals. (#777)
+
 ## [0.10.1] - 2026-04-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpg"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 rust-version = "1.82"
 description = "Modern Postgres terminal with built-in diagnostics and AI assistant"

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ Single binary, no dependencies, cross-platform.
 Build the latest stable release from source (requires Rust 1.85+):
 
 ```bash
-git clone --branch v0.10.1 --depth 1 https://github.com/NikolayS/rpg.git
+git clone --branch v0.10.2 --depth 1 https://github.com/NikolayS/rpg.git
 cd rpg
 cargo build --release
 sudo cp ./target/release/rpg /usr/local/bin/
 ```
 
 > **Note:** `main` is under active development and may be unstable. Pin to a
-> release tag (e.g. `v0.10.1`) for a known-good build. Release notes:
+> release tag (e.g. `v0.10.2`) for a known-good build. Release notes:
 > [github.com/NikolayS/rpg/releases](https://github.com/NikolayS/rpg/releases)
 
 ## Connect


### PR DESCRIPTION
Bump version to 0.10.2 following merge of #777.

## Changes
- `Cargo.toml`: `0.10.1` → `0.10.2`
- `CHANGELOG.md`: add `[0.10.2]` section
- `README.md`: update clone branch example and tag reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)