### PR TITLE
fix(compat): normalize relation title for PG14-17 partition tests (#799)

### DIFF
--- a/tests/compat/test-psql-regress.sh
+++ b/tests/compat/test-psql-regress.sh
@@ -204,7 +204,8 @@ normalize() {
     -e '/^parallel worker$/d' \
     -e '/enumtypid/s/=([0-9][0-9]*/=(OID/g' \
     -e 's/for operator [0-9][0-9]*/for operator OID/g' \
-    -e 's/ Query Identifier: [-0-9][0-9]*/ Query Identifier: 0000000000000000000/g' | \
+    -e 's/ Query Identifier: [-0-9][0-9]*/ Query Identifier: 0000000000000000000/g' \
+    -e 's/List of tables/List of relations/g' | \
   awk '
     BEGIN { after_qp = 0 }
     /^$/ { blank++; next }


### PR DESCRIPTION
## Summary

- Add sed normalization rule in the `normalize()` function of `tests/compat/test-psql-regress.sh` to canonicalize "List of tables" (PG18) to "List of relations" (PG14-17)
- Fixes `partition_merge` and `partition_split` test failures on PG14-17

## What was changed

PG18 changed the `\dt` meta-command output title from "List of relations" to "List of tables". The test harness (`tests/compat/test-psql-regress.sh`) compares psql vs rpg output. When rpg version-gates the title differently from the local psql binary, the `partition_merge` and `partition_split` tests fail on PG14-17.

The fix adds a single sed substitution rule (`s/List of tables/List of relations/g`) to the existing `normalize()` function, which already handles many other cross-version output differences (ANSI codes, timing lines, db name normalization, error prefixes, etc.). This ensures the title comparison is stable across all supported PG versions (14-18).

## Test plan

- [ ] CI passes on PG14, PG15, PG16, PG17, PG18
- [ ] `partition_merge` and `partition_split` tests no longer fail on PG14-17
- [ ] No regressions in other psql regression tests

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)