### PR TITLE
fix(compat): emit rpg:file:line: error location prefix

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -59,10 +59,13 @@ pub fn include_file<'a>(
             }
         };
 
-        // Save and update current_file so that nested \ir commands resolve
-        // paths relative to the directory of this file.
+        // Save and update current_file / line counter so that nested \ir
+        // commands resolve paths relative to the directory of this file,
+        // and error messages include the correct `rpg:filename:line:` prefix.
         let prev_file = settings.current_file.clone();
+        let prev_line = settings.current_line_number;
         settings.current_file = Some(path.to_owned());
+        settings.current_line_number = Some(0);
 
         let start_depth = settings.cond.depth();
 
@@ -99,9 +102,10 @@ pub fn include_file<'a>(
             }
         }
 
-        // Restore the previous current_file so callers see the right value
-        // after this include returns.
+        // Restore the previous current_file and line counter so callers
+        // see the right values after this include returns.
         settings.current_file = prev_file;
+        settings.current_line_number = prev_line;
 
         let end_depth = settings.cond.depth();
         if end_depth > start_depth {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1763,6 +1763,25 @@ pub fn eprint_db_error(
     eprint!("{msg}");
 }
 
+/// Print a `tokio_postgres::Error` to stderr with a file location prefix.
+///
+/// Like [`eprint_db_error`] but prepends `rpg:filename:line: ` to the first
+/// line of the error message when `prefix` is `Some`, matching psql's
+/// behaviour during `-f` / `\i` file execution.
+pub fn eprint_db_error_located(
+    prefix: Option<&str>,
+    err: &tokio_postgres::Error,
+    sql: Option<&str>,
+    verbose: bool,
+    terse: bool,
+    sqlstate: bool,
+) {
+    if let Some(pfx) = prefix {
+        eprint!("{pfx}");
+    }
+    eprint_db_error(err, sql, verbose, terse, sqlstate);
+}
+
 /// Format a `PostgreSQL` notice (from `tokio_postgres::error::DbError`) in psql
 /// style, with a colored severity prefix.
 ///

--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -609,7 +609,8 @@ pub async fn execute_query(
             if settings.echo_errors {
                 eprintln!("{sql_to_send}");
             }
-            crate::output::eprint_db_error(
+            crate::output::eprint_db_error_located(
+                settings.error_location_prefix().as_deref(),
                 &e,
                 Some(sql_to_send),
                 settings.verbose_errors,
@@ -831,7 +832,8 @@ pub async fn execute_query(
         if settings.echo_errors {
             eprintln!("{sql_to_send}");
         }
-        crate::output::eprint_db_error(
+        crate::output::eprint_db_error_located(
+            settings.error_location_prefix().as_deref(),
             &e,
             Some(sql_to_send),
             settings.verbose_errors,
@@ -1104,7 +1106,8 @@ pub async fn execute_query_extended(
             if settings.echo_errors {
                 eprintln!("{sql_to_send}");
             }
-            crate::output::eprint_db_error(
+            crate::output::eprint_db_error_located(
+                settings.error_location_prefix().as_deref(),
                 &e,
                 Some(sql_to_send),
                 settings.verbose_errors,
@@ -1231,7 +1234,8 @@ pub async fn execute_query_extended(
             if settings.echo_errors {
                 eprintln!("{sql_to_send}");
             }
-            crate::output::eprint_db_error(
+            crate::output::eprint_db_error_located(
+                settings.error_location_prefix().as_deref(),
                 &e,
                 Some(sql_to_send),
                 settings.verbose_errors,
@@ -2144,7 +2148,8 @@ pub(super) async fn execute_gexec(
             cells
         }
         Err(e) => {
-            crate::output::eprint_db_error(
+            crate::output::eprint_db_error_located(
+                settings.error_location_prefix().as_deref(),
                 &e,
                 Some(sql_to_send),
                 settings.verbose_errors,
@@ -2296,7 +2301,8 @@ pub(super) async fn execute_gset(
             settings.last_stmt_produced_rows = false;
         }
         Err(e) => {
-            crate::output::eprint_db_error(
+            crate::output::eprint_db_error_located(
+                settings.error_location_prefix().as_deref(),
                 &e,
                 Some(sql_to_send),
                 settings.verbose_errors,
@@ -2600,7 +2606,8 @@ pub(super) async fn execute_crosstabview(
             Some((col_names, col_oids, rows))
         }
         Err(e) => {
-            crate::output::eprint_db_error(
+            crate::output::eprint_db_error_located(
+                settings.error_location_prefix().as_deref(),
                 &e,
                 Some(sql_to_send),
                 settings.verbose_errors,

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1283,6 +1283,12 @@ pub struct ReplSettings {
     /// of the current script rather than the process working directory,
     /// matching psql behaviour.
     pub current_file: Option<String>,
+    /// 1-based line number in the currently-executing script file.
+    ///
+    /// Tracked during `-f` / `\i` / `\ir` execution so that error messages
+    /// can include the `rpg:filename:line:` location prefix (matching psql).
+    /// `None` when not executing from a file.
+    pub current_line_number: Option<u64>,
     /// Unique identifier for the current session (used by session persistence).
     ///
     /// Assigned once at REPL startup from [`crate::session_store::new_session_id`].
@@ -1490,6 +1496,7 @@ impl std::fmt::Debug for ReplSettings {
             .field("verbose_errors", &self.verbose_errors)
             .field("vi_mode", &self.vi_mode)
             .field("current_file", &self.current_file)
+            .field("current_line_number", &self.current_line_number)
             .field("session_id", &self.session_id)
             .field("query_count", &self.query_count)
             .field("is_superuser", &self.is_superuser)
@@ -1595,6 +1602,7 @@ impl Default for ReplSettings {
             sqlstate_errors: false,
             vi_mode: false,
             current_file: None,
+            current_line_number: None,
             session_id: crate::session_store::new_session_id(),
             query_count: 0,
             is_superuser: false,
@@ -1618,6 +1626,20 @@ impl Default for ReplSettings {
             last_explain_text: None,
             lua_registry: crate::lua_commands::LuaRegistry::load(""),
             initial_input: None,
+        }
+    }
+}
+
+impl ReplSettings {
+    /// Return the `rpg:filename:line: ` error location prefix when executing
+    /// from a file, or `None` in interactive / `-c` / stdin mode.
+    ///
+    /// Matches psql's behaviour of prefixing error messages with the source
+    /// file and line number during `-f` / `\i` / `\ir` processing.
+    pub fn error_location_prefix(&self) -> Option<String> {
+        match (&self.current_file, self.current_line_number) {
+            (Some(file), Some(line)) => Some(format!("rpg:{file}:{line}: ")),
+            _ => None,
         }
     }
 }
@@ -1777,6 +1799,12 @@ pub async fn exec_file(
         tx.update_from_sql("begin");
     }
 
+    // Set the current file path and initialise the line counter so that
+    // error messages include the `rpg:filename:line:` location prefix
+    // (matching psql behaviour during `-f` file processing).
+    settings.current_file = Some(path.to_owned());
+    settings.current_line_number = Some(0);
+
     // Loop to handle \c reconnections in file mode.  When exec_lines
     // encounters \c it returns early with the new client; we continue
     // processing remaining lines with the new connection.
@@ -1834,6 +1862,11 @@ pub async fn exec_file(
             tx.update_from_sql("rollback");
         }
     }
+
+    // Clear file context so subsequent interactive use does not carry stale
+    // file/line state into error messages.
+    settings.current_file = None;
+    settings.current_line_number = None;
 
     exit_code
 }
@@ -1914,7 +1947,8 @@ async fn execute_inline_copy_to(client: &Client, sql: &str, settings: &mut ReplS
     let stream = match client.copy_out(sql).await {
         Ok(s) => s,
         Err(e) => {
-            crate::output::eprint_db_error(
+            crate::output::eprint_db_error_located(
+                settings.error_location_prefix().as_deref(),
                 &e,
                 Some(sql),
                 settings.verbose_errors,
@@ -1941,7 +1975,8 @@ async fn execute_inline_copy_to(client: &Client, sql: &str, settings: &mut ReplS
                 }
             }
             Err(e) => {
-                crate::output::eprint_db_error(
+                crate::output::eprint_db_error_located(
+                    settings.error_location_prefix().as_deref(),
                     &e,
                     Some(sql),
                     settings.verbose_errors,
@@ -2006,7 +2041,8 @@ async fn execute_inline_copy_from(
     let sink = match client.copy_in(sql).await {
         Ok(s) => s,
         Err(e) => {
-            crate::output::eprint_db_error(
+            crate::output::eprint_db_error_located(
+                settings.error_location_prefix().as_deref(),
                 &e,
                 Some(sql),
                 settings.verbose_errors,
@@ -2019,7 +2055,8 @@ async fn execute_inline_copy_from(
 
     tokio::pin!(sink);
     if let Err(e) = sink.send(bytes::Bytes::from(payload.into_bytes())).await {
-        crate::output::eprint_db_error(
+        crate::output::eprint_db_error_located(
+            settings.error_location_prefix().as_deref(),
             &e,
             Some(sql),
             settings.verbose_errors,
@@ -2042,7 +2079,8 @@ async fn execute_inline_copy_from(
             true
         }
         Err(e) => {
-            crate::output::eprint_db_error(
+            crate::output::eprint_db_error_located(
+                settings.error_location_prefix().as_deref(),
                 &e,
                 Some(sql),
                 settings.verbose_errors,
@@ -2153,6 +2191,12 @@ pub(crate) async fn exec_lines(
     let mut prev_buf = String::new();
     let mut exit_code = 0i32;
     'lines: while let Some(line) = lines.next() {
+        // Track the current line number for error location prefixes.
+        // The counter is stored in settings so it persists across multiple
+        // exec_lines calls for the same file (e.g. after \c reconnections).
+        if let Some(ref mut n) = settings.current_line_number {
+            *n += 1;
+        }
         // `quit` / `exit` bare words work in all modes (psql behaviour).
         if is_quit_exit(line.trim(), buf.is_empty()) {
             break 'lines;
@@ -3048,7 +3092,8 @@ pub(crate) async fn exec_lines(
                             // for the outer loop to process as regular SQL.
                             match client.copy_in(&sql_owned).await {
                                 Err(e) => {
-                                    crate::output::eprint_db_error(
+                                    crate::output::eprint_db_error_located(
+                                        settings.error_location_prefix().as_deref(),
                                         &e,
                                         Some(&sql_owned),
                                         settings.verbose_errors,
@@ -3083,7 +3128,8 @@ pub(crate) async fn exec_lines(
                                         .send(bytes::Bytes::from(payload.into_bytes()))
                                         .await;
                                     if let Err(e) = send_ok {
-                                        crate::output::eprint_db_error(
+                                        crate::output::eprint_db_error_located(
+                                            settings.error_location_prefix().as_deref(),
                                             &e,
                                             Some(&sql_owned),
                                             settings.verbose_errors,
@@ -3108,7 +3154,8 @@ pub(crate) async fn exec_lines(
                                                 }
                                             }
                                             Err(e) => {
-                                                crate::output::eprint_db_error(
+                                                crate::output::eprint_db_error_located(
+                                                    settings.error_location_prefix().as_deref(),
                                                     &e,
                                                     Some(&sql_owned),
                                                     settings.verbose_errors,


### PR DESCRIPTION
## Summary

- Add `current_line_number: Option<u64>` field to `ReplSettings` to track the 1-based line number during file execution
- Emit `rpg:filename:line: ` prefix before error messages during `-f` / `\i` / `\ir` file processing, matching psql's `psql:filename:line: ` behaviour
- Add `eprint_db_error_located()` helper in `output.rs` that prepends the prefix before delegating to `eprint_db_error()`
- Thread the prefix through all error output paths in `execute.rs` (query execution, extended query, gexec, gset, crosstabview) and `mod.rs` (COPY TO/FROM error paths)
- No prefix emitted for `-c` commands, piped stdin, or interactive mode

## Test plan

- [ ] Verify `rpg -f script.sql` emits `rpg:script.sql:N: ERROR:  ...` for SQL errors (where N is the line of the terminating `;`)
- [ ] Verify `rpg -c "SELECT bad"` does NOT emit a file:line prefix
- [ ] Verify interactive mode does NOT emit a file:line prefix
- [ ] Verify `\i` / `\ir` in scripts emit the correct filename and line number
- [ ] Verify nested `\i` correctly restores the outer file's line counter
- [ ] CI regression tests pass (the normalizer strips both `psql:` and `rpg:` prefixes for comparison)

Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)