### PR TITLE
feat(ash): make sample query timeout configurable (#771)

### DIFF
--- a/src/ash/mod.rs
+++ b/src/ash/mod.rs
@@ -89,11 +89,7 @@ pub async fn run_ash(
     let pg_ash = sampler::detect_pg_ash(client).await;
     let mut state = AshState::new(pg_ash.installed);
     let mut snapshots: VecDeque<sampler::AshSnapshot> = VecDeque::with_capacity(600);
-    let timeout_ms = settings
-        .config
-        .ash
-        .sample_timeout_ms
-        .unwrap_or(crate::config::DEFAULT_ASH_SAMPLE_TIMEOUT_MS);
+    let timeout_ms = settings.config.ash.sample_timeout_ms();
 
     // Pre-populate ring buffer from pg_ash history when available.
     // Fills the left side of the timeline; live data scrolls in on the right.

--- a/src/ash/mod.rs
+++ b/src/ash/mod.rs
@@ -89,7 +89,11 @@ pub async fn run_ash(
     let pg_ash = sampler::detect_pg_ash(client).await;
     let mut state = AshState::new(pg_ash.installed);
     let mut snapshots: VecDeque<sampler::AshSnapshot> = VecDeque::with_capacity(600);
-    let timeout_ms = settings.config.ash.sample_timeout_ms;
+    let timeout_ms = settings
+        .config
+        .ash
+        .sample_timeout_ms
+        .unwrap_or(crate::config::DEFAULT_ASH_SAMPLE_TIMEOUT_MS);
 
     // Pre-populate ring buffer from pg_ash history when available.
     // Fills the left side of the timeline; live data scrolls in on the right.

--- a/src/ash/mod.rs
+++ b/src/ash/mod.rs
@@ -89,13 +89,14 @@ pub async fn run_ash(
     let pg_ash = sampler::detect_pg_ash(client).await;
     let mut state = AshState::new(pg_ash.installed);
     let mut snapshots: VecDeque<sampler::AshSnapshot> = VecDeque::with_capacity(600);
+    let timeout_ms = settings.config.ash.sample_timeout_ms;
 
     // Pre-populate ring buffer from pg_ash history when available.
     // Fills the left side of the timeline; live data scrolls in on the right.
     if pg_ash.installed {
         // Pre-populate using the current zoom window (bucket_secs × 600 samples).
         let history_window = state.bucket_secs() * 600;
-        let history = sampler::query_ash_history(client, history_window).await;
+        let history = sampler::query_ash_history(client, history_window, timeout_ms).await;
         for snap in history {
             if snapshots.len() == 600 {
                 snapshots.pop_front();
@@ -113,7 +114,8 @@ pub async fn run_ash(
     'outer: loop {
         // 1. Collect snapshot data for this frame.
         let snap_slice =
-            collect_frame_snapshots(client, &mut snapshots, &mut state, cpu_override).await;
+            collect_frame_snapshots(client, &mut snapshots, &mut state, cpu_override, timeout_ms)
+                .await;
         let in_history = state.pan_offset > 0 || matches!(state.mode, ViewMode::History { .. });
 
         // 2. Draw frame.
@@ -211,6 +213,7 @@ async fn collect_frame_snapshots(
     snapshots: &mut std::collections::VecDeque<sampler::AshSnapshot>,
     state: &mut AshState,
     cpu_override: Option<u32>,
+    timeout_ms: u64,
 ) -> Vec<sampler::AshSnapshot> {
     match &state.mode {
         ViewMode::History { from, to } => {
@@ -219,7 +222,7 @@ async fn collect_frame_snapshots(
                 .unwrap_or_default()
                 .as_secs()
                 .max(1);
-            let v = sampler::query_ash_history(client, window).await;
+            let v = sampler::query_ash_history(client, window, timeout_ms).await;
             if v.is_empty() {
                 snapshots.iter().cloned().collect()
             } else {
@@ -227,7 +230,7 @@ async fn collect_frame_snapshots(
             }
         }
         ViewMode::Live => {
-            match sampler::live_snapshot(client).await {
+            match sampler::live_snapshot(client, timeout_ms).await {
                 Ok(sampler::LiveSnapshotResult::Ok(mut snap)) => {
                     if cpu_override.is_some() {
                         snap.cpu_count = cpu_override;

--- a/src/ash/sampler.rs
+++ b/src/ash/sampler.rs
@@ -676,10 +676,8 @@ mod tests {
         );
     }
 
-    /// Verifies `live_snapshot` works with `timeout_ms = 0` (timeout disabled).
-    ///
-    /// The `if timeout_ms > 0` guard must skip the SET/RESET statement_timeout
-    /// entirely; the sample query should still succeed.
+    /// Verifies `live_snapshot` works when `timeout_ms = 0` (timeout disabled).
+    /// The query must succeed without setting or resetting `statement_timeout`.
     ///
     /// Run with: `cargo test --include-ignored test_live_snapshot_timeout_disabled`
     #[tokio::test]
@@ -695,19 +693,39 @@ mod tests {
             conn.await.ok();
         });
 
-        // timeout_ms = 0 disables the statement_timeout guard.
         let result = live_snapshot(&client, 0).await;
         assert!(
             result.is_ok(),
-            "live_snapshot with timeout_ms=0 should not error"
+            "live_snapshot with timeout_ms=0 must succeed"
+        );
+        match result.unwrap() {
+            LiveSnapshotResult::Ok(snap) => {
+                // Snapshot should have valid structure (counts may be 0).
+                assert!(snap.active_count == snap.by_type.values().sum::<u32>());
+            }
+            LiveSnapshotResult::Missed => {
+                panic!("unexpected Missed with timeout disabled");
+            }
+        }
+
+        // Verify statement_timeout was not changed (should still be default 0).
+        let row = client
+            .query_one("show statement_timeout", &[])
+            .await
+            .expect("show statement_timeout");
+        let val: String = row.get(0);
+        assert_eq!(
+            val, "0",
+            "statement_timeout must remain unchanged when timeout_ms=0"
         );
     }
 
-    /// Verifies `query_ash_history` works with `timeout_ms = 0` (timeout disabled).
+    /// Verifies `query_ash_history` works when `timeout_ms = 0` (timeout
+    /// disabled). Must not panic or set `statement_timeout`.
     ///
     /// Run with: `cargo test --include-ignored test_ash_history_timeout_disabled`
     #[tokio::test]
-    #[ignore = "requires pg_ash installed on postgresql://postgres@127.0.0.1:15433/ashtest"]
+    #[ignore = "requires connection to postgresql://postgres@127.0.0.1:15433/ashtest"]
     async fn test_ash_history_timeout_disabled() {
         let (client, conn) = tokio_postgres::connect(
             "host=127.0.0.1 port=15433 user=postgres dbname=ashtest",
@@ -719,22 +737,25 @@ mod tests {
             conn.await.ok();
         });
 
-        // Skip gracefully if pg_ash is not installed.
-        let ext_rows = client
-            .query("select 1 from pg_extension where extname = 'pg_ash'", &[])
-            .await
-            .unwrap_or_default();
-        if ext_rows.is_empty() {
-            eprintln!("pg_ash not installed — skipping timeout_disabled history test");
-            return;
+        // Should return empty vec or valid data — must not panic.
+        let history = query_ash_history(&client, 60, 0).await;
+        for snap in &history {
+            assert_eq!(
+                snap.active_count,
+                snap.by_type.values().sum::<u32>(),
+                "by_type sum must equal active_count"
+            );
         }
 
-        // timeout_ms = 0 disables the statement_timeout guard.
-        let history = query_ash_history(&client, 60, 0).await;
-        // Should not panic; may be empty if no history data exists.
-        eprintln!(
-            "test_ash_history_timeout_disabled: {} snapshots returned",
-            history.len()
+        // Verify statement_timeout was not changed.
+        let row = client
+            .query_one("show statement_timeout", &[])
+            .await
+            .expect("show statement_timeout");
+        let val: String = row.get(0);
+        assert_eq!(
+            val, "0",
+            "statement_timeout must remain unchanged when timeout_ms=0"
         );
     }
 }

--- a/src/ash/sampler.rs
+++ b/src/ash/sampler.rs
@@ -675,4 +675,66 @@ mod tests {
             "expected empty vec when pg_ash not installed"
         );
     }
+
+    /// Verifies `live_snapshot` works with `timeout_ms = 0` (timeout disabled).
+    ///
+    /// The `if timeout_ms > 0` guard must skip the SET/RESET statement_timeout
+    /// entirely; the sample query should still succeed.
+    ///
+    /// Run with: `cargo test --include-ignored test_live_snapshot_timeout_disabled`
+    #[tokio::test]
+    #[ignore = "requires connection to postgresql://postgres@127.0.0.1:15433/ashtest"]
+    async fn test_live_snapshot_timeout_disabled() {
+        let (client, conn) = tokio_postgres::connect(
+            "host=127.0.0.1 port=15433 user=postgres dbname=ashtest",
+            tokio_postgres::NoTls,
+        )
+        .await
+        .expect("connect to test database");
+        tokio::spawn(async move {
+            conn.await.ok();
+        });
+
+        // timeout_ms = 0 disables the statement_timeout guard.
+        let result = live_snapshot(&client, 0).await;
+        assert!(
+            result.is_ok(),
+            "live_snapshot with timeout_ms=0 should not error"
+        );
+    }
+
+    /// Verifies `query_ash_history` works with `timeout_ms = 0` (timeout disabled).
+    ///
+    /// Run with: `cargo test --include-ignored test_ash_history_timeout_disabled`
+    #[tokio::test]
+    #[ignore = "requires pg_ash installed on postgresql://postgres@127.0.0.1:15433/ashtest"]
+    async fn test_ash_history_timeout_disabled() {
+        let (client, conn) = tokio_postgres::connect(
+            "host=127.0.0.1 port=15433 user=postgres dbname=ashtest",
+            tokio_postgres::NoTls,
+        )
+        .await
+        .expect("connect to test database");
+        tokio::spawn(async move {
+            conn.await.ok();
+        });
+
+        // Skip gracefully if pg_ash is not installed.
+        let ext_rows = client
+            .query("select 1 from pg_extension where extname = 'pg_ash'", &[])
+            .await
+            .unwrap_or_default();
+        if ext_rows.is_empty() {
+            eprintln!("pg_ash not installed — skipping timeout_disabled history test");
+            return;
+        }
+
+        // timeout_ms = 0 disables the statement_timeout guard.
+        let history = query_ash_history(&client, 60, 0).await;
+        // Should not panic; may be empty if no history data exists.
+        eprintln!(
+            "test_ash_history_timeout_disabled: {} snapshots returned",
+            history.len()
+        );
+    }
 }

--- a/src/ash/sampler.rs
+++ b/src/ash/sampler.rs
@@ -152,10 +152,7 @@ pub enum LiveSnapshotResult {
 ///
 /// `timeout_ms` — maximum time in milliseconds for the sample query.
 /// `0` disables the timeout entirely.
-pub async fn live_snapshot(
-    client: &Client,
-    timeout_ms: u64,
-) -> anyhow::Result<LiveSnapshotResult> {
+pub async fn live_snapshot(client: &Client, timeout_ms: u64) -> anyhow::Result<LiveSnapshotResult> {
     let sql = "
         select
             case
@@ -185,10 +182,7 @@ pub async fn live_snapshot(
     // When timeout_ms is 0, skip the guard entirely (user opted out).
     if timeout_ms > 0 {
         client
-            .execute(
-                &format!("set statement_timeout = '{timeout_ms}ms'"),
-                &[],
-            )
+            .execute(&format!("set statement_timeout = '{timeout_ms}ms'"), &[])
             .await?;
     }
 
@@ -294,10 +288,7 @@ async fn query_ash_history_inner(
     // When timeout_ms is 0, skip the guard entirely (user opted out).
     if timeout_ms > 0 {
         let _ = client
-            .execute(
-                &format!("set statement_timeout = '{timeout_ms}ms'"),
-                &[],
-            )
+            .execute(&format!("set statement_timeout = '{timeout_ms}ms'"), &[])
             .await;
     }
 

--- a/src/ash/sampler.rs
+++ b/src/ash/sampler.rs
@@ -9,18 +9,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio_postgres::Client;
 
 // ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/// Maximum time allowed for a single `/ash` sample query (`pg_stat_activity`
-/// or `ash.wait_timeline`).  Matches the same guard used by `pg_ash`'s
-/// per-second `pg_cron` job — fail fast rather than block the TUI.
-///
-/// Future: move to `[ash]` config section so users can tune it.
-/// See: <https://github.com/NikolayS/rpg/issues/771>
-const ASH_QUERY_TIMEOUT_MS: u64 = 500;
-
-// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
@@ -157,11 +145,17 @@ pub enum LiveSnapshotResult {
 /// (`by_type`, `by_event`, `by_query`) without additional round-trips.
 ///
 /// Observer-effect protection: `SET statement_timeout` is applied before the
-/// query (see [`ASH_QUERY_TIMEOUT_MS`], matching the same guard used by
-/// `pg_ash`'s per-second cron job) and reset to 0 afterwards.  If the query
-/// times out the tick is skipped and [`LiveSnapshotResult::Missed`] is
-/// returned instead of blocking the TUI.
-pub async fn live_snapshot(client: &Client) -> anyhow::Result<LiveSnapshotResult> {
+/// query (matching the same guard used by `pg_ash`'s per-second cron job)
+/// and reset to 0 afterwards.  If the query times out the tick is skipped
+/// and [`LiveSnapshotResult::Missed`] is returned instead of blocking the
+/// TUI.
+///
+/// `timeout_ms` — maximum time in milliseconds for the sample query.
+/// `0` disables the timeout entirely.
+pub async fn live_snapshot(
+    client: &Client,
+    timeout_ms: u64,
+) -> anyhow::Result<LiveSnapshotResult> {
     let sql = "
         select
             case
@@ -187,18 +181,24 @@ pub async fn live_snapshot(client: &Client) -> anyhow::Result<LiveSnapshotResult
     // one). Use SET + reset instead: set for this query, restore default after.
     // This is a session-level change but is immediately restored, so it does
     // not leak across queries in the connection pool.
-    client
-        .execute(
-            &format!("set statement_timeout = '{ASH_QUERY_TIMEOUT_MS}ms'"),
-            &[],
-        )
-        .await?;
+    //
+    // When timeout_ms is 0, skip the guard entirely (user opted out).
+    if timeout_ms > 0 {
+        client
+            .execute(
+                &format!("set statement_timeout = '{timeout_ms}ms'"),
+                &[],
+            )
+            .await?;
+    }
 
     let rows = match client.query(sql, &[]).await {
         Ok(rows) => rows,
         Err(e) => {
             // Restore statement_timeout before returning — best-effort.
-            let _ = client.execute("set statement_timeout = 0", &[]).await;
+            if timeout_ms > 0 {
+                let _ = client.execute("set statement_timeout = 0", &[]).await;
+            }
             // statement_timeout fires as SQLSTATE 57014 (query_canceled).
             // Return Missed so the TUI can display a brief indicator and
             // continue rather than propagating an error.
@@ -210,7 +210,9 @@ pub async fn live_snapshot(client: &Client) -> anyhow::Result<LiveSnapshotResult
     };
 
     // Restore default timeout after successful query.
-    let _ = client.execute("set statement_timeout = 0", &[]).await;
+    if timeout_ms > 0 {
+        let _ = client.execute("set statement_timeout = 0", &[]).await;
+    }
 
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -246,8 +248,15 @@ pub async fn live_snapshot(client: &Client) -> anyhow::Result<LiveSnapshotResult
 /// - `pg_ash` is not installed (graceful degradation)
 /// - the query fails (transient error, permission issue, etc.)
 /// - no historical data exists for the requested window
-pub async fn query_ash_history(client: &Client, window_secs: u64) -> Vec<AshSnapshot> {
-    query_ash_history_inner(client, window_secs)
+///
+/// `timeout_ms` — maximum time in milliseconds for the history query.
+/// `0` disables the timeout entirely.
+pub async fn query_ash_history(
+    client: &Client,
+    window_secs: u64,
+    timeout_ms: u64,
+) -> Vec<AshSnapshot> {
+    query_ash_history_inner(client, window_secs, timeout_ms)
         .await
         .unwrap_or_default()
 }
@@ -260,6 +269,7 @@ pub async fn query_ash_history(client: &Client, window_secs: u64) -> Vec<AshSnap
 async fn query_ash_history_inner(
     client: &Client,
     window_secs: u64,
+    timeout_ms: u64,
 ) -> anyhow::Result<Vec<AshSnapshot>> {
     // ash.wait_timeline returns (bucket_start, wait_event, samples).
     // wait_event format: "Type:Event" or just "Type" when type == event
@@ -281,20 +291,27 @@ async fn query_ash_history_inner(
     );
 
     // Same observer-effect guard as live_snapshot.
-    let _ = client
-        .execute(
-            &format!("set statement_timeout = '{ASH_QUERY_TIMEOUT_MS}ms'"),
-            &[],
-        )
-        .await;
+    // When timeout_ms is 0, skip the guard entirely (user opted out).
+    if timeout_ms > 0 {
+        let _ = client
+            .execute(
+                &format!("set statement_timeout = '{timeout_ms}ms'"),
+                &[],
+            )
+            .await;
+    }
 
     let rows = match client.query(sql.as_str(), &[]).await {
         Ok(r) => {
-            let _ = client.execute("set statement_timeout = 0", &[]).await;
+            if timeout_ms > 0 {
+                let _ = client.execute("set statement_timeout = 0", &[]).await;
+            }
             r
         }
         Err(e) => {
-            let _ = client.execute("set statement_timeout = 0", &[]).await;
+            if timeout_ms > 0 {
+                let _ = client.execute("set statement_timeout = 0", &[]).await;
+            }
             return Err(anyhow::anyhow!("ash.wait_timeline query failed: {e}"));
         }
     };
@@ -624,7 +641,7 @@ mod tests {
             return;
         }
 
-        let history = query_ash_history(&client, 60).await;
+        let history = query_ash_history(&client, 60, 500).await;
         eprintln!(
             "test_pg_ash_history_live: {} snapshots returned",
             history.len()
@@ -661,7 +678,7 @@ mod tests {
         let _ = client.execute("drop extension if exists pg_ash", &[]).await;
 
         // Must return empty vec, not panic or propagate error.
-        let history = query_ash_history(&client, 60).await;
+        let history = query_ash_history(&client, 60, 500).await;
         assert!(
             history.is_empty(),
             "expected empty vec when pg_ash not installed"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1003,9 +1003,7 @@ fn merge_config(base: Config, overlay: Config) -> Config {
             audit_file: overlay.logging.audit_file.or(base.logging.audit_file),
         },
         ash: AshConfig {
-            sample_timeout_ms: if overlay.ash.sample_timeout_ms
-                == default_ash_sample_timeout_ms()
-            {
+            sample_timeout_ms: if overlay.ash.sample_timeout_ms == default_ash_sample_timeout_ms() {
                 base.ash.sample_timeout_ms
             } else {
                 overlay.ash.sample_timeout_ms

--- a/src/config.rs
+++ b/src/config.rs
@@ -474,7 +474,7 @@ impl Default for LoggingConfig {
 /// [ash]
 /// sample_timeout_ms = 500  # 0 = disabled
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct AshConfig {
     /// Maximum time in milliseconds allowed for a single `/ash` sample query
@@ -487,20 +487,14 @@ pub struct AshConfig {
     /// large clusters where the default 500 ms is too tight).
     ///
     /// Default: `500`.
-    pub sample_timeout_ms: u64,
+    ///
+    /// Wrapped in `Option` so that config merging can distinguish "field
+    /// absent from TOML" (`None`) from "explicitly set to 500" (`Some(500)`).
+    pub sample_timeout_ms: Option<u64>,
 }
 
-fn default_ash_sample_timeout_ms() -> u64 {
-    500
-}
-
-impl Default for AshConfig {
-    fn default() -> Self {
-        Self {
-            sample_timeout_ms: default_ash_sample_timeout_ms(),
-        }
-    }
-}
+/// Default timeout for `/ash` sample queries (milliseconds).
+pub const DEFAULT_ASH_SAMPLE_TIMEOUT_MS: u64 = 500;
 
 // ---------------------------------------------------------------------------
 // SSH tunnel configuration
@@ -1003,11 +997,7 @@ fn merge_config(base: Config, overlay: Config) -> Config {
             audit_file: overlay.logging.audit_file.or(base.logging.audit_file),
         },
         ash: AshConfig {
-            sample_timeout_ms: if overlay.ash.sample_timeout_ms == default_ash_sample_timeout_ms() {
-                base.ash.sample_timeout_ms
-            } else {
-                overlay.ash.sample_timeout_ms
-            },
+            sample_timeout_ms: overlay.ash.sample_timeout_ms.or(base.ash.sample_timeout_ms),
         },
         connections: {
             let mut merged = base.connections;
@@ -2118,5 +2108,143 @@ api_key_env = "PGMUSTARD_API_KEY"
             cfg.pgmustard.api_key_env,
             Some("PGMUSTARD_API_KEY".to_owned())
         );
+    }
+
+    // -- AshConfig --------------------------------------------------------------
+
+    #[test]
+    fn ash_config_default_is_none() {
+        // Default is None so that config merging can distinguish "absent" from
+        // "explicitly set to 500".  The actual default of 500 is applied at the
+        // usage site via unwrap_or(DEFAULT_ASH_SAMPLE_TIMEOUT_MS).
+        let cfg = AshConfig::default();
+        assert_eq!(cfg.sample_timeout_ms, None);
+    }
+
+    #[test]
+    fn ash_config_parse_explicit_value() {
+        let toml_str = r#"
+[ash]
+sample_timeout_ms = 200
+"#;
+        let cfg: Config = toml::from_str(toml_str).expect("should parse");
+        assert_eq!(cfg.ash.sample_timeout_ms, Some(200));
+    }
+
+    #[test]
+    fn ash_config_parse_explicit_default_value() {
+        // Explicitly setting 500 (the default) must be preserved as Some(500).
+        let toml_str = r#"
+[ash]
+sample_timeout_ms = 500
+"#;
+        let cfg: Config = toml::from_str(toml_str).expect("should parse");
+        assert_eq!(cfg.ash.sample_timeout_ms, Some(500));
+    }
+
+    #[test]
+    fn ash_config_parse_zero_disables_timeout() {
+        let toml_str = r#"
+[ash]
+sample_timeout_ms = 0
+"#;
+        let cfg: Config = toml::from_str(toml_str).expect("should parse");
+        assert_eq!(cfg.ash.sample_timeout_ms, Some(0));
+    }
+
+    #[test]
+    fn ash_config_absent_section_is_none() {
+        // No [ash] section at all — field should be None.
+        let toml_str = "";
+        let cfg: Config = toml::from_str(toml_str).expect("should parse");
+        assert_eq!(cfg.ash.sample_timeout_ms, None);
+    }
+
+    #[test]
+    fn ash_config_empty_section_is_none() {
+        // [ash] section present but sample_timeout_ms absent — field should be None.
+        let toml_str = r#"
+[ash]
+"#;
+        let cfg: Config = toml::from_str(toml_str).expect("should parse");
+        assert_eq!(cfg.ash.sample_timeout_ms, None);
+    }
+
+    // -- AshConfig merge --------------------------------------------------------
+
+    #[test]
+    fn merge_ash_overlay_none_preserves_base() {
+        // Base has sample_timeout_ms = Some(0), overlay has None (absent).
+        // Merged should keep the base value.
+        let base = Config {
+            ash: AshConfig {
+                sample_timeout_ms: Some(0),
+            },
+            ..Default::default()
+        };
+        let overlay = Config {
+            ash: AshConfig {
+                sample_timeout_ms: None,
+            },
+            ..Default::default()
+        };
+        let merged = merge_config(base, overlay);
+        assert_eq!(
+            merged.ash.sample_timeout_ms,
+            Some(0),
+            "base value should be preserved when overlay is absent"
+        );
+    }
+
+    #[test]
+    fn merge_ash_overlay_explicit_wins() {
+        // Base has sample_timeout_ms = Some(0), overlay explicitly sets Some(500).
+        // Merged should use the overlay value.
+        // This is the exact scenario that was broken before the Option<u64> fix:
+        // overlay value of 500 was silently dropped because it equalled the default.
+        let base = Config {
+            ash: AshConfig {
+                sample_timeout_ms: Some(0),
+            },
+            ..Default::default()
+        };
+        let overlay = Config {
+            ash: AshConfig {
+                sample_timeout_ms: Some(500),
+            },
+            ..Default::default()
+        };
+        let merged = merge_config(base, overlay);
+        assert_eq!(
+            merged.ash.sample_timeout_ms,
+            Some(500),
+            "overlay explicit value should win even when it equals the old default"
+        );
+    }
+
+    #[test]
+    fn merge_ash_both_none_stays_none() {
+        let base = Config::default();
+        let overlay = Config::default();
+        let merged = merge_config(base, overlay);
+        assert_eq!(merged.ash.sample_timeout_ms, None);
+    }
+
+    #[test]
+    fn merge_ash_base_some_overlay_different_some() {
+        let base = Config {
+            ash: AshConfig {
+                sample_timeout_ms: Some(300),
+            },
+            ..Default::default()
+        };
+        let overlay = Config {
+            ash: AshConfig {
+                sample_timeout_ms: Some(1000),
+            },
+            ..Default::default()
+        };
+        let merged = merge_config(base, overlay);
+        assert_eq!(merged.ash.sample_timeout_ms, Some(1000));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -468,7 +468,8 @@ impl Default for LoggingConfig {
 
 /// Active Session History (`/ash`) settings.
 ///
-/// Controls the behaviour of the `/ash` TUI sampler.
+/// Controls the timeout for both the live sample query and the history query
+/// used by the `/ash` TUI sampler.
 ///
 /// ```toml
 /// [ash]
@@ -487,14 +488,19 @@ pub struct AshConfig {
     /// large clusters where the default 500 ms is too tight).
     ///
     /// Default: `500`.
-    ///
-    /// Wrapped in `Option` so that config merging can distinguish "field
-    /// absent from TOML" (`None`) from "explicitly set to 500" (`Some(500)`).
     pub sample_timeout_ms: Option<u64>,
 }
 
-/// Default timeout for `/ash` sample queries (milliseconds).
-pub const DEFAULT_ASH_SAMPLE_TIMEOUT_MS: u64 = 500;
+const DEFAULT_ASH_SAMPLE_TIMEOUT_MS: u64 = 500;
+
+impl AshConfig {
+    /// Resolved timeout value: returns the configured value or the default
+    /// (500 ms) when not explicitly set.
+    pub fn sample_timeout_ms(&self) -> u64 {
+        self.sample_timeout_ms
+            .unwrap_or(DEFAULT_ASH_SAMPLE_TIMEOUT_MS)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // SSH tunnel configuration
@@ -2123,10 +2129,10 @@ api_key_env = "PGMUSTARD_API_KEY"
 
     #[test]
     fn ash_config_parse_explicit_value() {
-        let toml_str = r#"
+        let toml_str = r"
 [ash]
 sample_timeout_ms = 200
-"#;
+";
         let cfg: Config = toml::from_str(toml_str).expect("should parse");
         assert_eq!(cfg.ash.sample_timeout_ms, Some(200));
     }
@@ -2134,27 +2140,26 @@ sample_timeout_ms = 200
     #[test]
     fn ash_config_parse_explicit_default_value() {
         // Explicitly setting 500 (the default) must be preserved as Some(500).
-        let toml_str = r#"
+        let toml_str = r"
 [ash]
 sample_timeout_ms = 500
-"#;
+";
         let cfg: Config = toml::from_str(toml_str).expect("should parse");
         assert_eq!(cfg.ash.sample_timeout_ms, Some(500));
     }
 
     #[test]
     fn ash_config_parse_zero_disables_timeout() {
-        let toml_str = r#"
+        let toml_str = r"
 [ash]
 sample_timeout_ms = 0
-"#;
+";
         let cfg: Config = toml::from_str(toml_str).expect("should parse");
         assert_eq!(cfg.ash.sample_timeout_ms, Some(0));
     }
 
     #[test]
     fn ash_config_absent_section_is_none() {
-        // No [ash] section at all — field should be None.
         let toml_str = "";
         let cfg: Config = toml::from_str(toml_str).expect("should parse");
         assert_eq!(cfg.ash.sample_timeout_ms, None);
@@ -2162,20 +2167,33 @@ sample_timeout_ms = 0
 
     #[test]
     fn ash_config_empty_section_is_none() {
-        // [ash] section present but sample_timeout_ms absent — field should be None.
-        let toml_str = r#"
+        let toml_str = r"
 [ash]
-"#;
+";
         let cfg: Config = toml::from_str(toml_str).expect("should parse");
         assert_eq!(cfg.ash.sample_timeout_ms, None);
+    }
+
+    #[test]
+    fn ash_default_timeout_accessor() {
+        let cfg: Config = toml::from_str("").expect("should parse");
+        assert_eq!(cfg.ash.sample_timeout_ms(), 500);
+    }
+
+    #[test]
+    fn ash_disabled_timeout_accessor() {
+        let toml_str = r"
+[ash]
+sample_timeout_ms = 0
+";
+        let cfg: Config = toml::from_str(toml_str).expect("should parse");
+        assert_eq!(cfg.ash.sample_timeout_ms(), 0);
     }
 
     // -- AshConfig merge --------------------------------------------------------
 
     #[test]
     fn merge_ash_overlay_none_preserves_base() {
-        // Base has sample_timeout_ms = Some(0), overlay has None (absent).
-        // Merged should keep the base value.
         let base = Config {
             ash: AshConfig {
                 sample_timeout_ms: Some(0),
@@ -2198,10 +2216,6 @@ sample_timeout_ms = 0
 
     #[test]
     fn merge_ash_overlay_explicit_wins() {
-        // Base has sample_timeout_ms = Some(0), overlay explicitly sets Some(500).
-        // Merged should use the overlay value.
-        // This is the exact scenario that was broken before the Option<u64> fix:
-        // overlay value of 500 was silently dropped because it equalled the default.
         let base = Config {
             ash: AshConfig {
                 sample_timeout_ms: Some(0),
@@ -2246,5 +2260,23 @@ sample_timeout_ms = 0
         };
         let merged = merge_config(base, overlay);
         assert_eq!(merged.ash.sample_timeout_ms, Some(1000));
+    }
+
+    #[test]
+    fn merge_ash_overlay_unset_preserves_base_via_toml() {
+        let base: Config = toml::from_str(
+            r"
+[ash]
+sample_timeout_ms = 0
+",
+        )
+        .expect("parse base");
+        let overlay: Config = toml::from_str("").expect("parse overlay");
+        let merged = merge_config(base, overlay);
+        assert_eq!(
+            merged.ash.sample_timeout_ms(),
+            0,
+            "unset overlay must preserve base value"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,8 @@ pub struct Config {
     pub pgmustard: PgMustardConfig,
     /// Structured-log file rotation settings.
     pub logging: LoggingConfig,
+    /// Active Session History (`/ash`) settings.
+    pub ash: AshConfig,
     /// Named connection profiles (keyed by profile name).
     #[serde(default)]
     pub connections: HashMap<String, ConnectionProfile>,
@@ -456,6 +458,46 @@ impl Default for LoggingConfig {
             max_file_size_mb: 10,
             max_files: 5,
             audit_file: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASH (Active Session History) settings
+// ---------------------------------------------------------------------------
+
+/// Active Session History (`/ash`) settings.
+///
+/// Controls the behaviour of the `/ash` TUI sampler.
+///
+/// ```toml
+/// [ash]
+/// sample_timeout_ms = 500  # 0 = disabled
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct AshConfig {
+    /// Maximum time in milliseconds allowed for a single `/ash` sample query
+    /// (`pg_stat_activity` or `ash.wait_timeline`).
+    ///
+    /// Matches the same guard used by `pg_ash`'s per-second `pg_cron` job —
+    /// fail fast rather than block the TUI.
+    ///
+    /// Set to `0` to disable the timeout entirely (for power users on very
+    /// large clusters where the default 500 ms is too tight).
+    ///
+    /// Default: `500`.
+    pub sample_timeout_ms: u64,
+}
+
+fn default_ash_sample_timeout_ms() -> u64 {
+    500
+}
+
+impl Default for AshConfig {
+    fn default() -> Self {
+        Self {
+            sample_timeout_ms: default_ash_sample_timeout_ms(),
         }
     }
 }
@@ -959,6 +1001,15 @@ fn merge_config(base: Config, overlay: Config) -> Config {
                 overlay.logging.max_files
             },
             audit_file: overlay.logging.audit_file.or(base.logging.audit_file),
+        },
+        ash: AshConfig {
+            sample_timeout_ms: if overlay.ash.sample_timeout_ms
+                == default_ash_sample_timeout_ms()
+            {
+                base.ash.sample_timeout_ms
+            } else {
+                overlay.ash.sample_timeout_ms
+            },
         },
         connections: {
             let mut merged = base.connections;


### PR DESCRIPTION
## Summary

- Add an `[ash]` section to `config.toml` with a `sample_timeout_ms` field (default 500) so users on very large clusters can tune the `/ash` sample query timeout
- When `sample_timeout_ms = 0`, the `statement_timeout` guard is disabled entirely (opt-out for power users)
- Plumb the configured value from `Config` through `run_ash()` → `collect_frame_snapshots()` → `live_snapshot()` / `query_ash_history()`

Example config:
```toml
[ash]
sample_timeout_ms = 1000  # 0 = disabled
```

Closes #771

## Test plan

- [x] `cargo build` — compiles with no warnings
- [x] `cargo test` — all 1994 tests pass
- [x] `cargo clippy` — no lint issues
- [ ] Manual: verify `/ash` works with default config (no `[ash]` section)
- [ ] Manual: verify `/ash` respects a custom `sample_timeout_ms` value
- [ ] Manual: verify `sample_timeout_ms = 0` disables the timeout guard

https://claude.ai/code/session_01KCZcPqNsAKcqgTCgs51gd2