### PR TITLE
feat(explain): highlight plain EXPLAIN queries in REPL (#750)

### DIFF
--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -1677,10 +1677,14 @@ pub(super) async fn execute_query_interactive(
             (s, captured.as_slice())
         }
     } else if ok && is_explain_statement(sql) {
-        // Raw format: `last_explain_text` already set by `execute_query`.
-        display = std::borrow::Cow::Borrowed(captured.as_slice());
-        let s = std::str::from_utf8(&captured).unwrap_or("");
-        (s, captured.as_slice())
+        // Raw format: apply syntax highlighting to plan lines within the
+        // psql-formatted table output.  `highlight_explain` only colorizes
+        // plan node names, timing, and filter lines — table borders, the
+        // QUERY PLAN header, and the (N rows) footer pass through unchanged.
+        let raw_text = String::from_utf8_lossy(&captured);
+        enhanced = crate::explain::highlight::highlight_explain(&raw_text, settings.no_highlight);
+        display = std::borrow::Cow::Borrowed(b"");
+        (enhanced.as_str(), enhanced.as_bytes())
     } else {
         display = std::borrow::Cow::Borrowed(captured.as_slice());
         let s = std::str::from_utf8(&captured).unwrap_or("");


### PR DESCRIPTION
## Summary

- Apply `highlight_explain()` to plain `EXPLAIN` / `EXPLAIN ANALYZE` queries typed in the REPL when `explain_format` is `raw`
- Node names render in bold cyan, actual time in green/yellow/red by magnitude, filter/timing lines are highlighted
- Enhanced and Compact formats already had their own rendering via `try_render_explain`; this closes the gap for Raw format

Closes #750

## Test plan

- [ ] Interactive REPL: `EXPLAIN SELECT ...` shows highlighted output (default Enhanced format already works; Raw format now also highlights)
- [ ] `\pset explain_format raw` then `EXPLAIN ANALYZE SELECT ...` — plan nodes, timing, and filters are colored
- [ ] `\pset explain_format enhanced` — unchanged behavior (Enhanced rendering)
- [ ] `--no-highlight` flag disables all coloring
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean

https://claude.ai/code/session_01KCZcPqNsAKcqgTCgs51gd2