### PR TITLE
docs: add red/green TDD section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,23 @@ timeout 10 kubectl exec pod-name -n namespace -- \
 - Dynamic UI: relative timestamps with ISO 8601 hover tooltip
 - Static content: absolute timestamps `YYYY-MM-DD HH:mm:ss UTC`
 
+## Testing approach — red/green TDD
+
+Use red/green TDD, especially for bug fixes but also for new features:
+
+1. **Red** — write a failing test (or identify an existing failing test case) that
+   reproduces the bug or specifies the new behavior. Confirm it fails.
+2. **Green** — write the minimal code to make the test pass.
+3. **Refactor** — clean up while keeping tests green.
+
+For bug fixes this is mandatory: every fix must include a test that would have
+caught the bug. For new features it is strongly encouraged — write the test
+first when practical, or immediately after the implementation when the test
+setup is complex.
+
+When fixing psql compatibility gaps, the psql regression test suite serves as
+the "red" phase — a failing diff is the test. The fix makes the diff disappear.
+
 ## PR workflow (mandatory for all agents)
 
 Every PR must go through this sequence before merge — no exceptions:


### PR DESCRIPTION
## Summary

- Adds a "Testing approach — red/green TDD" section to CLAUDE.md documenting the red/green/refactor workflow established during the psql-compat sprint
- Bug fixes require a regression test; new features strongly encouraged to use TDD
- Documents that psql regression test diffs serve as the "red" phase for compat work

Closes #814

## Test plan

- [x] Verify CLAUDE.md renders correctly with the new section
- [x] Content matches the spec from issue #814

https://claude.ai/code/session_01Qys4VZe2yNwcwVmqR2DVpD