### PR TITLE
fix: resolve clippy 1.95 lint regressions

### DIFF
--- a/src/ash/renderer.rs
+++ b/src/ash/renderer.rs
@@ -1555,7 +1555,7 @@ mod tests {
         // Labels should not visually merge into garbage.
         for label in &labels {
             // Each label should look like HH:MM:SS (8 chars).
-            assert!(label.len() <= 8, "label '{label}' looks merged/overlapping",);
+            assert!(label.len() <= 8, "label '{label}' looks merged/overlapping");
         }
     }
 

--- a/src/ash/state.rs
+++ b/src/ash/state.rs
@@ -279,15 +279,11 @@ impl AshState {
         }
 
         match key.code {
-            KeyCode::Up => {
-                if self.selected_row > 0 {
-                    self.selected_row -= 1;
-                }
+            KeyCode::Up if self.selected_row > 0 => {
+                self.selected_row -= 1;
             }
-            KeyCode::Down => {
-                if list_len > 0 && self.selected_row < list_len - 1 {
-                    self.selected_row += 1;
-                }
+            KeyCode::Down if list_len > 0 && self.selected_row < list_len - 1 => {
+                self.selected_row += 1;
             }
             // Enter: caller is responsible for calling drill_into with row data.
             KeyCode::Char('b') => {

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -331,11 +331,7 @@ pub fn print_compat_report() -> (usize, usize) {
 
     rpg_println!("{separator}");
 
-    let pct = if total == 0 {
-        0
-    } else {
-        supported * 100 / total
-    };
+    let pct = (supported * 100).checked_div(total).unwrap_or(0);
     rpg_println!("Overall: {supported}/{total} commands supported ({pct}%)");
 
     (supported, total)
@@ -377,7 +373,7 @@ mod tests {
         let cats = categories();
         for (cat, entries) in &cats {
             for e in entries {
-                assert!(!e.command.is_empty(), "empty command in category {cat}",);
+                assert!(!e.command.is_empty(), "empty command in category {cat}");
                 assert!(
                     !e.notes.is_empty(),
                     "empty notes for {} in category {cat}",

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1419,7 +1419,7 @@ impl Highlighter for RpgHelper {
         if self.highlight_enabled() {
             return true;
         }
-        self.dropdown.lock().map(|dd| dd.active).unwrap_or(false)
+        self.dropdown.lock().is_ok_and(|dd| dd.active)
     }
 
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -435,8 +435,7 @@ fn default_host_port() -> (String, u16) {
             if path
                 .join(".s.PGSQL.5432")
                 .metadata()
-                .map(|m| m.file_type().is_socket())
-                .unwrap_or(false)
+                .is_ok_and(|m| m.file_type().is_socket())
             {
                 return ((*dir).to_owned(), 5432);
             }
@@ -455,8 +454,7 @@ fn default_host_port() -> (String, u16) {
                                 if entry
                                     .path()
                                     .metadata()
-                                    .map(|m| m.file_type().is_socket())
-                                    .unwrap_or(false)
+                                    .is_ok_and(|m| m.file_type().is_socket())
                                 {
                                     found_ports.push(port);
                                 }

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -171,10 +171,8 @@ async fn run_and_print_full(
 
             for msg in messages {
                 match msg {
-                    SimpleQueryMessage::RowDescription(columns) => {
-                        if col_names.is_empty() {
-                            col_names = columns.iter().map(|c| c.name().to_owned()).collect();
-                        }
+                    SimpleQueryMessage::RowDescription(columns) if col_names.is_empty() => {
+                        col_names = columns.iter().map(|c| c.name().to_owned()).collect();
                     }
                     SimpleQueryMessage::Row(row) => {
                         if col_names.is_empty() {

--- a/src/large_object.rs
+++ b/src/large_object.rs
@@ -344,10 +344,8 @@ async fn run_and_print(client: &Client, sql: &str, title: Option<&str>) {
 
             for msg in messages {
                 match msg {
-                    SimpleQueryMessage::RowDescription(cols) => {
-                        if col_names.is_empty() {
-                            col_names = cols.iter().map(|c| c.name().to_owned()).collect();
-                        }
+                    SimpleQueryMessage::RowDescription(cols) if col_names.is_empty() => {
+                        col_names = cols.iter().map(|c| c.name().to_owned()).collect();
                     }
                     SimpleQueryMessage::Row(row) => {
                         if col_names.is_empty() {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -223,7 +223,7 @@ pub fn init(level: Level, log_file: Option<Box<dyn Write + Send>>) {
 pub fn init_rotating(level: Level, log_path: PathBuf, rotation: RotationConfig) {
     // Determine initial bytes written so the first rotation threshold is
     // computed correctly even if the file already exists.
-    let existing_bytes = fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
+    let existing_bytes = fs::metadata(&log_path).map_or(0, |m| m.len());
 
     match OpenOptions::new().create(true).append(true).open(&log_path) {
         Ok(f) => {

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -785,11 +785,9 @@ fn draw_frame(
         let prefix = if state.search_forward { "/" } else { "?" };
         format!("{prefix}{buf}")
     } else {
-        let pct = if max_scroll_y == 0 {
-            100usize
-        } else {
-            (state.scroll_y * 100) / max_scroll_y
-        };
+        let pct = (state.scroll_y * 100)
+            .checked_div(max_scroll_y)
+            .unwrap_or(100usize);
         let last_visible = (state.scroll_y + content_height).min(lines.len());
         let mut base = format!(
             " Lines {}-{} of {} ({pct}%) \
@@ -892,10 +890,8 @@ fn handle_nav_key(
     match key.code {
         KeyCode::Char('q') | KeyCode::Esc => return true,
         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => return true,
-        KeyCode::Down | KeyCode::Char('j') => {
-            if state.scroll_y < max_scroll_y {
-                state.scroll_y += 1;
-            }
+        KeyCode::Down | KeyCode::Char('j') if state.scroll_y < max_scroll_y => {
+            state.scroll_y += 1;
         }
         KeyCode::Up | KeyCode::Char('k') => {
             state.scroll_y = state.scroll_y.saturating_sub(1);

--- a/src/repl/execute.rs
+++ b/src/repl/execute.rs
@@ -27,9 +27,7 @@ fn write_to_stdout_or_wasm(data: &[u8]) {
 fn terminal_rows() -> usize {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        crossterm::terminal::size()
-            .map(|(_, h)| h as usize)
-            .unwrap_or(24)
+        crossterm::terminal::size().map_or(24, |(_, h)| h as usize)
     }
     #[cfg(target_arch = "wasm32")]
     {
@@ -2679,14 +2677,12 @@ pub(super) async fn execute_crosstabview(
             let null_str = settings.pset.null_display.clone();
             for msg in messages {
                 match msg {
-                    SimpleQueryMessage::RowDescription(cols) => {
-                        if col_names.is_empty() {
-                            col_names = cols.iter().map(|c| c.name().to_owned()).collect();
-                            col_oids = cols
-                                .iter()
-                                .map(tokio_postgres::SimpleColumn::type_oid)
-                                .collect();
-                        }
+                    SimpleQueryMessage::RowDescription(cols) if col_names.is_empty() => {
+                        col_names = cols.iter().map(|c| c.name().to_owned()).collect();
+                        col_oids = cols
+                            .iter()
+                            .map(tokio_postgres::SimpleColumn::type_oid)
+                            .collect();
                     }
                     SimpleQueryMessage::Row(row) => {
                         if col_names.is_empty() {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -2860,7 +2860,7 @@ pub(crate) async fn exec_lines(
                                 }
                             }
                         }
-                        MetaResult::ClosePrepared(name) => {
+                        MetaResult::ClosePrepared(name)
                             if !deallocate_named(
                                 client,
                                 &name,
@@ -2869,12 +2869,11 @@ pub(crate) async fn exec_lines(
                                 settings.terse_errors,
                                 settings.sqlstate_errors,
                             )
-                            .await
-                            {
-                                exit_code = 1;
-                                if settings.single_transaction {
-                                    break 'lines;
-                                }
+                            .await =>
+                        {
+                            exit_code = 1;
+                            if settings.single_transaction {
+                                break 'lines;
                             }
                         }
                         MetaResult::ExecuteBufferToFile(path) => {
@@ -3610,9 +3609,7 @@ pub(crate) fn maybe_page(settings: &mut ReplSettings, text: &str) {
     let term_rows = {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            crossterm::terminal::size()
-                .map(|(_, h)| h as usize)
-                .unwrap_or(24)
+            crossterm::terminal::size().map_or(24, |(_, h)| h as usize)
         }
         #[cfg(target_arch = "wasm32")]
         {
@@ -4022,12 +4019,10 @@ fn apply_prompt(settings: &mut ReplSettings, prompt_text: &str, var_name: &str) 
                             break false;
                         }
                         // Backspace — delete last character.
-                        (KeyCode::Backspace, _) => {
-                            if input.pop().is_some() {
-                                // Erase the character on screen.
-                                let _ = write!(io::stderr(), "\x08 \x08");
-                                let _ = io::stderr().flush();
-                            }
+                        (KeyCode::Backspace, _) if input.pop().is_some() => {
+                            // Erase the character on screen.
+                            let _ = write!(io::stderr(), "\x08 \x08");
+                            let _ = io::stderr().flush();
                         }
                         // Printable character — echo and accumulate.
                         (KeyCode::Char(ch), _) => {


### PR DESCRIPTION
## Summary

Rust 1.95.0 (released April 2026) introduced four new default-denied clippy lints that fire on existing code. CI on \`stable\` started failing as soon as the GitHub Actions runner picked up 1.95.

This PR applies the clippy-suggested refactors across all 18 occurrences so CI goes green again.

## Lints fixed

| Lint | Sites | Refactor |
|---|---|---|
| \`map_unwrap_or\` | 6 | \`x.map(f).unwrap_or(v)\` → \`x.map_or(v, f)\` or \`x.is_ok_and(f)\` |
| \`collapsible_match\` | 8 | \`arm => { if cond { body } }\` → \`arm if cond => { body }\` |
| \`manual_checked_ops\` | 2 | \`if d == 0 { v } else { n / d }\` → \`n.checked_div(d).unwrap_or(v)\` |
| \`unnecessary_trailing_comma\` | 2 | drop trailing \`,\` in macro calls |

## Behavior preservation

- \`collapsible_match\` rewrites convert the inner \`if\` into a match guard. Both affected matches have an existing \`_ => {}\` catch-all, so when a guard fails the fall-through is a no-op — same net behavior as the original.
- \`manual_checked_ops\` rewrites preserve the divide-by-zero fallback value (0 in \`compat.rs\`, 100 in \`pager.rs\`).
- All other rewrites are mechanical 1:1 substitutions.

## Verified locally under rust 1.95.0

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test\` (2063 unit tests + connection_paths + integration_repl all pass; integration_smoke requires a local Postgres and is off by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)