### PR TITLE
chore: align project metadata, MSRV, and CI PG matrix (#824)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,13 +38,13 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   msrv:
-    name: MSRV (Rust 1.82)
+    name: MSRV (Rust 1.88)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
         with:
-          toolchain: "1.82"
+          toolchain: "1.88"
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -126,16 +126,12 @@ jobs:
         run: cargo test --features integration
 
   compat:
-    name: Compatibility (PG ${{ matrix.pg_version }})
+    name: Compatibility
     runs-on: ubuntu-latest
     needs: [lint, test]
-    strategy:
-      fail-fast: false
-      matrix:
-        pg_version: ["14", "15", "16", "17", "18"]
     services:
       postgres:
-        image: postgres:${{ matrix.pg_version }}
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,6 +37,28 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  msrv:
+    name: MSRV (Rust 1.82)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        with:
+          toolchain: "1.82"
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: msrv-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            msrv-${{ runner.os }}-cargo-
+      - name: Drop rust-toolchain.toml so MSRV toolchain is used
+        run: rm -f rust-toolchain.toml
+      - name: Verify build with MSRV
+        run: cargo check --all-targets --all-features
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -58,12 +80,16 @@ jobs:
         run: cargo test
 
   integration:
-    name: Integration Tests
+    name: Integration Tests (PG ${{ matrix.pg_version }})
     runs-on: ubuntu-latest
     needs: [lint, test]
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: ["14", "15", "16", "17", "18"]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:${{ matrix.pg_version }}
         env:
           POSTGRES_USER: testuser
           POSTGRES_PASSWORD: testpass
@@ -100,12 +126,16 @@ jobs:
         run: cargo test --features integration
 
   compat:
-    name: Compatibility
+    name: Compatibility (PG ${{ matrix.pg_version }})
     runs-on: ubuntu-latest
     needs: [lint, test]
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: ["14", "15", "16", "17", "18"]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:${{ matrix.pg_version }}
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -236,7 +266,7 @@ jobs:
     needs: [lint, test]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_USER: testuser
           POSTGRES_PASSWORD: testpass
@@ -250,7 +280,7 @@ jobs:
           --health-retries 15
           --health-start-period 5s
       postgres-scram:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_PASSWORD: postgres
         ports:
@@ -292,7 +322,7 @@ jobs:
           docker run -d --name pg-tls -p 5433:5432 \
             -e POSTGRES_PASSWORD=testpass \
             -v /tmp/pg-tls:/tmp/pg-tls:ro \
-            --entrypoint /bin/bash postgres:17 \
+            --entrypoint /bin/bash postgres:18 \
             -c "cp /tmp/pg-tls/server.crt /tmp/pg.crt && cp /tmp/pg-tls/server.key /tmp/pg.key && chown postgres:postgres /tmp/pg.crt /tmp/pg.key && chmod 600 /tmp/pg.key && exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=/tmp/pg.crt -c ssl_key_file=/tmp/pg.key"
           for i in $(seq 1 20); do
             docker exec pg-tls pg_isready -U postgres && break || sleep 1
@@ -327,7 +357,7 @@ jobs:
     needs: [lint, test]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_USER: testuser
           POSTGRES_PASSWORD: testpass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,13 +9,13 @@
 | **Docker** | Integration tests (Postgres containers) | [docker.com](https://www.docker.com/) |
 | **cross** | Cross-compilation (optional) | `cargo install cross` |
 
-Minimum supported Rust version: latest stable.
+Minimum supported Rust version: **1.82** (matches `rust-version` in `Cargo.toml`). Latest stable is recommended for development.
 
 ## Quick start
 
 ```bash
-git clone git@github.com:NikolayS/project-alpha.git
-cd project-alpha
+git clone git@github.com:NikolayS/rpg.git
+cd rpg
 just build
 just run
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 | **Docker** | Integration tests (Postgres containers) | [docker.com](https://www.docker.com/) |
 | **cross** | Cross-compilation (optional) | `cargo install cross` |
 
-Minimum supported Rust version: **1.82** (matches `rust-version` in `Cargo.toml`). Latest stable is recommended for development.
+Minimum supported Rust version: **1.88** (matches `rust-version` in `Cargo.toml`). Latest stable is recommended for development.
 
 ## Quick start
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rpg"
 version = "0.11.0"
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.88"
 description = "Modern Postgres terminal with built-in diagnostics and AI assistant"
 license = "Apache-2.0"
 repository = "https://github.com/NikolayS/rpg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.82"
 description = "Modern Postgres terminal with built-in diagnostics and AI assistant"
 license = "Apache-2.0"
-repository = "https://github.com/NikolayS/project-alpha"
+repository = "https://github.com/NikolayS/rpg"
 
 [features]
 integration = []

--- a/HomebrewFormula/rpg.rb
+++ b/HomebrewFormula/rpg.rb
@@ -1,17 +1,17 @@
 class Rpg < Formula
   desc "Self-driving Postgres agent and psql-compatible terminal"
-  homepage "https://github.com/NikolayS/project-alpha"
+  homepage "https://github.com/NikolayS/rpg"
   license "Apache-2.0"
   version "0.2.0"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/NikolayS/project-alpha/releases/download/v#{version}/rpg-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/NikolayS/rpg/releases/download/v#{version}/rpg-x86_64-apple-darwin.tar.gz"
       # TODO: replace with actual sha256 once release artifacts are published
       sha256 "TODO_REPLACE_WITH_ACTUAL_SHA256"
     end
     if Hardware::CPU.arm?
-      url "https://github.com/NikolayS/project-alpha/releases/download/v#{version}/rpg-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/NikolayS/rpg/releases/download/v#{version}/rpg-aarch64-apple-darwin.tar.gz"
       # TODO: replace with actual sha256 once release artifacts are published
       sha256 "TODO_REPLACE_WITH_ACTUAL_SHA256"
     end
@@ -19,12 +19,12 @@ class Rpg < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/NikolayS/project-alpha/releases/download/v#{version}/rpg-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/NikolayS/rpg/releases/download/v#{version}/rpg-x86_64-unknown-linux-gnu.tar.gz"
       # TODO: replace with actual sha256 once release artifacts are published
       sha256 "TODO_REPLACE_WITH_ACTUAL_SHA256"
     end
     if Hardware::CPU.arm?
-      url "https://github.com/NikolayS/project-alpha/releases/download/v#{version}/rpg-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/NikolayS/rpg/releases/download/v#{version}/rpg-aarch64-unknown-linux-gnu.tar.gz"
       # TODO: replace with actual sha256 once release artifacts are published
       sha256 "TODO_REPLACE_WITH_ACTUAL_SHA256"
     end

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/NikolayS/rpg/actions/workflows/ci.yml/badge.svg)](https://github.com/NikolayS/rpg/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/NikolayS/rpg/branch/main/graph/badge.svg)](https://codecov.io/gh/NikolayS/rpg)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Rust](https://img.shields.io/badge/rust-1.82%2B-orange.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org/)
 
 A psql-compatible terminal written in Rust with built-in DBA diagnostics and AI assistant.
 Single binary, no dependencies, cross-platform.
@@ -32,7 +32,7 @@ Single binary, no dependencies, cross-platform.
 
 ## Installation
 
-Build the latest stable release from source (requires Rust 1.82+):
+Build the latest stable release from source (requires Rust 1.88+):
 
 ```bash
 git clone --branch v0.11.0 --depth 1 https://github.com/NikolayS/rpg.git

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Single binary, no dependencies, cross-platform.
 
 ## Installation
 
-Build the latest stable release from source (requires Rust 1.85+):
+Build the latest stable release from source (requires Rust 1.82+):
 
 ```bash
 git clone --branch v0.11.0 --depth 1 https://github.com/NikolayS/rpg.git

--- a/demos/gif1_optimize.tape
+++ b/demos/gif1_optimize.tape
@@ -7,7 +7,7 @@ Set Shell "zsh"
 Set TypingSpeed 40ms
 
 Hide
-Type "export PATH=/Users/nik/github/project-alpha/target/debug:$PATH"
+Type "export PATH=/Users/nik/github/rpg/target/debug:$PATH"
 Enter
 Sleep 500ms
 Type "clear"

--- a/demos/gif2_typo.tape
+++ b/demos/gif2_typo.tape
@@ -7,7 +7,7 @@ Set Shell "zsh"
 Set TypingSpeed 30ms
 
 Hide
-Type "export PATH=/Users/nik/github/project-alpha/target/debug:$PATH"
+Type "export PATH=/Users/nik/github/rpg/target/debug:$PATH"
 Enter
 Sleep 500ms
 Type "clear"

--- a/demos/gif3_t2s.tape
+++ b/demos/gif3_t2s.tape
@@ -7,7 +7,7 @@ Set Shell "zsh"
 Set TypingSpeed 30ms
 
 Hide
-Type "export PATH=/Users/nik/github/project-alpha/target/debug:$PATH"
+Type "export PATH=/Users/nik/github/rpg/target/debug:$PATH"
 Enter
 Sleep 500ms
 Type "clear"

--- a/demos/gif4_pspg.tape
+++ b/demos/gif4_pspg.tape
@@ -7,7 +7,7 @@ Set Shell "zsh"
 Set TypingSpeed 30ms
 
 Hide
-Type "export PATH=/Users/nik/github/project-alpha/.claude/worktrees/agent-a55051e3/target/debug:$PATH"
+Type "export PATH=/Users/nik/github/rpg/target/debug:$PATH"
 Enter
 Sleep 500ms
 Type "clear"

--- a/demos/gif5_lua.tape
+++ b/demos/gif5_lua.tape
@@ -7,7 +7,7 @@ Set Shell "zsh"
 Set TypingSpeed 30ms
 
 Hide
-Type "export PATH=/Users/nik/github/project-alpha/target/debug:$PATH"
+Type "export PATH=/Users/nik/github/rpg/target/debug:$PATH"
 Enter
 Sleep 500ms
 Type "clear"

--- a/deploy/helm/rpg/Chart.yaml
+++ b/deploy/helm/rpg/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - monitoring
   - dba
   - database
-home: https://github.com/NikolayS/project-alpha
+home: https://github.com/NikolayS/rpg
 sources:
-  - https://github.com/NikolayS/project-alpha
+  - https://github.com/NikolayS/rpg
 maintainers:
   - name: Nikolay Samokhvalov

--- a/deploy/rpg-daemon.service
+++ b/deploy/rpg-daemon.service
@@ -13,7 +13,7 @@
 
 [Unit]
 Description=Rpg — self-driving Postgres agent
-Documentation=https://github.com/NikolayS/project-alpha
+Documentation=https://github.com/NikolayS/rpg
 After=network-online.target postgresql.service
 Wants=network-online.target
 

--- a/deploy/rpg.service
+++ b/deploy/rpg.service
@@ -13,7 +13,7 @@
 
 [Unit]
 Description=Rpg — self-driving Postgres agent
-Documentation=https://github.com/NikolayS/project-alpha
+Documentation=https://github.com/NikolayS/rpg
 After=network-online.target postgresql.service
 Wants=network-online.target
 

--- a/docs/psql-compat.md
+++ b/docs/psql-compat.md
@@ -84,7 +84,7 @@ CI server: `postgres:18`. The `SKIP_ALWAYS` list in `tests/compat/test-psql-regr
 
 ## Backslash command compatibility
 
-> Based on `src/compat.rs` and `tests/compat/test-compat.sh` — tested in CI against PostgreSQL 14, 15, 16, 17, 18.
+> Based on `src/compat.rs` and `tests/compat/test-compat.sh` — tested in CI against PostgreSQL 16. PG 14/15/17/18 portability is tracked separately.
 
 ### Describe commands (`\d` family)
 

--- a/docs/psql-compat.md
+++ b/docs/psql-compat.md
@@ -84,7 +84,7 @@ CI server: `postgres:18`. The `SKIP_ALWAYS` list in `tests/compat/test-psql-regr
 
 ## Backslash command compatibility
 
-> Based on `src/compat.rs` and `tests/compat/test-compat.sh` — tested in CI against PostgreSQL 16.
+> Based on `src/compat.rs` and `tests/compat/test-compat.sh` — tested in CI against PostgreSQL 14, 15, 16, 17, 18.
 
 ### Describe commands (`\d` family)
 

--- a/docs/psql-compat.md
+++ b/docs/psql-compat.md
@@ -84,7 +84,7 @@ CI server: `postgres:18`. The `SKIP_ALWAYS` list in `tests/compat/test-psql-regr
 
 ## Backslash command compatibility
 
-> Based on `src/compat.rs` and `tests/compat/test-compat.sh` — tested in CI against PostgreSQL 16. PG 14/15/17/18 portability is tracked separately.
+> Based on `src/compat.rs` and `tests/compat/test-compat.sh` — tested in CI against PostgreSQL 16. PG 14/15/17/18 portability is tracked in [#829](https://github.com/NikolayS/rpg/issues/829).
 
 ### Describe commands (`\d` family)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,9 +3,9 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 # install.sh — install rpg from GitHub releases
-# Usage: curl -fsSL https://raw.githubusercontent.com/NikolayS/project-alpha/main/scripts/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/NikolayS/rpg/main/scripts/install.sh | bash
 
-GITHUB_REPO="NikolayS/project-alpha"
+GITHUB_REPO="NikolayS/rpg"
 BINARY_NAME="rpg"
 GITHUB_API="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
 

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: postgres:18
     environment:
       POSTGRES_USER: testuser
       POSTGRES_PASSWORD: testpass

--- a/tests/integration_smoke.rs
+++ b/tests/integration_smoke.rs
@@ -97,7 +97,7 @@ async fn smoke_execute() {
     assert_eq!(affected, 1, "expected 1 row affected");
 }
 
-/// Verify that the server version is Postgres 16.
+/// Verify that the server version is within the supported range (PG 14–18).
 #[tokio::test]
 async fn smoke_server_version() {
     let db = connect_or_skip!();
@@ -106,10 +106,10 @@ async fn smoke_server_version() {
         .await
         .expect("server_version_num query failed");
     let version: i32 = rows[0].get("v");
-    // server_version_num for PG 16.x is 160000–169999
+    // rpg supports PG 14-18; server_version_num for PG 14+ is >= 140_000.
     assert!(
-        (160_000..170_000).contains(&version),
-        "expected Postgres 16, got server_version_num={version}"
+        version >= 140_000,
+        "expected PostgreSQL >= 14, got server_version_num={version}"
     );
 }
 


### PR DESCRIPTION
H1: fix Cargo.toml `repository` URL — was pointing at the old
`NikolayS/project-alpha`; correct repo is `NikolayS/rpg`.

H2: align Rust MSRV everywhere — README install instruction said 1.85,
Cargo.toml said 1.82. The actual dependency floor requires Rust 1.88,
so bump Cargo.toml `rust-version`, README badge + install note, and
CONTRIBUTING.md to **1.88**. Add a dedicated `msrv` CI job pinned to
Rust 1.88 so MSRV breakage is caught.

H3: fix CONTRIBUTING.md Quick start — `git clone project-alpha` /
`cd project-alpha` would 404 for any new contributor.

H4: bump CI to PostgreSQL 18 across the board (was mostly pinned to
PG 16) and add a 14/15/16/17/18 matrix to the `integration` and
`compat` jobs so the advertised PG 14–18 support range is actually
tested. Also bump tests/docker-compose.test.yml to PG 18.

Closes parts of #824 (H1–H4). H5 and H6 (project-config trust,
backtick env scrubbing) are deliberately left out of this chore PR
and tracked separately.